### PR TITLE
fix(goal,hooks): correct timeout units and permission aggregation

### DIFF
--- a/packages/opencode/src/goal/goal.ts
+++ b/packages/opencode/src/goal/goal.ts
@@ -388,7 +388,7 @@ export const layer = Layer.effect(
 
       if (newParseFailures >= GoalPrompts.MAX_CONSECUTIVE_PARSE_FAILURES) {
         const pauseReason =
-          "judge 模型未返回有效 JSON 判定。请配置 auxiliary.goalJudge 指向更可靠的模型，然后 /goal resume。"
+          "judge 模型未返回有效 JSON 判定。请检查模型配置或换用更可靠的模型，然后 /goal resume。"
         const updated = new GoalState.Info({
           ...state,
           status: "paused",

--- a/packages/opencode/src/goal/judge.ts
+++ b/packages/opencode/src/goal/judge.ts
@@ -53,7 +53,7 @@ export const run = Effect.fn("Goal.Judge.run")(function* (
     user: userPrompt,
     temperature: 0,
     maxTokens: 200,
-    timeout: GoalPrompts.DEFAULT_JUDGE_TIMEOUT,
+    timeout: GoalPrompts.DEFAULT_JUDGE_TIMEOUT_SECONDS,
   }).pipe(
     Effect.map((text) => parseJudgeResponse(text)),
     // Transport errors (timeout, network, non-JSON transport-level failure)

--- a/packages/opencode/src/goal/prompts.ts
+++ b/packages/opencode/src/goal/prompts.ts
@@ -3,7 +3,9 @@ import { GoalState } from "./state"
 export * as GoalPrompts from "./prompts"
 
 export const DEFAULT_MAX_TURNS = 20
-export const DEFAULT_JUDGE_TIMEOUT = 30_000
+// Seconds — used as `Effect.timeout(`${timeout} seconds`)` in loop.ts.
+// Was 30_000 (ms) which produced "30000 seconds" = 8.3h (effectively no timeout).
+export const DEFAULT_JUDGE_TIMEOUT_SECONDS = 30
 export const MAX_CONSECUTIVE_PARSE_FAILURES = 3
 export const JUDGE_RESPONSE_SNIPPET_CHARS = 4000
 // Zombie-goal freshness guard threshold (D6). A goal that is still active with

--- a/packages/opencode/src/hook/settings.ts
+++ b/packages/opencode/src/hook/settings.ts
@@ -1050,11 +1050,7 @@ const commandHandler: HookHandler = {
 
 const mcpHandler: HookHandler = {
   type: "mcp",
-  run: Effect.fn("SettingsHook.handler.mcp")(function* (entry, envelope, _cwd, inHook) {
-    if (inHook) {
-      log.warn("nested mcp hook skipped (re-entry guard)", { command: commandText(entry) })
-      return { json: undefined, exitBlock: undefined }
-    }
+  run: Effect.fn("SettingsHook.handler.mcp")(function* (entry, envelope, _cwd, _inHook) {
     const mcpSvc = Option.getOrUndefined(yield* Effect.serviceOption(MCP.Service))
     if (!mcpSvc) {
       log.warn("mcp hook skipped: MCP service not in context", { command: commandText(entry) })
@@ -1245,7 +1241,7 @@ const agentHandler: HookHandler = {
 
       const captured: { value: HookJSONOutput | null } = { value: null }
       const ac = new AbortController()
-      const timeoutMs = entry.timeout ?? DEFAULT_AGENT_TIMEOUT_MS
+      const timeoutMs = entry.timeout ? entry.timeout * 1000 : DEFAULT_AGENT_TIMEOUT_MS
       const timer = setTimeout(() => ac.abort(), timeoutMs)
 
       const loopExit = yield* Effect.tryPromise({
@@ -1526,9 +1522,19 @@ export const layer = Layer.effect(
             }
           }
           if (hso && "permissionDecision" in hso && hso.permissionDecision) {
-            result.permissionDecision = hso.permissionDecision
-            result.permissionDecisionReason =
-              "permissionDecisionReason" in hso ? hso.permissionDecisionReason : undefined
+            const incoming = hso.permissionDecision
+            const current = result.permissionDecision
+            // Most-restrictive-wins: deny > ask > allow. A later hook cannot
+            // relax an earlier hook's deny (Claude Code permission semantics).
+            const moreRestrictive =
+              current === undefined ||
+              incoming === "deny" ||
+              (incoming === "ask" && current === "allow")
+            if (moreRestrictive) {
+              result.permissionDecision = incoming
+              result.permissionDecisionReason =
+                "permissionDecisionReason" in hso ? hso.permissionDecisionReason : undefined
+            }
           }
           if (hso && "updatedInput" in hso && hso.updatedInput) {
             result.updatedInput = hso.updatedInput


### PR DESCRIPTION
## Summary

Five fixes found by cross-review (FABLE5 model), verified against current code, applied.

## Goal module (2 fixes)

### G1: Judge timeout unit mismatch — `DEFAULT_JUDGE_TIMEOUT` was 30_000 (ms) used as `Effect.timeout("30000 seconds")` = 8.3h
**Before:** `DEFAULT_JUDGE_TIMEOUT = 30_000` → `Effect.timeout(`${opts.timeout} seconds`)` → `"30000 seconds"` = effectively no timeout. A hanging provider would stall the goal loop for hours.

**After:** `DEFAULT_JUDGE_TIMEOUT_SECONDS = 30` → `Effect.timeout("30 seconds")`. Unit is now consistent.

### G2: Pause message referenced non-existent config
**Before:** `goal.ts:391` told users to "配置 auxiliary.goalJudge" — but the code never reads this config (judge always uses `provider.defaultModel()`). Users following the hint would see no effect.

**After:** Message now says "检查模型配置或换用更可靠的模型" (generic guidance).

## Hooks module (3 fixes)

### H1: Agent handler timeout missing `* 1000`
**Before:** `settings.ts:1248` — `entry.timeout ?? DEFAULT_AGENT_TIMEOUT_MS` — the ONLY handler that didn't multiply seconds by 1000. A user configuring `timeout: 120` (intending 120 seconds) got 120ms.

**After:** `entry.timeout ? entry.timeout * 1000 : DEFAULT_AGENT_TIMEOUT_MS` — matches all other handler types (command/mcp/http/prompt).

### H2: permissionDecision was last-write-wins (security semantics)
**Before:** `settings.ts:1528` — each hook's `permissionDecision` overwrote the previous. A later hook's `allow` could override an earlier hook's `deny`.

**After:** Most-restrictive-wins (deny > ask > allow). Once any hook says `deny`, it stays `deny`. Matches Claude Code permission semantics.

### H3: MCP re-entry guard was dead code
**Before:** `settings.ts:1053` — `if (inHook)` guard, but `runEntry` always passed `false` for `inHook` (line 1480). The guard never fired.

**After:** Guard removed; parameter renamed to `_inHook` (matching all other handlers).

## Findings NOT fixed (assessed as not actionable)

| ID | Claim | Assessment |
|----|-------|------------|
| G3 | done branch cleanup race | Speculative — noReply messages don't trigger idle events; afterIdle is already in a forked fiber; deleteAndPublishDone is fiber-safe |
| H4 | seen Set instance-global | Per-directory (InstanceState), not per-session — needs product decision, not a clear bug |
| H5 | Settings loaded once | Covered by existing `hook/extensions/hot-reload.ts` which watches settings files |

## Verification

- `bun run typecheck`: 0 errors
- `bun test test/goal/`: 56 pass, 0 fail
- Pre-push hook: turbo typecheck FULL TURBO (all cached)

## Note

The previous dev CI run (PR #39) had 1 test failure in `attention.test.ts` (TUI sound notification mock) — pre-existing, unrelated to goal-loop. 3079/3104 tests passed including all 56 goal tests.