### PR TITLE
fix(tool): resolve Goal.Service at execute time, not ToolRegistry build

### DIFF
--- a/packages/opencode/src/tool/goal.ts
+++ b/packages/opencode/src/tool/goal.ts
@@ -23,16 +23,21 @@ type Metadata = {
   } | null
 }
 
-// Goal.Service is resolved lazily (serviceOption) rather than declared as
-// a hard dependency of the tool layer. This keeps ToolRegistry's requirement
-// set small and lets the tool degrade gracefully if Goal isn't provided by
-// the entry point — matching how src/session/prompt.ts and
-// src/session/session.ts access Goal.Service.
+// Goal.Service MUST be resolved inside `execute` (request phase), NOT in this
+// build-phase `init` gen. `init` runs once during ToolRegistry construction,
+// which lives in one Layer.mergeAll group of AppLayer while Goal.defaultLayer
+// lives in a sibling group; mergeAll siblings cannot see each other's outputs,
+// so a build-phase serviceOption(Goal.Service) is guaranteed None and would be
+// captured in this closure, permanently no-op-ing the tool (verified by the
+// runtime "autonomous goal service is not available" symptom). At execute time
+// the session request context carries the full AppLayer, so Goal.Service is
+// reachable. This corrects the misleading reference in goal-loop-correctness
+// task 6.1, which cited the old build-phase probe as the pattern to follow.
+// serviceOption contributes R = never, so Tool.define<…, never> is unchanged
+// and headless runtimes that omit Goal still degrade gracefully below.
 export const GoalTool = Tool.define<typeof Parameters, Metadata, never>(
   "goal",
   Effect.gen(function* () {
-    const goal = Option.getOrUndefined(yield* Effect.serviceOption(Goal.Service))
-
     return {
       description: DESCRIPTION,
       parameters: Parameters,
@@ -41,6 +46,7 @@ export const GoalTool = Tool.define<typeof Parameters, Metadata, never>(
           // Goal state belongs to the session itself; it is not an external
           // resource boundary (no filesystem, no network, no cross-session
           // write), so it does not need a permission gate.
+          const goal = Option.getOrUndefined(yield* Effect.serviceOption(Goal.Service))
 
           if (!goal) {
             // Goal service not wired into this entry point (some headless

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -90,6 +90,10 @@ export const TaskTool = Tool.define(
     const scope = yield* Scope.Scope
     const flags = yield* RuntimeFlags.Service
     const database = yield* Database.Service
+    // Build-phase serviceOption is SAFE here, unlike tool/goal.ts: SettingsHook
+    // arrives via Layer.provideMerge (app-runtime.ts), whose output is visible to
+    // the ToolRegistry mergeAll group during construction, so this resolves Some.
+    // Goal.Service, by contrast, is a mergeAll sibling and invisible at build.
     const settingsHook = Option.getOrUndefined(yield* Effect.serviceOption(SettingsHook.Service))
 
     const run = Effect.fn("TaskTool.execute")(function* (

--- a/packages/opencode/test/tool/goal-tool.test.ts
+++ b/packages/opencode/test/tool/goal-tool.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect } from "bun:test"
+import { Effect, Layer } from "effect"
+import { Agent } from "../../src/agent/agent"
+import { Goal } from "../../src/goal/goal"
+import { GoalState } from "../../src/goal/state"
+import { GoalTool } from "../../src/tool/goal"
+import { MessageID, SessionID } from "../../src/session/schema"
+import { Truncate } from "@/tool/truncate"
+import type { Tool } from "@/tool/tool"
+import { testEffect } from "../lib/effect"
+
+// Goal.Service is INTENTIONALLY absent from this build context — it mirrors the
+// production ToolRegistry build phase (AppLayer group2), where Goal.Service (a
+// group1 Layer.mergeAll sibling) is not visible at construction. Goal is
+// provided only at execute time below, matching the production request phase.
+//
+// Before the tool-init-service-resolution fix, the goal tool captured a
+// build-phase `None` from Effect.serviceOption(Goal.Service) into a closure, so
+// the reachability assertions below would FAIL regardless of the execute-time
+// provide (the tool always returned "service unavailable"). These tests lock
+// the fixed contract: the probe resolves in execute, where Goal.Service lives.
+const it = testEffect(Layer.mergeAll(Truncate.defaultLayer, Agent.defaultLayer))
+
+function ctx(): Tool.Context {
+  return {
+    sessionID: SessionID.make("ses_goal_tool"),
+    messageID: MessageID.make("msg_goal_tool"),
+    callID: "call_goal_tool",
+    agent: "build",
+    abort: AbortSignal.any([]),
+    messages: [],
+    metadata: () => Effect.void,
+    ask: () => Effect.void,
+  }
+}
+
+const activeGoal = {
+  goal: "read the docs",
+  status: "active",
+  turns_used: 2,
+  max_turns: 20,
+  created_at: Date.now(),
+  last_turn_at: Date.now(),
+  consecutive_parse_failures: 0,
+  subgoals: [],
+} as GoalState.Info
+
+const doneGoal = { ...activeGoal, status: "done", turns_used: 3 } as GoalState.Info
+
+describe("tool.goal — service resolution phase", () => {
+  it.instance("status reaches Goal.Service when provided at execute time", () =>
+    Effect.gen(function* () {
+      const info = yield* GoalTool
+      const tool = yield* info.init()
+      const goalLayer = Layer.mock(Goal.Service, {
+        load: () => Effect.succeed(undefined),
+      })
+
+      const result = yield* tool.execute({ action: "status" }, ctx()).pipe(Effect.provide(goalLayer))
+
+      expect(result.output).not.toContain("not available in this runtime")
+      expect(result.output).toContain("No autonomous goal")
+    }),
+  )
+
+  it.instance("status renders state when an active goal is loaded", () =>
+    Effect.gen(function* () {
+      const info = yield* GoalTool
+      const tool = yield* info.init()
+      const goalLayer = Layer.mock(Goal.Service, {
+        load: () => Effect.succeed(activeGoal),
+      })
+
+      const result = yield* tool.execute({ action: "status" }, ctx()).pipe(Effect.provide(goalLayer))
+
+      expect(result.output).toContain("Goal: read the docs")
+      expect(result.output).toContain("Status: active")
+      expect(result.output).toContain("Turns: 2/20")
+    }),
+  )
+
+  it.instance("complete calls markDone and clears goal state (regression guard)", () =>
+    Effect.gen(function* () {
+      let markDoneCalls = 0
+      const info = yield* GoalTool
+      const tool = yield* info.init()
+      const goalLayer = Layer.mock(Goal.Service, {
+        load: () => Effect.succeed(activeGoal),
+        markDone: () =>
+          Effect.sync(() => {
+            markDoneCalls += 1
+            return doneGoal
+          }),
+      })
+
+      const result = yield* tool.execute({ action: "complete", reason: "docs read" }, ctx()).pipe(
+        Effect.provide(goalLayer),
+      )
+
+      expect(markDoneCalls).toBe(1)
+      expect(result.output).toContain("目标已达成")
+      expect(result.output).toContain("docs read")
+    }),
+  )
+
+  it.instance("complete refuses to complete when no active goal is loaded", () =>
+    Effect.gen(function* () {
+      const info = yield* GoalTool
+      const tool = yield* info.init()
+      const goalLayer = Layer.mock(Goal.Service, {
+        load: () => Effect.succeed(undefined),
+      })
+
+      const result = yield* tool.execute({ action: "complete", reason: "nothing to do" }, ctx()).pipe(
+        Effect.provide(goalLayer),
+      )
+
+      expect(markDoneNeverCalled(result.output))
+      expect(result.output).toContain("Cannot complete goal: no active goal")
+    }),
+  )
+
+  it.instance("status degrades gracefully when Goal.Service is absent (headless)", () =>
+    Effect.gen(function* () {
+      const info = yield* GoalTool
+      const tool = yield* info.init()
+
+      // No Goal.Service provided at execute time — e.g. a headless runtime.
+      const result = yield* tool.execute({ action: "status" }, ctx())
+
+      expect(result.output).toContain("not available in this runtime")
+    }),
+  )
+})
+
+function markDoneNeverCalled(output: string) {
+  return !output.includes("目标已达成")
+}


### PR DESCRIPTION
The goal tool probed `Effect.serviceOption(Goal.Service)` in Tool.define's build-phase init gen. ToolRegistry builds in an AppLayer mergeAll group that cannot see sibling-group outputs, so the probe was always `None` and the closure permanently no-op'd the tool ('goal service unavailable'; `complete` never ran `markDone`, the loop could not terminate via tool).

- Move the probe into `execute` (request phase, full AppLayer context); R stays `never`, headless degradation preserved
- Document why `task.ts`'s build-phase probe is safe (SettingsHook arrives via provideMerge)
- Add integration test mirroring the production layer topology (Goal absent at build, provided at execute) — 5 tests green
- OpenSpec change: `tool-init-service-resolution`

Verification: `bun turbo typecheck` 29/29 green; `bun test test/tool/goal-tool.test.ts test/goal/` 63/63 green.