### PR TITLE
fix(mcp): deterministic elicitation session routing cleanup

### DIFF
--- a/packages/opencode/src/mcp/elicitation.ts
+++ b/packages/opencode/src/mcp/elicitation.ts
@@ -43,9 +43,23 @@ const ELICITATION_TIMEOUT_MS = 300_000
  * concurrent cross-session MCP calls are best-effort (last writer wins) —
  * acceptable and strictly better than ALS-only routing, which never resolves.
  */
-let activeSession: string | undefined
-export const setActiveElicitationSession = (id: string | undefined) => {
-  activeSession = id
+type ActiveElicitationSession = { id: string; token: number }
+type ActiveElicitationSessionCleanup = () => void
+
+let activeSessionToken = 0
+const activeSession: ActiveElicitationSession[] = []
+export const setActiveElicitationSession = (id: string | undefined): ActiveElicitationSessionCleanup => {
+  if (id === undefined) {
+    activeSession.splice(0)
+    return () => {}
+  }
+
+  const entry = { id, token: activeSessionToken++ }
+  activeSession.push(entry)
+  return () => {
+    const index = activeSession.findIndex((item) => item.token === entry.token)
+    if (index >= 0) activeSession.splice(index, 1)
+  }
 }
 
 export type ElicitAction = "accept" | "decline" | "cancel"
@@ -319,7 +333,7 @@ export function registerElicitationHandler(
     params?: { message?: string; requestedSchema?: unknown; mode?: string }
   }) => {
     const params = request.params ?? {}
-    const sessionID = SessionContext.sessionID ?? activeSession
+    const sessionID = SessionContext.sessionID ?? activeSession.at(-1)?.id
     const response = await bridge.promise(
       handleElicitation({
         message: params.message ?? "",

--- a/packages/opencode/src/session/tools.ts
+++ b/packages/opencode/src/session/tools.ts
@@ -161,13 +161,10 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
               // effectiveArgs reflects any PreToolUse updatedInput rewrite (shallow merge).
               args = decision.effectiveArgs
             }
-            // Set the active session for server-initiated MCP elicitation. The
-            // SDK transport dispatch breaks AsyncLocalStorage, so the elicitation
-            // handler reads this module-level slot (set here, cleared below) to
-            // route the surfaced Question to this session.
-            setActiveElicitationSession(ctx.sessionID)
-            const result = yield* item.execute(args, ctx)
-            setActiveElicitationSession(undefined)
+            const result = yield* Effect.suspend(() => {
+              const cleanup = setActiveElicitationSession(ctx.sessionID)
+              return item.execute(args, ctx).pipe(Effect.ensuring(Effect.sync(cleanup)))
+            })
             const output = {
               ...result,
               attachments: result.attachments?.map((attachment) => ({
@@ -556,7 +553,10 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
           }
           const result: Awaited<ReturnType<NonNullable<typeof execute>>> = yield* Effect.gen(function* () {
             yield* ctx.ask({ permission: key, metadata: {}, patterns: ["*"], always: ["*"] })
-            return yield* Effect.promise(() => execute(args, opts))
+            return yield* Effect.suspend(() => {
+              const cleanup = setActiveElicitationSession(ctx.sessionID)
+              return Effect.promise(() => execute(args, opts)).pipe(Effect.ensuring(Effect.sync(cleanup)))
+            })
           }).pipe(
             Effect.withSpan("Tool.execute", {
               attributes: {

--- a/packages/opencode/test/mcp/elicitation-transport.test.ts
+++ b/packages/opencode/test/mcp/elicitation-transport.test.ts
@@ -8,7 +8,6 @@ import { Question } from "@/question"
 import { Notification } from "@/notification"
 import { SettingsHook, type HookPayload } from "@/hook/settings"
 import { registerElicitationHandler, setActiveElicitationSession } from "@/mcp/elicitation"
-import { SessionContext } from "@/effect/session-context"
 import { EventV2Bridge } from "@/event-v2-bridge"
 import { EffectBridge } from "@/effect/bridge"
 import { disposeAllInstances, testInstanceStoreLayer } from "../fixture/fixture"
@@ -31,6 +30,7 @@ import { pollWithTimeout, testEffect } from "../lib/effect"
 // an MCP tool blocks on elicitation exactly as it blocks on any slow operation.
 
 afterEach(async () => {
+  setActiveElicitationSession(undefined)
   await disposeAllInstances()
 })
 
@@ -64,6 +64,7 @@ const env = Layer.mergeAll(
 const it = testEffect(env)
 
 const SESSION = "ses_elicitation_transport"
+const STALE_SESSION = "ses_elicitation_transport_stale"
 
 /**
  * Build a stub MCP server whose only tool, "pick", elicits a color choice from
@@ -114,18 +115,23 @@ describe("mcp elicitation — real transport round-trip (5.4)", () => {
       )
       registerElicitationHandler(client, bridge)
       const server = makeStubServer()
+      yield* Effect.addFinalizer(() =>
+        Effect.promise(() => Promise.all([client.close(), server.close()])).pipe(Effect.catch(() => Effect.void)),
+      )
       const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
       yield* Effect.promise(() => Promise.all([client.connect(clientTransport), server.connect(serverTransport)]))
 
       // Drive the tool call. Production MCP tool execution sets the active
       // session synchronously around the server call (the SDK transport dispatch
       // breaks AsyncLocalStorage, so SessionContext alone is insufficient — see
-      // elicitation.ts). The test mirrors that by setting the slot directly.
+      // elicitation.ts). The test mirrors that by setting the fallback directly.
       const before = rec.recorded.length
-      setActiveElicitationSession(SESSION)
-      const callFiber = yield* Effect.promise(() =>
-        SessionContext.run(SESSION, () => client.callTool({ name: "pick", arguments: {} })),
-      ).pipe(Effect.forkScoped)
+      const cleanup = setActiveElicitationSession(SESSION)
+      yield* Effect.addFinalizer(() => Effect.sync(cleanup))
+      const staleCleanup = setActiveElicitationSession(STALE_SESSION)
+      yield* Effect.addFinalizer(() => Effect.sync(staleCleanup))
+      staleCleanup()
+      const callFiber = yield* Effect.promise(() => client.callTool({ name: "pick", arguments: {} })).pipe(Effect.forkScoped)
 
       // The elicitation surfaces as a pending Question.
       const pending = yield* pollWithTimeout(
@@ -136,6 +142,7 @@ describe("mcp elicitation — real transport round-trip (5.4)", () => {
         "elicitation never surfaced as a Question",
         "15 seconds",
       )
+      expect(String(pending[0].sessionID)).toBe(SESSION)
 
       // Reply "green" → adapter validates, accepts, returns content to the server.
       yield* question.reply({ requestID: pending[0].id, answers: [["green"]] })
@@ -154,9 +161,6 @@ describe("mcp elicitation — real transport round-trip (5.4)", () => {
           (p) => p.event === "ElicitationResult" && JSON.stringify((p as { result?: unknown }).result).includes("green"),
         ),
       ).toHaveLength(1)
-
-      // Cleanup the connected pair.
-      yield* Effect.promise(() => Promise.all([client.close(), server.close()])).pipe(Effect.catch(() => Effect.void))
     }),
   )
 })


### PR DESCRIPTION
## Why

CI `Unit Tests (linux)` ([run 28708327504](https://github.com/LeXwDeX/OpenCode-DAG/actions/runs/28708327504)) failed in `packages/opencode/test/mcp/elicitation-transport.test.ts`:

```
(fail) mcp elicitation — real transport round-trip (5.4) > server elicits mid-tool-call; client surfaces, user replies, accept round-trips [15021.94ms]
error: elicitation never surfaced as a Question
```

The same test passes in isolation; it only flakes under the full concurrent suite.

## Root cause

`activeSession` was a module-level single value with 'last writer wins' semantics, cleared by a non-atomic set/undefined pair in `SessionTools.resolve`:

```ts
setActiveElicitationSession(ctx.sessionID)
const result = yield* item.execute(args, ctx)
setActiveElicitationSession(undefined)   // not guaranteed on failure/interrupt
```

Under concurrent/nested/failing tool execution the value could be wiped (another caller clearing) or leaked (cleanup skipped on failure). The elicitation handler then read `undefined` as the sessionID, declined immediately without surfacing a Question, `callTool` resolved fast, but the test kept polling `question.list()` for 15s until timeout.

## Fix

Replace the single slot with a **tokenized LIFO stack**.

- `setActiveElicitationSession(id)` returns a cleanup that removes only its own token; concurrent/nested callers no longer clear each other.
- `SessionTools.resolve` wraps tool execution in `Effect.ensuring` so cleanup runs on success, failure, and interruption.
- The handler reads `activeSession.at(-1)?.id` as fallback after `SessionContext.sessionID`.
- The transport test cleans up client/server and the active-session token via `Effect.addFinalizer`, and adds a stale-token routing assertion.

No changes to MCP protocol schema, question validation, hook payloads, or HTTP/API behavior. No SDK regeneration.

## Verification

```
packages/opencode $ bun test --timeout 30000 test/mcp/elicitation-transport.test.ts test/mcp/elicitation-integration.test.ts
 8 pass / 0 fail (17 expect calls)

packages/opencode $ bun typecheck
 pass
```