### PR TITLE
chore(ci): switch CI trigger from dev to main

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -2,14 +2,14 @@
 # 🧪 CI · Test
 # ----------------------------------------------------------------------------
 # Purpose : Run unit + Playwright e2e tests across Linux & Windows
-# Trigger : Push to `dev` (CI gate before main) + manual workflow_dispatch
+# Trigger : Push to `main` + manual workflow_dispatch
 # Jobs    : unit  — `bun turbo test` on linux only (windows dropped — see
 #                    unit-tests matrix comment; free windows-latest runners
 #                    can't fit the suite in a reasonable CI budget)
 #           e2e   — Playwright chromium on linux + windows (matrix)
-# Gate    : MUST pass before merging dev → main (per AGENTS.md Git Workflow 铁律)
-# Notes   : `cancel-in-progress: false` — every dev push gets a full run
-#           No trigger on feat/* (frequent changes) or main (release-only).
+# Gate    : MUST pass — main is the sole integration branch (per AGENTS.md)
+# Notes   : `cancel-in-progress: false` — every main push gets a full run
+#           No trigger on feat/* or fix/* (frequent changes).
 # ============================================================================
 
 name: 🧪 CI · Test
@@ -17,7 +17,7 @@ name: 🧪 CI · Test
 on:
   push:
     branches:
-      - dev
+      - main
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci-typecheck.yml
+++ b/.github/workflows/ci-typecheck.yml
@@ -2,10 +2,10 @@
 # 🔍 CI · Typecheck
 # ----------------------------------------------------------------------------
 # Purpose : TypeScript type checking across all packages (bun typecheck)
-# Trigger : Push to `dev` (CI gate before main) + manual workflow_dispatch
+# Trigger : Push to `main` + manual workflow_dispatch
 # Jobs    : typecheck — single Linux runner, `bun typecheck`
-# Gate    : MUST pass before merging dev → main (per AGENTS.md Git Workflow 铁律)
-# Notes   : No trigger on feat/* (frequent changes) or main (release-only).
+# Gate    : MUST pass — main is the sole integration branch (per AGENTS.md)
+# Notes   : No trigger on feat/* or fix/* (frequent changes).
 # ============================================================================
 
 name: 🔍 CI · Typecheck
@@ -13,7 +13,7 @@ name: 🔍 CI · Typecheck
 on:
   push:
     branches:
-      - dev
+      - main
   workflow_dispatch:
 
 jobs:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,35 +1,32 @@
 - To regenerate the JavaScript SDK, run `./packages/sdk/js/script/build.ts`.
-- The default branch in this repo is `dev`.
-- Local `main` ref may not exist; use `dev` or `origin/dev` for diffs.
+- The default branch in this repo is `main`.
 
 ## Git Workflow (铁律)
 
 ```
 feat/* ──┐
 fix/* ───┤
-debug/* ─┼──merge──▶ dev ──[ TDD 覆盖率 + CI + E2E 全绿 ]──▶ dev 版本 ──push──▶ main
+debug/* ─┼──merge──▶ main ──[ TDD 覆盖率 + CI + E2E 全绿 ]──▶ main 版本
 docs/* ──┤
 refactor/*┤
 test/* ──┤
 chore/* ─┘
 ```
 
-**各类 `{type}/*` 分支汇总到 `dev`。`dev` 是唯一的质量门禁**：只有 TDD 覆盖率 + CI + E2E 全部通过，才产出可发布的 `dev` 版本；通过后才能 push 到 `main`。
+**各类 `{type}/*` 分支汇总到 `main`。`main` 是唯一的质量门禁**：只有 TDD 覆盖率 + CI + E2E 全部通过，才产出可发布的版本。
 
 | Branch | CI/TDD | Purpose |
 |--------|--------|---------|
 | `{type}/{name}` | ❌ 不跑 | 功能/修复/调试/文档/重构/测试/杂务等开发，频繁变更 |
-| `dev` | ✅ **只有 dev 会触发 TDD 覆盖率 + CI + E2E 的 GitHub Actions** | 质量门禁，全绿才产出 dev 版本 |
-| `main` | ❌ 不跑 | 发布专用，只接受 dev 验证通过的代码 |
+| `main` | ✅ **只有 main 会触发 TDD 覆盖率 + CI + E2E 的 GitHub Actions** | 质量门禁 + 发版，全绿才产出新版本 |
 
 **流程**：
-1. 从 `dev` 切出 `{type}/{name}` 分支开发
-2. 完成后合并到 `dev`
-3. `dev` 必须全绿（TDD 覆盖率 + CI + E2E，由 GitHub Actions 配置触发）→ 产出 dev 版本
-4. 验证通过后才能 push 到 `main`
-5. `main` 只用于发版（`fork-release` 手动触发）
+1. 从 `main` 切出 `{type}/{name}` 分支开发
+2. 完成后合并到 `main`
+3. `main` 必须全绿（TDD 覆盖率 + CI + E2E，由 GitHub Actions 配置触发）→ 产出新版本
+4. `main` 同时用于发版（`fork-release` 手动触发）
 
-CI 配置：`test.yml` 和 `typecheck.yml` 仅在 push 到 `dev` 时触发，`cancel-in-progress: false` 保证每次都跑完。
+CI 配置：`ci-test.yml` 和 `ci-typecheck.yml` 仅在 push 到 `main` 时触发，`cancel-in-progress: false` 保证每次都跑完。
 
 ## Branch Names
 


### PR DESCRIPTION
dev branch retired. CI (test + typecheck) now triggers on push to main. AGENTS.md workflow updated to reflect main as sole integration branch.