### PR TITLE
feat(skill): add built-in configure-hooks skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ logs/
 tsconfig.tsbuildinfo
 # opencode runtime-generated local project config (created when running the built binary in a package dir)
 **/.opencode/settings.json
+
+# OpenSpec artifacts (local-only, not tracked)
+/openspec/

--- a/packages/core/src/plugin/skill.ts
+++ b/packages/core/src/plugin/skill.ts
@@ -7,8 +7,10 @@ import { Effect } from "effect"
 import { AbsolutePath } from "../schema"
 import { SkillV2 } from "../skill"
 import customizeOpencodeContent from "./skill/customize-opencode.md" with { type: "text" }
+import configureHooksContent from "./skill/configure-hooks.md" with { type: "text" }
 
 export const CustomizeOpencodeContent = customizeOpencodeContent
+export const ConfigureHooksContent = configureHooksContent
 
 export const Plugin = define({
   id: "skill",
@@ -23,6 +25,18 @@ export const Plugin = define({
               "Use ONLY when the user is editing or creating opencode's own configuration: opencode.json, opencode.jsonc, files under .opencode/, or files under ~/.config/opencode/. Also use when creating or fixing opencode agents, subagents, commands, skills, plugins, MCP servers, or permission rules. Do not use for the user's own application code, or for any project that is not configuring opencode itself.",
             location: AbsolutePath.make("/builtin/customize-opencode.md"),
             content: CustomizeOpencodeContent,
+          }),
+        }),
+      )
+      draft.source(
+        SkillV2.EmbeddedSource.make({
+          type: "embedded",
+          skill: SkillV2.Info.make({
+            name: "configure-hooks",
+            description:
+              "Use when the user wants to automatically run something on an opencode event — before/after a tool call, on session start/end, on compaction, etc. — or asks about opencode's hooks / hooks.json / event hooks. Covers hooks.json file locations and format, the 27 supported events, and the 5 hook types (command, mcp, http, prompt, agent). Also use to migrate hooks from Claude Code's .claude/settings.json via /import-claude-hooks.",
+            location: AbsolutePath.make("/builtin/configure-hooks.md"),
+            content: ConfigureHooksContent,
           }),
         }),
       )

--- a/packages/core/src/plugin/skill/configure-hooks.md
+++ b/packages/core/src/plugin/skill/configure-hooks.md
@@ -1,0 +1,123 @@
+<!--
+  Built-in skill. Name and description are registered in code at
+  packages/opencode/src/skill/index.ts (CONFIGURE_HOOKS_SKILL_DESCRIPTION).
+  The body below becomes the skill's content.
+-->
+
+# Configuring OpenCode hooks
+
+Hooks let you run code (shell command, MCP tool, HTTP call, LLM prompt, or an
+autonomous sub-agent) automatically when specific events happen during a
+session — before/after a tool call, on session start, on compaction, etc.
+Config lives in dedicated `hooks.json` files (NOT `opencode.json`, NOT
+`.claude/settings.json` — `.claude/` is never read for hooks).
+
+## Where files live
+
+| Scope   | Path                                | Hot-reloaded?                    |
+| ------- | ------------------------------------ | --------------------------------- |
+| Global  | `~/.config/opencode/hooks.json`      | No — requires restart             |
+| Project | `.opencode/hooks.json`               | Yes — polled every ~2s            |
+| Worktree| `<worktree>/.opencode/hooks.json`    | Yes (when worktree ≠ project dir) |
+
+Layers concat-append (do NOT override by key): global hooks run, then project
+hooks are appended after, in file order. A single event can have hooks from
+multiple layers all firing.
+
+If you find a `hooks` field left inside `settings.json` or `.claude/`, it is
+ignored — point the user at `/import-claude-hooks` to migrate it.
+
+## File format
+
+Top-level keys are event names; each maps to a list of matcher blocks:
+
+```json
+{
+  "PreToolUse": [
+    {
+      "matcher": "Bash",
+      "hooks": [{ "type": "command", "command": "./scripts/check.sh", "timeout": 10 }]
+    }
+  ],
+  "SessionStart": [
+    {
+      "matcher": "*",
+      "hooks": [{ "type": "command", "command": "./scripts/welcome.sh" }]
+    }
+  ]
+}
+```
+
+`matcher` selects which tool/target the block applies to:
+
+- `"*"` or omitted — matches everything
+- `"Bash"` — exact match (case-insensitive)
+- `"Bash|Edit|Write"` — pipe-separated list
+- any other string — treated as a regex tested against the target
+
+## Events (27 total)
+
+Tool lifecycle: `PreToolUse`, `PostToolUse`, `PostToolUseFailure`
+Permission: `PermissionRequest`, `PermissionDenied`
+Session lifecycle: `Setup`, `SessionStart`, `SessionEnd`, `Stop`, `StopFailure`
+Subagents: `SubagentStart`, `SubagentStop`
+Prompt/compaction: `UserPromptSubmit`, `PreCompact`, `PostCompact`
+Tasks/goals: `TaskCreated`, `TaskCompleted`, `TeammateIdle`
+Other: `Notification`, `Elicitation`, `ElicitationResult`, `ConfigChange`,
+`WorktreeCreate`, `WorktreeRemove`, `InstructionsLoaded`, `CwdChanged`,
+`FileChanged`
+
+If you need the exact input/output shape for a specific event, read
+`packages/opencode/src/hook/settings.ts` (`HookEvent`, `HookSpecificOutput`) —
+this skill is a map, not the full schema.
+
+## Hook types (all 5 implemented)
+
+| `type`    | What it does                                                                 |
+| --------- | ----------------------------------------------------------------------------- |
+| `command` | Runs a shell command. Event data is piped to stdin as JSON; stdout/exit code drive the result. |
+| `mcp`     | Invokes an MCP tool, addressed as `mcp__<server>__<tool>`.                    |
+| `http`    | POSTs the event envelope to `url`; response body is parsed as JSON.           |
+| `prompt`  | Sends the event to an LLM, constrained to structured JSON output.             |
+| `agent`   | Runs an autonomous sub-agent loop (bash/read_file/list_dir/grep) to react to the event. |
+
+### `command` protocol
+
+- stdin: JSON envelope with event data
+- exit code `0`: success, stdout optionally parsed as `HookJSONOutput` JSON
+- exit code `2`: **block** — stderr becomes the block reason, shown to the agent
+- any other exit code, or timeout: logged as a warning, does NOT abort the flow
+- `${CLAUDE_PLUGIN_ROOT}` / `${CLAUDE_PLUGIN_DATA}` expand to the directory the
+  hook was declared in / its data dir — usable in `command`
+- `options` (fork-only field, no CC equivalent): exported as
+  `CLAUDE_PLUGIN_OPTION_<KEY>` env vars in the subprocess
+
+### Common output fields (`HookJSONOutput`, applies across types)
+
+```json
+{
+  "decision": "approve" | "block",
+  "reason": "shown when blocking",
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "allow" | "deny" | "ask",
+    "additionalContext": "text injected into the session"
+  }
+}
+```
+
+Not every field applies to every event — `hookSpecificOutput` shape varies per
+event (see `HookSpecificOutput` in `settings.ts` for the exact per-event union).
+
+## Applying changes
+
+Global `hooks.json` loads once at startup — **restart required**. Project and
+worktree `hooks.json` are polled and take effect within a few seconds without
+a restart.
+
+## Migrating from Claude Code
+
+`/import-claude-hooks` reads `~/.claude/settings.json` / `./.claude/settings.json`
+/ `.claude/settings.local.json`, walks the user through importing each hook,
+and writes approved ones into the right `hooks.json`. Point users here instead
+of hand-copying Claude Code hook config.

--- a/packages/core/test/plugin/skill.test.ts
+++ b/packages/core/test/plugin/skill.test.ts
@@ -30,4 +30,18 @@ describe("SkillPlugin.Plugin", () => {
       )
     }),
   )
+
+  it.effect("registers the built-in configure-hooks skill", () =>
+    Effect.gen(function* () {
+      const skill = yield* SkillV2.Service
+      yield* SkillPlugin.Plugin.effect(host({ skill: { ...skill, reload: skill.reload } }))
+
+      expect(yield* skill.list()).toContainEqual(
+        expect.objectContaining({
+          name: "configure-hooks",
+          description: expect.stringContaining("hooks"),
+        }),
+      )
+    }),
+  )
 })

--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -34,6 +34,16 @@ const CUSTOMIZE_OPENCODE_SKILL_DESCRIPTION =
   "Use ONLY when the user is editing or creating opencode's own configuration: opencode.json, opencode.jsonc, files under .opencode/, or files under ~/.config/opencode/. Also use when creating or fixing opencode agents, subagents, skills, plugins, MCP servers, or permission rules. Do not use for the user's own application code, or for any project that is not configuring opencode itself."
 const CUSTOMIZE_OPENCODE_SKILL_BODY = SkillPlugin.CustomizeOpencodeContent
 
+// Built-in skill. Agents have no innate knowledge of opencode's hooks system
+// (events, hooks.json format, handler types) — without this skill they either
+// guess wrong or never discover hooks exist. Description alone is enough to
+// know hooks are possible and when to reach for them; the body (loaded lazily
+// on skill invocation) has the event list, file format, and handler protocol.
+const CONFIGURE_HOOKS_SKILL_NAME = "configure-hooks"
+const CONFIGURE_HOOKS_SKILL_DESCRIPTION =
+  "Use when the user wants to automatically run something on an opencode event — before/after a tool call, on session start/end, on compaction, etc. — or asks about opencode's hooks / hooks.json / event hooks. Covers hooks.json file locations and format, the 27 supported events, and the 5 hook types (command, mcp, http, prompt, agent). Also use to migrate hooks from Claude Code's .claude/settings.json via /import-claude-hooks."
+const CONFIGURE_HOOKS_SKILL_BODY = SkillPlugin.ConfigureHooksContent
+
 export const Info = Schema.Struct({
   name: Schema.String,
   description: Schema.optional(Schema.String),
@@ -280,6 +290,12 @@ export const layer = Layer.effect(
           description: CUSTOMIZE_OPENCODE_SKILL_DESCRIPTION,
           location: "<built-in>",
           content: CUSTOMIZE_OPENCODE_SKILL_BODY,
+        }
+        s.skills[CONFIGURE_HOOKS_SKILL_NAME] = {
+          name: CONFIGURE_HOOKS_SKILL_NAME,
+          description: CONFIGURE_HOOKS_SKILL_DESCRIPTION,
+          location: "<built-in>",
+          content: CONFIGURE_HOOKS_SKILL_BODY,
         }
         yield* loadSkills(s, yield* InstanceState.get(discovered), events)
         return s


### PR DESCRIPTION
## Summary
- OpenCode's hooks system (`hooks.json`, 27 events, 5 handler types) has no discovery path for agents without an explicit prompt — the format only lives in source/docs, so an agent either guesses wrong or never realizes hooks exist.
- Adds a built-in `configure-hooks` skill, mirroring the existing `customize-opencode` pattern: a short always-in-context description ("hooks exist, here's when to use them") with the full reference (file locations, event list, handler protocol, migration pointer) loaded lazily only when the skill is invoked.
- Registered in both skill surfaces that already carry `customize-opencode`: `packages/opencode/src/skill/index.ts` (v1, CLI runtime) and `packages/core/src/plugin/skill.ts` (v2, `define()`-based plugin registry) — kept in parity so neither runtime silently lacks the skill.

## Changes
- `packages/core/src/plugin/skill/configure-hooks.md` — skill body: hooks.json locations/hot-reload behavior, concat-append merge order, matcher syntax, 27-event list, 5 handler types, command protocol (stdin/exit-code-2/env vars), and the `/import-claude-hooks` migration pointer
- `packages/core/src/plugin/skill.ts` — exports `ConfigureHooksContent`, registers the skill in the v2 `Plugin`
- `packages/opencode/src/skill/index.ts` — registers the built-in skill for the v1 (CLI) skill registry
- `packages/core/test/plugin/skill.test.ts` — asserts the v2 plugin registers `configure-hooks`

## Test plan
- [x] `bun test packages/core/test/plugin/skill.test.ts` — 2 pass (existing `customize-opencode` case + new `configure-hooks` case)
- [x] `bun test packages/opencode/test/skill/` — 22 pass, no regressions
- [x] `bun turbo typecheck` (via pre-commit hook) — 29/29 packages pass