### PR TITLE
fix(opencode): exit prompt loop on blocked turn + relax elicitation poll timeout

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1385,6 +1385,11 @@ export const layer = Layer.effect(
         // When a Stop hook blocks, the agent gets another model turn; this flag skips
         // the "already finished" exit for one iteration so the turn can actually run.
         let forceContinue = false
+        // Set when the previous iteration's processor outcome was "break" (turn
+        // finished or was blocked, e.g. permission rejected). The top-of-loop
+        // finished-check alone misses blocked turns whose finish is "tool-calls",
+        // so this flag forces the exit path (and its Stop hook) to fire.
+        let turnStopped = false
         const session = yield* sessions.get(sessionID).pipe(Effect.orDie)
         // Capture the lastAssistant helper before the loop's destructured `lastAssistant`
         // (the latest assistant info) shadows it inside the step body.
@@ -1414,10 +1419,11 @@ export const layer = Layer.effect(
             ) ?? false
 
           if (
-            lastAssistant?.finish &&
-            !["tool-calls"].includes(lastAssistant.finish) &&
-            !hasToolCalls &&
-            lastUser.id < lastAssistant.id
+            turnStopped ||
+            (lastAssistant?.finish &&
+              !["tool-calls"].includes(lastAssistant.finish) &&
+              !hasToolCalls &&
+              lastUser.id < lastAssistant.id)
           ) {
             const orphan = lastAssistantMsg?.parts.find(
               (part): part is SessionV1.ToolPart => part.type === "tool" && isOrphanedInterruptedTool(part),
@@ -1425,7 +1431,7 @@ export const layer = Layer.effect(
             if (orphan) {
               yield* Effect.logWarning("loop exit with orphaned interrupted tool", {
                 "session.id": sessionID,
-                messageID: lastAssistant.id,
+                messageID: lastAssistant?.id,
                 tool: orphan.tool,
                 callID: orphan.callID,
               })
@@ -1435,6 +1441,7 @@ export const layer = Layer.effect(
             // runs; reset the flag so that turn can finish and Stop normally.
             if (forceContinue) {
               forceContinue = false
+              turnStopped = false
             } else {
               yield* compaction.prune({ sessionID }).pipe(Effect.ignore, Effect.forkIn(scope))
               yield* Effect.logInfo("exiting loop", { "session.id": sessionID })
@@ -1730,7 +1737,9 @@ export const layer = Layer.effect(
           )
           // The turn finished (outcome "break") or is ongoing (tool calls). Either way
           // loop back: the finished-check at the top of the next iteration fires the
-          // Stop hook and returns once the agent is truly done.
+          // Stop hook and returns once the agent is truly done. turnStopped covers
+          // blocked turns (permission rejected) whose finish is still "tool-calls".
+          turnStopped = outcome === "break"
           if (outcome === "break") turnError = handle.message.error
           continue
         }

--- a/packages/opencode/test/mcp/elicitation-transport.test.ts
+++ b/packages/opencode/test/mcp/elicitation-transport.test.ts
@@ -134,7 +134,7 @@ describe("mcp elicitation — real transport round-trip (5.4)", () => {
           return items.length === 1 ? (items as readonly Question.Request[]) : undefined
         }),
         "elicitation never surfaced as a Question",
-        "5 seconds",
+        "15 seconds",
       )
 
       // Reply "green" → adapter validates, accepts, returns content to the server.


### PR DESCRIPTION
Fixes the two Unit Tests failures in dev run 28706411343 (introduced by #62).

## Root cause 1 — blocked turn no longer exits the prompt loop
#62 replaced the immediate `break` on `outcome === "break"` with `continue`, relying on the top-of-loop finished-check to exit (so the Stop hook fires). But a blocked turn (permission rejected → processor returns `"stop"`) still has `finish === "tool-calls"`, so the finished-check never fired and the model got an extra turn — `run-process.test.ts > rejects requested permissions by default` saw stdout "continued after rejection" instead of empty.

Fix: track `outcome === "break"` in a `turnStopped` flag and include it in the exit condition; reset it when a Stop-hook block forces a continuation turn. The Stop/StopFailure hook path now also fires for blocked turns.

## Root cause 2 — elicitation-transport poll timeout too tight for CI
The 5s `pollWithTimeout` flaked on the loaded CI host. Bumped to 15s.

## Verification
- `bun typecheck` clean
- `test/cli/run/run-process.test.ts` 13 pass
- `test/session/` 386 tests, 0 fail
- `test/mcp/ test/hook/ test/session/prompt.test.ts` 270 pass, 0 fail