### PR TITLE
fix(ci): deduplicate bun cache savers to eliminate save-collision warnings

### DIFF
--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: "Additional flags to pass to 'bun install'"
     required: false
     default: ""
+  save-cache:
+    description: "Whether to save the bun cache after install (set false for jobs that share an OS with another saver)"
+    required: false
+    default: "true"
 runs:
   using: "composite"
   steps:
@@ -59,7 +63,7 @@ runs:
       shell: bash
 
     - name: Save Bun dependencies
-      if: steps.bun-cache.outputs.cache-hit != 'true' && github.event_name != 'pull_request' && github.event_name != 'pull_request_target'
+      if: inputs.save-cache == 'true' && steps.bun-cache.outputs.cache-hit != 'true' && github.event_name != 'pull_request' && github.event_name != 'pull_request_target'
       uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ${{ steps.cache.outputs.dir }}

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -137,6 +137,11 @@ jobs:
 
       - name: Setup Bun
         uses: ./.github/actions/setup-bun
+        with:
+          # Only Windows saves (sole Windows job). Linux e2e skips —
+          # unit-tests (linux) is the single Linux cache saver, avoiding
+          # intra-run cache key collision on {OS}-bun-{hash}.
+          save-cache: ${{ matrix.settings.name == 'windows' }}
 
       - name: Read Playwright version
         id: playwright-version


### PR DESCRIPTION
## Problem

E2E Tests CI showed recurring `Cache save failed` warnings. Root cause: `setup-bun` composite action's save step ran in every job sharing the cache key `{OS}-bun-{hash}`. On Linux, `unit-tests` + `e2e-tests (linux)` raced to save the same key.

## Fix

Added `save-cache` input (default `true`) to `setup-bun` action. E2E tests pass `save-cache: ${{ matrix.settings.name == 'windows' }}` — only the Windows variant saves (sole Windows job); Linux e2e skips (unit-tests linux is the single Linux saver).

## Effect

- Linux intra-run collision: **eliminated** (2 savers → 1)
- Windows cross-run collision: unchanged (unavoidable without a dedicated Windows caching job, but rare)

Analysis credit: FABLE5 cross-review.