### PR TITLE
fix(hooks): SessionEnd cleanup order + hot-reload event filtering

### DIFF
--- a/packages/opencode/src/hook/extensions/hot-reload.ts
+++ b/packages/opencode/src/hook/extensions/hot-reload.ts
@@ -99,18 +99,21 @@ export function watchSettings(
 
   for (const dir of dirs) {
     try {
-      const watcher = watch(dir, { persistent: false }, (eventType, filename) => {
+      const watcher = watch(dir, { persistent: false }, (_eventType, filename) => {
         if (!filename || !watchedNames.has(filename)) return
-        if (eventType !== "change") return
 
-        // Debounce: 500ms
+        // Debounce: 500ms. Min 1s between reloads.
+        // On min-interval block, reschedule (not drop) so rapid successive
+        // saves are not permanently lost.
         if (debounceTimer) clearTimeout(debounceTimer)
-        debounceTimer = setTimeout(() => {
+        const file = path.join(dir, filename)
+        const tryReload = () => {
           const now = Date.now()
-          if (now - lastReload < 1000) return // Min 1s between reloads
+          if (now - lastReload < 1000) {
+            debounceTimer = setTimeout(tryReload, 1000 - (now - lastReload))
+            return
+          }
           lastReload = now
-
-          const file = path.join(dir, filename)
           log.info("settings file changed, reloading", { file })
           // Fire-and-forget: reload errors are logged but never crash
           Effect.runPromise(reload()).then(
@@ -123,7 +126,8 @@ export function watchSettings(
             },
             (err) => log.warn("settings reload failed", { file, error: String(err) }),
           )
-        }, 500)
+        }
+        debounceTimer = setTimeout(tryReload, 500)
       })
       watchers.push(watcher)
     } catch {

--- a/packages/opencode/src/hook/settings.ts
+++ b/packages/opencode/src/hook/settings.ts
@@ -1431,7 +1431,9 @@ export const layer = Layer.effect(
       // session, which is harmless.
       if (payload.event === "SessionEnd" && ctx.sessionID) {
         s.seen.delete(ctx.sessionID)
-        yield* sessionHooks.clear(SessionID.make(ctx.sessionID))
+        // NOTE: sessionHooks.clear is deferred to after hook execution
+        // (before each return point below) — clearing here would remove
+        // session-registered SessionEnd hooks before the matcher can see them.
       }
 
       // ── WP-6A: O(1) short-circuit ─────────────────────────────
@@ -1449,6 +1451,9 @@ export const layer = Layer.effect(
         : false
       if (!hasFile && !hasSession) {
         log.info("trigger short-circuit", { event: payload.event, reason: "no_matchers", hasFile, hasSession })
+        if (payload.event === "SessionEnd" && ctx.sessionID) {
+          yield* sessionHooks.clear(SessionID.make(ctx.sessionID))
+        }
         return result
       }
 
@@ -1493,6 +1498,9 @@ export const layer = Layer.effect(
       ]
       if (!matchers.length) {
         log.info("trigger short-circuit", { event: payload.event, reason: "empty_matchers" })
+        if (payload.event === "SessionEnd" && ctx.sessionID) {
+          yield* sessionHooks.clear(SessionID.make(ctx.sessionID))
+        }
         return result
       }
 
@@ -1610,6 +1618,9 @@ export const layer = Layer.effect(
         if (result.preventContinuation) break
       }
 
+      if (payload.event === "SessionEnd" && ctx.sessionID) {
+        yield* sessionHooks.clear(SessionID.make(ctx.sessionID))
+      }
       return result
     })
 


### PR DESCRIPTION
Two regressions from PRs #42/#43, found by FABLE5 cross-review (round 3). Both verified, both fixed.

## Bug 1: SessionEnd cleanup before matcher (regression from #42)

`sessionHooks.clear` was called at trigger entry, BEFORE `hasForEvent` and `sessionHooks.list`. Session-registered SessionEnd hooks were cleared before the matcher could see them — registered but never fired.

**Fix:** `sessionHooks.clear` moved from trigger entry to before each return point (3 paths: short-circuit, empty-matchers, final). `seen.delete` stays at entry (harmless).

## Bug 2: Hot-reload dropped 'rename' events (regression from #43)

`eventType !== "change"` filter dropped 'rename' events — the exact events Linux/inotify emits for new file creation and vim/VSCode atomic saves. The directory-watching refactor's core goal (detect runtime-created settings.json) was silently broken. Tests passed because `fs.writeFile` on existing files emits 'change'.

**Fix:** eventType filter removed. Only filename is filtered (`watchedNames`).

## Bonus: min-interval reschedule (polish from #43)

Min-interval check (1s) previously dropped the reload with `return`. Rapid successive saves (second save within 1s of first reload) were permanently lost. Now reschedules via `setTimeout(tryReload, remaining)`.

## Verification
- typecheck: clean
- hook tests: 6 pass
- goal tests: 58 pass (no regression)
- FABLE5 review: PASS — "两处修复都正确，测试 64/64 全绿"