### PR TITLE
fix(ci): designate a single bun cache saver per OS to stop save races

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -70,6 +70,11 @@ jobs:
 
       - name: Setup Bun
         uses: ./.github/actions/setup-bun
+        with:
+          # ci-typecheck.yml's Linux job is the designated Linux cache
+          # saver (runs on every push, fast, low collision risk) — this job
+          # only restores, to avoid racing on the same {OS}-bun-{hash} key.
+          save-cache: false
 
       - name: Configure Git Identity
         run: |

--- a/.github/workflows/release-fork.yml
+++ b/.github/workflows/release-fork.yml
@@ -87,6 +87,13 @@ jobs:
       - name: Setup Bun
         if: inputs.platforms == '' || contains(inputs.platforms, matrix.name)
         uses: ./.github/actions/setup-bun
+        with:
+          # Linux and Windows bun caches are each owned by a single saver
+          # elsewhere (ci-typecheck.yml linux, ci-test.yml e2e windows) to
+          # avoid racing on the same {OS}-bun-{hash} key when this manual
+          # release build runs concurrently with a push-triggered CI run.
+          # macOS has no other job in the repo, so it's safe to save here.
+          save-cache: ${{ matrix.name == 'macos' }}
 
       - name: Build CLI
         if: inputs.platforms == '' || contains(inputs.platforms, matrix.name)


### PR DESCRIPTION
## Summary
- Concurrent Linux/Windows jobs across `ci-test.yml`, `ci-typecheck.yml`, and `release-fork.yml` all compute the same `{OS}-bun-{hash}` cache key and race to save it, producing "Unable to reserve cache... another job may be creating this cache" warnings and the cache never actually landing.
- Designate a single saver per OS: `ci-typecheck.yml` (linux), `ci-test.yml` e2e-tests (windows, unchanged), `release-fork.yml` (macos, the only job touching macOS). Every other job now only restores.

## Test plan
- [x] `bun turbo typecheck` passes (ran via pre-commit hook)
- [ ] Trigger `release-fork.yml` via workflow_dispatch alongside a push to `dev`/`main` and confirm no more "Unable to reserve cache" warnings, and that cache saves succeed on the designated jobs