### PR TITLE
fix(ci): pre-install ripgrep to avoid network-dependent test failures

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -69,6 +69,12 @@ jobs:
           git config --global user.email "bot@opencode.ai"
           git config --global user.name "opencode"
 
+      - name: Install ripgrep
+        # tool.glob tests hit ripgrep; without the system binary, binary.ts
+        # downloads rg from GitHub releases every run (temp XDG per preload),
+        # gambling on network stability — ECONNRESET fails the test.
+        run: sudo apt-get update && sudo apt-get install -y ripgrep
+
       - name: Cache Turbo
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:


### PR DESCRIPTION
## Root Cause

The dev CI `🧪 CI · Test` run was failing on `tool.glob > matches files from a directory path` — NOT on attention.test.ts (that was expected noise from failure-path tests, misread as the failure source).

The actual failure chain:
1. `tool.glob` test hits `core/src/ripgrep/binary.ts`
2. `binary.ts` calls `which("rg")` — no system ripgrep on the runner
3. Falls back to downloading rg from GitHub releases
4. Test preload creates a fresh temp XDG dir per run → no cache → downloads every time
5. GitHub download hit `ECONNRESET` → `TransportError` → test fails

Every CI run was gambling on GitHub download stability.

## Fix

Add `sudo apt-get install -y ripgrep` to the `unit-tests` job, before tests run. `which("rg")` now finds the system binary at `/usr/bin/rg`, bypassing the download entirely.

## Verification

No code change — CI infrastructure only. The next dev CI run after merge will confirm the fix (the `tool.glob` test should pass without network dependency).

## Credit

Root cause analysis by cross-review (FABLE5 model) — pulled the actual CI logs and identified the real failure vs the noise.