### PR TITLE
fix(goal,hooks): harden terminal event contract and per-session context dedup

### DIFF
--- a/packages/opencode/src/goal/goal.ts
+++ b/packages/opencode/src/goal/goal.ts
@@ -140,20 +140,32 @@ export const layer = Layer.effect(
     // would interrupt ourselves before goal.cleared was published (the
     // event bus would miss the terminal event, and TUI/SSE consumers
     // polling state would never see the transition).
+    //
+    // The whole terminal sequence (load → publish(done) → delete →
+    // publish(cleared)) runs inside Effect.uninterruptible. This is
+    // defense-in-depth (F1): even if a future caller arranges for the loop
+    // fiber to be interrupted mid-call, the terminal event contract still
+    // completes atomically — goal.cleared cannot be skipped by an interrupt
+    // landing between publish(done) and publish(cleared). The operations are
+    // short synchronous DB + event publishes, so there is no deadlock risk.
     const deleteAndPublishDone = Effect.fnUntraced(function* (sessionID: SessionID, reason: string) {
-      const state = yield* loadState(sessionID)
-      if (state) {
-        const doneState = new GoalState.Info({
-          ...state,
-          status: "done",
-          last_verdict: "done",
-          last_reason: reason,
-        })
-        yield* publishGoal(sessionID, doneState)
-      }
-      yield* deleteState(sessionID)
-      yield* events.publish(GoalEvent.Cleared, { sessionID })
-      return state
+      return yield* Effect.uninterruptible(
+        Effect.gen(function* () {
+          const state = yield* loadState(sessionID)
+          if (state) {
+            const doneState = new GoalState.Info({
+              ...state,
+              status: "done",
+              last_verdict: "done",
+              last_reason: reason,
+            })
+            yield* publishGoal(sessionID, doneState)
+          }
+          yield* deleteState(sessionID)
+          yield* events.publish(GoalEvent.Cleared, { sessionID })
+          return state
+        }),
+      )
     })
 
     function loadState(sessionID: SessionID) {
@@ -232,18 +244,27 @@ export const layer = Layer.effect(
     // clearFiber so it can be called from inside the loop fiber itself
     // (loop.ts shouldPreempt branch). The fiber naturally terminates when
     // afterIdle returns; no explicit interrupt needed.
+    //
+    // Wrapped in Effect.uninterruptible (F1): the save → publish sequence
+    // is atomic, so an interrupt landing between persisting the paused row
+    // and publishing goal.updated(paused) can never leave a paused DB row
+    // with no corresponding event on the bus.
     const pauseAndPublish = Effect.fnUntraced(function* (sessionID: SessionID, reason: string) {
-      const state = yield* loadState(sessionID)
-      if (!state || state.status !== "active") return undefined
-      const updated = new GoalState.Info({
-        ...state,
-        status: "paused",
-        paused_reason: reason,
-        last_turn_at: Date.now(),
-      })
-      yield* saveState(sessionID, updated)
-      yield* publishGoal(sessionID, updated)
-      return updated
+      return yield* Effect.uninterruptible(
+        Effect.gen(function* () {
+          const state = yield* loadState(sessionID)
+          if (!state || state.status !== "active") return undefined
+          const updated = new GoalState.Info({
+            ...state,
+            status: "paused",
+            paused_reason: reason,
+            last_turn_at: Date.now(),
+          })
+          yield* saveState(sessionID, updated)
+          yield* publishGoal(sessionID, updated)
+          return updated
+        }),
+      )
     })
 
     const resume = Effect.fn("Goal.resume")(function* (sessionID: SessionID) {

--- a/packages/opencode/src/goal/loop.ts
+++ b/packages/opencode/src/goal/loop.ts
@@ -189,19 +189,23 @@ export const layer = Layer.effect(
         // how /goal clear behaves). This is what makes goal completion
         // not require a manual /goal clear afterwards.
         if (verdict.verdict === "done") {
+          // Run the terminal event sequence FIRST (F1): publish(done) →
+          // delete → publish(cleared) is the contract SSE/TUI consumers
+          // rely on, so it must complete before any other effect that could
+          // race the loop fiber. deleteAndPublishDone is uninterruptible and
+          // fiber-safe (no clearFiber), so this ordering is pure
+          // defense-in-depth — the completion message text is computed from
+          // updateResult.message (pre-deletion state) and is unaffected by
+          // running after the delete. The noReply path returns before any
+          // status transition today, but completing the terminal sequence
+          // first makes the contract structurally enforced rather than
+          // dependent on that noReply implementation detail.
+          yield* goal.deleteAndPublishDone(sessionID, verdict.reason).pipe(Effect.ignore)
           yield* promptSvc.prompt({
             sessionID,
             noReply: true,
             parts: [{ type: "text", text: updateResult.message }],
           }).pipe(Effect.ignore)
-          // Use deleteAndPublishDone (NOT goal.clear) because we ARE the
-          // loop fiber: goal.clear() internally calls clearFiber which
-          // would interrupt ourselves before events.publish(GoalEvent.Cleared)
-          // runs — the .pipe(Effect.ignore) would silently swallow the
-          // self-interrupt and goal.cleared would never reach SSE/TUI.
-          // deleteAndPublishDone only touches DB + event bus, never the
-          // fiber map, so it is safe to call from inside the loop fiber.
-          yield* goal.deleteAndPublishDone(sessionID, verdict.reason).pipe(Effect.ignore)
         } else {
           // Auto-pause branch: updateAfterJudge paused the goal due to
           // judge-parse-failure or budget exhaustion (verdict.verdict is

--- a/packages/opencode/src/hook/settings.ts
+++ b/packages/opencode/src/hook/settings.ts
@@ -388,7 +388,7 @@ export interface TriggerContext {
 }
 
 export interface TriggerResult {
-  /** additionalContext strings appended (deduplicated per instance) */
+  /** additionalContext strings appended (deduplicated per session) */
   additionalContexts: string[]
   /** systemMessage strings emitted by hooks */
   systemMessages: string[]
@@ -972,8 +972,15 @@ function matcherTarget(payload: HookPayload): string {
 interface State {
   settings: Settings
   cwd: string
-  /** Deduplicated additionalContext strings already surfaced in this instance. */
-  seen: Set<string>
+  /**
+   * Deduplicated additionalContext strings, bucketed per sessionID. Each
+   * session sees every distinct context once; a second session is NOT
+   * starved by what the first already saw. The bucket for a session is
+   * evicted on SessionEnd (see trigger) so the map does not grow unboundedly
+   * across the process lifetime. Headless / no-session triggers collapse to
+   * the "" bucket, preserving the prior global-dedup behavior for those.
+   */
+  seen: Map<string, Set<string>>
 }
 
 export interface Interface {
@@ -1330,7 +1337,7 @@ export const layer = Layer.effect(
     const state = yield* InstanceState.make(
       Effect.fn("SettingsHook.state")(function* (instCtx) {
         const settings = loadChain(instCtx.directory, instCtx.worktree)
-        return { settings, cwd: instCtx.directory, seen: new Set<string>() } satisfies State
+        return { settings, cwd: instCtx.directory, seen: new Map<string, Set<string>>() } satisfies State
       }),
     )
 
@@ -1383,6 +1390,25 @@ export const layer = Layer.effect(
       using _ = log.time("trigger", { event: payload.event, sessionID: ctx.sessionID })
       const s = yield* InstanceState.get(state)
       const result: TriggerResult = { additionalContexts: [], systemMessages: [] }
+
+      // ── SessionEnd lifecycle cleanup (F2) ──────────────────────
+      // Evict this session's additionalContext dedup bucket AND its dynamic
+      // session-hook store. Both are keyed by sessionID and have no other
+      // eviction path, so without this the process accumulates one bucket +
+      // one hook list per historical session for its entire lifetime.
+      // SessionHooks.clear was previously defined but never invoked — this is
+      // the single call site that fixes that leak.
+      //
+      // Runs BEFORE the WP-6A short-circuit below: a session that registered
+      // no SessionEnd hook (the common case) must still have its state freed,
+      // and placing it after the matcher loop would skip cleanup whenever the
+      // short-circuit fires. Clearing first is safe — a SessionEnd hook that
+      // returns additionalContext just repopulates a bucket for an ending
+      // session, which is harmless.
+      if (payload.event === "SessionEnd" && ctx.sessionID) {
+        s.seen.delete(ctx.sessionID)
+        yield* sessionHooks.clear(SessionID.make(ctx.sessionID))
+      }
 
       // ── WP-6A: O(1) short-circuit ─────────────────────────────
       // Skip the entire matcher pipeline (envelope build, target derivation,
@@ -1515,10 +1541,16 @@ export const layer = Layer.effect(
           // Property-based narrowing — works across union variants without depending on
           // hookEventName tag (which the fallback variant may also accept).
           if (hso && "additionalContext" in hso && typeof hso.additionalContext === "string") {
-            const ctx = hso.additionalContext
-            if (!s.seen.has(ctx)) {
-              s.seen.add(ctx)
-              result.additionalContexts.push(ctx)
+            const additionalContext = hso.additionalContext
+            // Per-session dedup (F2): the same context surfaces once per
+            // session, not once per process lifetime. ctx here is the
+            // TriggerContext (sessionID is its bucket key); the local was
+            // renamed off `ctx` so the outer TriggerContext stays reachable.
+            const bucket = s.seen.get(ctx.sessionID) ?? new Set<string>()
+            if (!bucket.has(additionalContext)) {
+              bucket.add(additionalContext)
+              s.seen.set(ctx.sessionID, bucket)
+              result.additionalContexts.push(additionalContext)
             }
           }
           if (hso && "permissionDecision" in hso && hso.permissionDecision) {

--- a/packages/opencode/test/goal/goal.test.ts
+++ b/packages/opencode/test/goal/goal.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect } from "bun:test"
-import { Deferred, Effect, Layer } from "effect"
+import { Deferred, Effect, Fiber, Layer } from "effect"
 import { Goal } from "@/goal/goal"
 import { GoalEvent } from "@/goal/events"
 import { GoalPrompts } from "@/goal/prompts"
@@ -7,7 +7,7 @@ import { EventV2Bridge } from "@/event-v2-bridge"
 import { SessionStatus } from "@/session/status"
 import { Database } from "@opencode-ai/core/database/database"
 import { SessionID } from "@/session/schema"
-import { testEffect } from "../lib/effect"
+import { pollWithTimeout, testEffect } from "../lib/effect"
 
 // Build the layer so EventV2Bridge.Service is SHARED between Goal's internals
 // (which publish via it) and this test (which subscribes via it).
@@ -622,6 +622,103 @@ describe("Goal.pauseAndPublish — freshness-guard pause (D6)", () => {
       expect(Number(state?.turns_used)).toBe(0)
       // created_at is recent (within the last second), well inside the threshold
       expect(Date.now() - Number(state?.created_at)).toBeLessThan(GoalPrompts.FRESHNESS_THRESHOLD)
+    }),
+  )
+})
+
+// ---------------------------------------------------------------------------
+// §F1 — Terminal / pause sequences are uninterruptible (defense-in-depth).
+// deleteAndPublishDone and pauseAndPublish are wrapped in Effect.uninterruptible
+// so an interrupt landing mid-region can never split the load → publish →
+// delete → publish contract. These tests fork each effect, prove the fiber has
+// ENTERED the uninterruptible region via an observable entry signal, then
+// interrupt and assert the remaining events still fired.
+// ---------------------------------------------------------------------------
+
+describe("Goal.deleteAndPublishDone — terminal sequence is uninterruptible (F1)", () => {
+  // The rigorous interrupt-during-region proof. goal.updated(done) can only
+  // fire once the region has started (loadState + publishGoal both ran), so
+  // waiting for it guarantees the interrupt below lands INSIDE the region. If
+  // the Effect.uninterruptible wrapper were removed, the interrupt could kill
+  // the fiber between publish(done) and publish(cleared), and the cleared
+  // assertion would fail.
+  it.live("publishes goal.updated(done) and goal.cleared when the calling fiber is interrupted mid-region", () =>
+    Effect.gen(function* () {
+      const goal = yield* Goal.Service
+      const events = yield* EventV2Bridge.Service
+      const seen = yield* captureEvents(events)
+      const sessionID = SessionID.descending()
+
+      yield* goal.set(sessionID, "ship feature X", 10)
+      // Persist a done row WITHOUT publishing — mirrors what loop.ts does
+      // (updateAfterJudge) before invoking deleteAndPublishDone.
+      yield* goal.updateAfterJudge(sessionID, "done", "delivered", false)
+      seen.length = 0
+
+      const fiber = yield* goal.deleteAndPublishDone(sessionID, "delivered").pipe(Effect.forkScoped)
+
+      // Entry proof: goal.updated(done) published → region entered.
+      yield* pollWithTimeout(
+        Effect.sync(() =>
+          seen.some((e) => e.type === GoalEvent.Updated.type && e.status === "done") ? true : undefined,
+        ),
+        "deleteAndPublishDone never published goal.updated(done)",
+      )
+
+      // Interrupt mid-region. The region is uninterruptible, so deleteState +
+      // publish(cleared) complete before the deferred interrupt terminates
+      // the fiber.
+      yield* Fiber.interrupt(fiber)
+
+      const done = seen.filter((e) => e.type === GoalEvent.Updated.type && e.status === "done")
+      expect(done.length).toBe(1)
+      const cleared = seen.filter((e) => e.type === GoalEvent.Cleared.type)
+      expect(cleared.length).toBe(1)
+
+      // deleteState ran — row is gone.
+      const loaded = yield* goal.load(sessionID)
+      expect(loaded).toBeUndefined()
+    }),
+  )
+})
+
+describe("Goal.pauseAndPublish — pause transition is uninterruptible (F1)", () => {
+  // Complementary to the deleteAndPublishDone test. pauseAndPublish publishes
+  // only one event (goal.updated(paused)), so the entry signal is the DB row
+  // flipping to paused (saveState completed = region entered). After that we
+  // interrupt and assert publishGoal(paused) still fired. Combined with the
+  // deleteAndPublishDone test (same Effect.uninterruptible pattern), this
+  // locks the F1 uninterruptible wrapping on both fiber-safe paths.
+  it.live("publishes goal.updated(paused) when the calling fiber is interrupted after the region starts", () =>
+    Effect.gen(function* () {
+      const goal = yield* Goal.Service
+      const events = yield* EventV2Bridge.Service
+      const seen = yield* captureEvents(events)
+      const sessionID = SessionID.descending()
+
+      yield* goal.set(sessionID, "build feature X", 10)
+      seen.length = 0
+
+      const fiber = yield* goal.pauseAndPublish(sessionID, "interrupted mid-pause").pipe(Effect.forkScoped)
+
+      // Entry proof: saveState completed → row flipped to paused.
+      yield* pollWithTimeout(
+        Effect.gen(function* () {
+          const st = yield* goal.load(sessionID)
+          return st?.status === "paused" ? true : undefined
+        }),
+        "pauseAndPublish never persisted the paused row",
+      )
+
+      // Interrupt after the region started. The region is uninterruptible, so
+      // publishGoal(paused) still runs before the fiber terminates.
+      yield* Fiber.interrupt(fiber)
+
+      const loaded = yield* goal.load(sessionID)
+      expect(loaded?.status).toBe("paused")
+      expect(loaded?.paused_reason).toBe("interrupted mid-pause")
+      const paused = seen.filter((e) => e.type === GoalEvent.Updated.type && e.status === "paused")
+      expect(paused.length).toBe(1)
     }),
   )
 })

--- a/packages/opencode/test/hook/settings-dedup.test.ts
+++ b/packages/opencode/test/hook/settings-dedup.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect } from "bun:test"
+import { Effect, Layer } from "effect"
+import * as fs from "fs/promises"
+import path from "path"
+import { SettingsHook } from "@/hook/settings"
+import { SessionHooks } from "@/hook/session-hooks"
+import { EventV2Bridge } from "@/event-v2-bridge"
+import { Database } from "@opencode-ai/core/database/database"
+import { SessionID } from "@/session/schema"
+import { testEffect } from "../lib/effect"
+
+// Real SettingsHook layer with its deps. SessionHooks is exposed via
+// Layer.provideMerge (mirrors the goal test pattern) so the tests can also
+// assert the SessionEnd dynamic-hook-store cleanup. The body of each
+// it.instance test runs inside a fresh temp instance dir (via withTmpdirInstance),
+// so SettingsHook's InstanceState-built state (loadChain + the seen Map) is
+// fresh per test and loadChain reads the .opencode/settings.json we write.
+const testLayer = SettingsHook.layer.pipe(
+  Layer.provide(EventV2Bridge.defaultLayer),
+  Layer.provide(Database.defaultLayer),
+  Layer.provideMerge(SessionHooks.defaultLayer),
+)
+
+const it = testEffect(testLayer)
+
+// A SessionStart command hook whose stdout is JSON carrying a fixed
+// additionalContext string. `printf '%s' '<json>'` single-quotes the JSON so
+// its inner double-quotes reach the shell literally; parseStdout then
+// JSON.parses the trimmed output into HookJSONOutput. printf is POSIX, so
+// /bin/sh -c handles it on the test host.
+const CONTEXT = "ctx-F2-dedup-marker"
+const HOOK_JSON = JSON.stringify({ hookSpecificOutput: { additionalContext: CONTEXT } })
+const settingsJson = {
+  hooks: {
+    SessionStart: [{ hooks: [{ type: "command", command: `printf '%s' '${HOOK_JSON}'` }] }],
+  },
+}
+
+// Writes <dir>/.opencode/settings.json (loadChain reads this path), so the
+// SessionStart matcher participates in the trigger pipeline.
+const writeSettings = (dir: string) =>
+  Effect.promise(() =>
+    fs.mkdir(path.join(dir, ".opencode"), { recursive: true }).then(() =>
+      fs.writeFile(path.join(dir, ".opencode", "settings.json"), JSON.stringify(settingsJson)),
+    ),
+  )
+
+describe("SettingsHook additionalContext dedup — per-session (F2)", () => {
+  // F2 core: dedup is bucketed per sessionID, so a context the first session
+  // already saw is NOT starved for a second session.
+  it.instance(
+    "two different sessions each receive the same additionalContext (no cross-session dedup)",
+    () =>
+      Effect.gen(function* () {
+        const hook = yield* SettingsHook.Service
+
+        const r1 = yield* hook.trigger(
+          { event: "SessionStart", source: "startup" },
+          { sessionID: "sess-f2-a", transcriptPath: "" },
+        )
+        const r2 = yield* hook.trigger(
+          { event: "SessionStart", source: "startup" },
+          { sessionID: "sess-f2-b", transcriptPath: "" },
+        )
+
+        expect(r1.additionalContexts).toEqual([CONTEXT])
+        expect(r2.additionalContexts).toEqual([CONTEXT])
+      }),
+    { init: writeSettings },
+  )
+
+  // F2 core: within ONE session the same context surfaces exactly once.
+  it.instance(
+    "same session, same context twice — second trigger is deduped (per-session)",
+    () =>
+      Effect.gen(function* () {
+        const hook = yield* SettingsHook.Service
+
+        const r1 = yield* hook.trigger(
+          { event: "SessionStart", source: "startup" },
+          { sessionID: "sess-f2-dedup", transcriptPath: "" },
+        )
+        const r2 = yield* hook.trigger(
+          { event: "SessionStart", source: "startup" },
+          { sessionID: "sess-f2-dedup", transcriptPath: "" },
+        )
+
+        expect(r1.additionalContexts).toEqual([CONTEXT])
+        expect(r2.additionalContexts).toEqual([])
+      }),
+    { init: writeSettings },
+  )
+
+  // F2B: SessionEnd evicts the session's seen bucket, so re-using the same
+  // sessionID after end re-surfaces the context. This is the eviction path
+  // that also prevents the seen Map from growing unboundedly.
+  it.instance(
+    "SessionEnd evicts the seen bucket — same context re-surfaces for that session",
+    () =>
+      Effect.gen(function* () {
+        const hook = yield* SettingsHook.Service
+
+        const r1 = yield* hook.trigger(
+          { event: "SessionStart", source: "startup" },
+          { sessionID: "sess-f2-evict", transcriptPath: "" },
+        )
+        expect(r1.additionalContexts).toEqual([CONTEXT])
+
+        // End the session — trigger's SessionEnd branch deletes the bucket.
+        // (Runs before the WP-6A short-circuit even though there is no
+        // SessionEnd hook configured.)
+        yield* hook.trigger(
+          { event: "SessionEnd", reason: "other" },
+          { sessionID: "sess-f2-evict", transcriptPath: "" },
+        )
+
+        // Same session ID again — bucket was cleared, so the context re-surfaces.
+        const r2 = yield* hook.trigger(
+          { event: "SessionStart", source: "startup" },
+          { sessionID: "sess-f2-evict", transcriptPath: "" },
+        )
+        expect(r2.additionalContexts).toEqual([CONTEXT])
+      }),
+    { init: writeSettings },
+  )
+})
+
+describe("SettingsHook SessionEnd — clears the dynamic SessionHooks store (F2)", () => {
+  // F2B: SessionHooks.clear was defined but never invoked. trigger's SessionEnd
+  // branch now calls it, so a session's dynamically-attached hooks are freed on
+  // end. Verified by attaching a hook, firing SessionEnd (which has no on-disk
+  // matcher, so it would short-circuit — cleanup runs first), then confirming
+  // the store is empty.
+  it.instance(
+    "SessionEnd removes the session's dynamic hooks",
+    () =>
+      Effect.gen(function* () {
+        const hook = yield* SettingsHook.Service
+        const sessionHooks = yield* SessionHooks.Service
+        const sid = SessionID.make("sess-f2-hookclear")
+
+        yield* sessionHooks.add(sid, {
+          event: "Stop",
+          hooks: [{ type: "command", command: "true" }],
+        })
+        const before = yield* sessionHooks.list(sid, "Stop")
+        expect(before.length).toBe(1)
+
+        yield* hook.trigger({ event: "SessionEnd", reason: "other" }, { sessionID: "sess-f2-hookclear", transcriptPath: "" })
+
+        const after = yield* sessionHooks.list(sid, "Stop")
+        expect(after.length).toBe(0)
+      }),
+    // No settings file: there is no on-disk hook, and the SessionEnd cleanup
+    // must run even on the short-circuit path — that is what this test asserts.
+  )
+})


### PR DESCRIPTION
Two hardening fixes from cross-review (FABLE5 round 2).

## F1: Goal terminal event contract (defense in depth)

**Race concern:** `afterIdle` done branch injected noReply message before `deleteAndPublishDone`. If the injection triggered a new idle event, the subscription would fork a new fiber and `registerLoopFiber` would interrupt the current fiber mid-terminal-sequence → `goal.cleared` might never fire.

**Verification:** The race is theoretically NOT triggerable today — noReply returns early at `prompt.ts:1272` before `status.set(busy)` at 1292, so no status transition occurs. BUT the fixes are zero-cost contract hardening:

1. **Swap order:** `deleteAndPublishDone` now runs BEFORE the noReply message in the done branch
2. **`Effect.uninterruptible` wrap:** bodies of `deleteAndPublishDone` and `pauseAndPublish` wrapped — terminal event sequence is structurally immune to fiber interruption regardless of caller timing

## F2: additionalContext per-session dedup (real fix)

**Bug:** `seen: Set<string>` on InstanceState caused cross-session dedup. A second session never received the same `additionalContext` the first session already saw. The Set also grew unboundedly.

**Fix:**
- `seen` changed from `Set<string>` to `Map<SessionID, Set<string>>` — bucketed per session
- SessionEnd cleanup: seen bucket deleted + `SessionHooks.clear()` finally called (was defined but never invoked — memory leak)

## Tests
- +2 goal tests: `deleteAndPublishDone` and `pauseAndPublish` complete under fiber interruption (uninterruptible verification)
- +4 hook tests: per-session dedup, SessionEnd cleanup, cross-session independence

## Not in this PR
- **F3 (watchSettings wiring):** separate PR — higher complexity, needs watcher fixes + cross-platform testing