### PR TITLE
修复：(quota)refresh 加版本号 guard 防止 provider 切换时旧请求覆盖

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/session/quota/view.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/session/quota/view.tsx
@@ -87,7 +87,11 @@ export function QuotaView(props: { api: TuiPluginApi; session_id: string }) {
     }
   }
 
+  // 版本号 guard：providerID 切换或新一轮 refresh 启动时，旧的 in-flight
+  // 请求 resolve 后会被丢弃，避免用过期数据覆盖当前 provider 的显示。
+  let refreshSeq = 0
   async function refresh() {
+    const seq = ++refreshSeq
     const pid = providerID()
     if (!pid || !isCopilotMode(pid)) {
       setLabel("")
@@ -97,6 +101,7 @@ export function QuotaView(props: { api: TuiPluginApi; session_id: string }) {
     // 注意：auth.json 位于 Global.Path.data（XDG_DATA_HOME），
     // 不能用 props.api.state.path.state（XDG_STATE_HOME），二者是不同目录。
     const authEntry = await readCopilotAuthEntry(Global.Path.data)
+    if (seq !== refreshSeq) return
     const endpoint = resolveEndpoint({ providerConfig, authEntry })
     if (!endpoint) {
       console.debug(`[quota] resolveEndpoint null providerID=${pid}`)
@@ -104,6 +109,7 @@ export function QuotaView(props: { api: TuiPluginApi; session_id: string }) {
       return
     }
     const q = await fetchQuota(endpoint)
+    if (seq !== refreshSeq) return
     if (q) applyQuota(q)
     else setLabel("")
   }


### PR DESCRIPTION
60s setInterval 触发的 async refresh 与 providerID 变化的 createEffect refresh 可能并发；旧 fetch resolve 后会用过期数据覆盖当前 provider 的 显示。每次 refresh 自增 seq，await 后比对，stale 即丢弃。

### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Please provide a description of the issue, the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [ ] I have tested my changes locally
- [ ] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
