### PR TITLE
fix(sdk): revert @hey-api/openapi-ts to 0.90.10 to match lockfile

### DIFF
--- a/packages/sdk/js/package.json
+++ b/packages/sdk/js/package.json
@@ -22,7 +22,7 @@
     "dist"
   ],
   "devDependencies": {
-    "@hey-api/openapi-ts": "0.97.3",
+    "@hey-api/openapi-ts": "0.90.10",
     "@tsconfig/node22": "catalog:",
     "@types/cross-spawn": "catalog:",
     "@types/node": "catalog:",


### PR DESCRIPTION
## Problem

CI Unit Tests on main fail at `@opencode-ai/sdk#build`:

```
error: SseFn patch did not apply; @hey-api/openapi-ts output may have changed
```

## Root cause

Dependabot #38 bumped `packages/sdk/js/package.json` to **0.97.3** without updating `bun.lock` (still pins **0.90.10**) or adapting `script/build.ts`. On CI, `bun install` resolves 0.97.3, whose generated `types.gen.ts` no longer contains the SseFn signature the post-gen patch rewrites — the build throws by design (fail-loud guard).

## Fix

Revert the version to 0.90.10, matching the lockfile. One line.

A real 0.97.3 upgrade should be its own PR and needs:
- conditional patch logic (upstream likely fixed the TError-in-TReturn bug the patch works around)
- openapi-ts config update (`instance` option is deprecated in 0.97.x)
- regenerated checked-in output + `check:generated` verification
- an actual `bun.lock` update

## Verification

- `bun install --frozen-lockfile` — clean, no changes
- `packages/sdk/js` `bun run build` — succeeds, zero diff in generated files
- full-repo `turbo typecheck` — 29/29 pass (pre-commit hook)