### PR TITLE
feat(hooks): wire watchSettings for runtime settings hot-reload

### DIFF
--- a/packages/opencode/src/hook/extensions/hot-reload.ts
+++ b/packages/opencode/src/hook/extensions/hot-reload.ts
@@ -23,30 +23,29 @@ import type { Settings } from "../settings"
 const log = Log.create({ service: "hook.extensions.hot-reload" })
 
 /**
- * All settings file paths that participate in the hook chain.
- * Mirrors the 6-layer chain in settings.ts loadChain().
+ * Directories whose `settings.json` / `settings.local.json` participate in the
+ * hook chain. We watch the parent directories (not the individual files) so a
+ * settings file that does not exist yet is still detected the moment it is
+ * created — watching the file directly would miss it entirely. Mirrors the
+ * 6-layer chain in settings.ts loadChain().
  */
-function settingsFiles(projectDir: string, opencodeGlobalConfig?: string): string[] {
+function settingsDirs(
+  projectDir: string,
+  worktree: string | undefined,
+  opencodeGlobalConfig?: string,
+): string[] {
   const home = process.env.HOME ?? process.env.USERPROFILE ?? ""
-  const candidates = [
-    path.join(home, ".claude", "settings.json"),
+  const dirs = [
+    path.join(home, ".claude"),
+    path.join(projectDir, ".claude"),
+    path.join(projectDir, ".opencode"),
   ]
-
-  // Layer 2: opencode global config (if provided)
-  if (opencodeGlobalConfig) {
-    candidates.push(path.join(opencodeGlobalConfig, "settings.json"))
+  if (opencodeGlobalConfig) dirs.push(opencodeGlobalConfig)
+  if (worktree && worktree !== projectDir) {
+    dirs.push(path.join(worktree, ".claude"), path.join(worktree, ".opencode"))
   }
-
-  // Project-level files
-  candidates.push(
-    path.join(projectDir, ".claude", "settings.json"),
-    path.join(projectDir, ".opencode", "settings.json"),
-    path.join(projectDir, ".claude", "settings.local.json"),
-    path.join(projectDir, ".opencode", "settings.local.json"),
-  )
-
-  // Only watch files whose parent directory exists
-  return candidates.filter((f) => existsSync(path.dirname(f)))
+  // Dedupe (worktree may collapse onto project) and keep only existing dirs.
+  return [...new Set(dirs)].filter((d) => existsSync(d))
 }
 
 export interface HotReloadHandle {
@@ -70,16 +69,19 @@ function countHooks(settings: Settings): number {
 }
 
 /**
- * Watch all settings files for changes. On change, call the reload
- * callback which should re-run loadChain() and update the state.
+ * Watch settings source directories for changes. On a `settings.json` /
+ * `settings.local.json` change, call the reload callback which should re-run
+ * loadChain() and update the state.
  *
  * @param projectDir - Project root directory
+ * @param worktree - Optional git worktree root; its .claude/.opencode dirs are watched too
  * @param reload - Effect that re-runs loadChain() and returns new Settings
  * @param onReload - Callback invoked with new settings and changed file path
  * @param opencodeGlobalConfig - Optional path to opencode global config dir
  */
 export function watchSettings(
   projectDir: string,
+  worktree: string | undefined,
   reload: () => Effect.Effect<Settings>,
   onReload: (newSettings: Settings, changedFile: string) => void,
   opencodeGlobalConfig?: string,
@@ -88,12 +90,17 @@ export function watchSettings(
   let debounceTimer: ReturnType<typeof setTimeout> | null = null
   let lastReload = 0
 
-  const files = settingsFiles(projectDir, opencodeGlobalConfig)
-  log.info("watching settings files", { count: files.length, files })
+  // Watch parent dirs and filter by settings filename inside the callback, so
+  // a settings file created at runtime is detected even though it did not
+  // exist when watching started.
+  const watchedNames = new Set(["settings.json", "settings.local.json"])
+  const dirs = settingsDirs(projectDir, worktree, opencodeGlobalConfig)
+  log.info("watching settings dirs", { count: dirs.length, dirs })
 
-  for (const file of files) {
+  for (const dir of dirs) {
     try {
-      const watcher = watch(file, { persistent: false }, (eventType) => {
+      const watcher = watch(dir, { persistent: false }, (eventType, filename) => {
+        if (!filename || !watchedNames.has(filename)) return
         if (eventType !== "change") return
 
         // Debounce: 500ms
@@ -103,6 +110,7 @@ export function watchSettings(
           if (now - lastReload < 1000) return // Min 1s between reloads
           lastReload = now
 
+          const file = path.join(dir, filename)
           log.info("settings file changed, reloading", { file })
           // Fire-and-forget: reload errors are logged but never crash
           Effect.runPromise(reload()).then(
@@ -119,8 +127,8 @@ export function watchSettings(
       })
       watchers.push(watcher)
     } catch {
-      // File doesn't exist yet — that's fine, it might be created later
-      log.debug("skipping non-existent settings file", { file })
+      // Dir removed between settingsDirs() and watch() — harmless.
+      log.debug("skipping non-existent settings dir", { dir })
     }
   }
 

--- a/packages/opencode/src/hook/settings.ts
+++ b/packages/opencode/src/hook/settings.ts
@@ -61,7 +61,7 @@ import { EventV2Bridge } from "@/event-v2-bridge"
 import { Database } from "@opencode-ai/core/database/database"
 import type { SessionHookEntry } from "./session-hooks"
 import { SessionID } from "@/session/schema"
-import { buildForkHooks } from "./extensions" // [FORK:hook-ext]
+import { buildForkHooks, watchSettings } from "./extensions" // [FORK:hook-ext]
 
 const log = Log.create({ service: "hook.settings" })
 
@@ -1337,7 +1337,31 @@ export const layer = Layer.effect(
     const state = yield* InstanceState.make(
       Effect.fn("SettingsHook.state")(function* (instCtx) {
         const settings = loadChain(instCtx.directory, instCtx.worktree)
-        return { settings, cwd: instCtx.directory, seen: new Map<string, Set<string>>() } satisfies State
+        const stateObj = {
+          settings,
+          cwd: instCtx.directory,
+          seen: new Map<string, Set<string>>(),
+        } satisfies State
+
+        // [FORK:hook-ext] Hot-reload settings files at runtime. The watcher
+        // re-runs loadChain on a settings.json change and mutates
+        // stateObj.settings in place. trigger reads s.settings via
+        // InstanceState.get on every call, and the cache returns the SAME
+        // state object, so the mutation is visible without invalidating the
+        // cache. The finalizer closes the watcher when the instance scope is
+        // disposed (same scope-based cleanup discipline as GoalLoop.state).
+        const handle = watchSettings(
+          instCtx.directory,
+          instCtx.worktree,
+          () => Effect.sync(() => loadChain(instCtx.directory, instCtx.worktree)),
+          (newSettings) => {
+            stateObj.settings = newSettings
+          },
+          Global.Path.config,
+        )
+        yield* Effect.addFinalizer(() => Effect.sync(() => handle.close()))
+
+        return stateObj
       }),
     )
 

--- a/packages/opencode/test/hook/settings-hot-reload.test.ts
+++ b/packages/opencode/test/hook/settings-hot-reload.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, test } from "bun:test"
+import { Effect, Layer } from "effect"
+import * as fs from "fs/promises"
+import os from "os"
+import path from "path"
+import { SettingsHook } from "@/hook/settings"
+import { SessionHooks } from "@/hook/session-hooks"
+import { EventV2Bridge } from "@/event-v2-bridge"
+import { Database } from "@opencode-ai/core/database/database"
+import { watchSettings } from "@/hook/extensions"
+import { TestInstance } from "../fixture/fixture"
+import { pollWithTimeout, testEffect } from "../lib/effect"
+
+// Real SettingsHook layer with its deps, mirroring the dedup test. SessionHooks
+// is exposed via Layer.provideMerge. Each it.instance test runs in a fresh temp
+// instance dir, so InstanceState-built state (loadChain + the seen Map) and the
+// watchSettings watcher are fresh per test.
+const testLayer = SettingsHook.layer.pipe(
+  Layer.provide(EventV2Bridge.defaultLayer),
+  Layer.provide(Database.defaultLayer),
+  Layer.provideMerge(SessionHooks.defaultLayer),
+)
+
+const it = testEffect(testLayer)
+
+const CONTEXT_V1 = "ctx-hot-reload-v1"
+const CONTEXT_V2 = "ctx-hot-reload-v2"
+
+// A SessionStart command hook whose stdout JSON carries a fixed additionalContext
+// marker. `printf '%s' '<json>'` single-quotes the JSON so its inner double
+// quotes reach the shell literally; parseStdout then JSON.parses the output.
+const hookJson = (ctx: string) =>
+  JSON.stringify({ hookSpecificOutput: { additionalContext: ctx } })
+
+const settingsFor = (ctx: string) => ({
+  hooks: {
+    SessionStart: [{ hooks: [{ type: "command", command: `printf '%s' '${hookJson(ctx)}'` }] }],
+  },
+})
+
+const opencodeDir = (dir: string) => path.join(dir, ".opencode")
+const settingsPath = (dir: string) => path.join(opencodeDir(dir), "settings.json")
+
+const writeSettings = (dir: string, ctx: string) =>
+  Effect.promise(async () => {
+    await fs.mkdir(opencodeDir(dir), { recursive: true })
+    await fs.writeFile(settingsPath(dir), JSON.stringify(settingsFor(ctx)))
+  })
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms))
+
+describe("SettingsHook hot-reload — watchSettings wiring (F3)", () => {
+  // F3.1 integration: changing settings.json at runtime is picked up by the
+  // next trigger after the watcher debounce. The first trigger runs
+  // InstanceState.get → loadChain (reads v1) AND wires watchSettings; the
+  // on-disk edit fires the .opencode dir watcher, reload() re-runs loadChain
+  // (reads v2), and onReload mutates the cached state object's .settings in
+  // place — visible to trigger without invalidating the cache.
+  it.instance(
+    "runtime settings.json change is surfaced by the next trigger after debounce",
+    () =>
+      Effect.gen(function* () {
+        const hook = yield* SettingsHook.Service
+
+        // Baseline: trigger runs loadChain (v1) and starts the watcher.
+        const r1 = yield* hook.trigger(
+          { event: "SessionStart", source: "startup" },
+          { sessionID: "sess-f3-base", transcriptPath: "" },
+        )
+        expect(r1.additionalContexts).toEqual([CONTEXT_V1])
+
+        // Edit the on-disk settings to v2.
+        const inst = yield* TestInstance
+        yield* writeSettings(inst.directory, CONTEXT_V2)
+
+        // Poll until the hot-reload has mutated the cached settings to v2.
+        // Each poll uses a fresh session so per-session dedup never masks the
+        // new marker. The reload is driven by the watcher's 500ms setTimeout
+        // debounce + fs.watch delivery, so we wait on the observable effect
+        // rather than a fixed sleep.
+        let n = 0
+        yield* pollWithTimeout(
+          Effect.gen(function* () {
+            n += 1
+            const r = yield* hook.trigger(
+              { event: "SessionStart", source: "startup" },
+              { sessionID: `sess-f3-poll-${n}`, transcriptPath: "" },
+            )
+            return r.additionalContexts.includes(CONTEXT_V2) ? true : undefined
+          }),
+          "settings hot-reload did not surface v2 within timeout",
+          "6 seconds",
+        )
+
+        // Final confirmation with a clean session.
+        const r2 = yield* hook.trigger(
+          { event: "SessionStart", source: "startup" },
+          { sessionID: "sess-f3-final", transcriptPath: "" },
+        )
+        expect(r2.additionalContexts).toEqual([CONTEXT_V2])
+      }),
+    { init: (dir) => writeSettings(dir, CONTEXT_V1) },
+  )
+
+  // F3.2 + cleanup: watchSettings watches parent dirs (so it fires on a
+  // settings.json change) and handle.close() stops all reloads. Direct unit
+  // test of the watcher mechanism, independent of the SettingsHook layer.
+  // Fixed sleeps are justified here — this test exercises debounce/throttle
+  // timing and proves absence of reload after close().
+  test("watchSettings reloads on settings.json change and stops after close", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "hot-reload-"))
+    const file = settingsPath(dir)
+    await fs.mkdir(opencodeDir(dir), { recursive: true })
+    await fs.writeFile(file, JSON.stringify({ hooks: {} }))
+
+    let marker: string | undefined
+    const handle = watchSettings(
+      dir,
+      undefined,
+      () =>
+        Effect.sync(() => ({
+          hooks: { SessionStart: [{ hooks: [{ type: "command", command: "true" }] }] },
+        })),
+      () => {
+        marker = "reloaded"
+      },
+    )
+
+    // Trigger a change. fs.watch fires "change" for settings.json on overwrite.
+    await fs.writeFile(file, JSON.stringify({ hooks: { Stop: [] } }))
+    // Wait past the 500ms debounce for the reload to land.
+    await sleep(1000)
+    expect(marker).toBe("reloaded")
+
+    // After close(), further changes must NOT reload.
+    handle.close()
+    marker = undefined
+    await fs.writeFile(file, JSON.stringify({ hooks: { Notification: [] } }))
+    await sleep(1000)
+    expect(marker).toBeUndefined()
+
+    await fs.rm(dir, { recursive: true, force: true })
+  })
+})


### PR DESCRIPTION
## Finding 3 from cross-review (FABLE5)

`watchSettings()` in `hot-reload.ts` was a complete implementation (debounce, min-interval, error-safe) that was **never called anywhere** — dead code. Settings.json changes during runtime didn't take effect without restart.

## What changed

### `hot-reload.ts`
- **Per-file → per-directory watching:** Previously watched individual `settings.json` files — if a file didn't exist at startup, it was never detected when later created. Now watches parent directories (`.claude/`, `.opencode/`) and filters by filename in the callback.
- **Worktree support:** Added `worktree` parameter so worktree settings files are also watched.
- **Deduplication:** Multiple candidate files sharing a parent dir are covered by one watcher.

### `settings.ts`
- Wired `watchSettings()` into the `InstanceState.make` init closure:
  - `reload` callback re-runs `loadChain()` and returns new Settings
  - `onReload` mutates `state.settings` in place (trigger reads it on next call)
  - `Effect.addFinalizer` calls `handle.close()` on instance disposal

### Test
- Integration test: writes v1 settings.json → starts layer → writes v2 → polls trigger until v2 surfaces (after 500ms debounce)
- Unit test: `watchSettings` fires reload on change; stops after `close()`

## Verification
- typecheck: ✅ green
- hook tests: 6 pass (4 existing dedup + 2 new hot-reload)
- goal tests: 58 pass (no regression)

## Note
The integration test uses real `fs.watch` (Linux/inotify) with a 6s poll timeout. If CI runners are slow, the poll timeout may need bumping.