### PR TITLE
feat(hook): close hooks/goal completeness gaps

### DIFF
--- a/packages/opencode/src/goal/goal.ts
+++ b/packages/opencode/src/goal/goal.ts
@@ -242,11 +242,11 @@ export const layer = Layer.effect(
       const state = new GoalState.Info({
         goal,
         status: "active",
-        turns_used: 0 as any,
-        max_turns: (maxTurns ?? GoalPrompts.DEFAULT_MAX_TURNS) as any,
+        turns_used: GoalState.nni(0),
+        max_turns: GoalState.nni(maxTurns ?? GoalPrompts.DEFAULT_MAX_TURNS),
         created_at: now,
         last_turn_at: now,
-        consecutive_parse_failures: 0 as any,
+        consecutive_parse_failures: GoalState.nni(0),
         subgoals: [],
       })
       yield* saveState(sessionID, state)
@@ -307,7 +307,7 @@ export const layer = Layer.effect(
       const updated = new GoalState.Info({
         ...state,
         status: "active",
-        consecutive_parse_failures: 0 as any,
+        consecutive_parse_failures: GoalState.nni(0),
         paused_reason: undefined,
         last_turn_at: Date.now(),
       })
@@ -417,7 +417,7 @@ export const layer = Layer.effect(
           last_turn_at: now,
           last_verdict: "done",
           last_reason: reason,
-          consecutive_parse_failures: newParseFailures as any,
+          consecutive_parse_failures: GoalState.nni(newParseFailures),
         })
         yield* saveState(sessionID, updated)
         // Do NOT publish goal.updated here. deleteAndPublishDone is the SOLE
@@ -434,7 +434,7 @@ export const layer = Layer.effect(
         }
       }
 
-      const turnsUsed = (state.turns_used + 1) as any
+      const turnsUsed = GoalState.nni(Number(state.turns_used) + 1)
 
       if (newParseFailures >= GoalPrompts.MAX_CONSECUTIVE_PARSE_FAILURES) {
         const pauseReason =
@@ -447,7 +447,7 @@ export const layer = Layer.effect(
           last_verdict: "continue",
           last_reason: reason,
           paused_reason: pauseReason,
-          consecutive_parse_failures: newParseFailures as any,
+          consecutive_parse_failures: GoalState.nni(newParseFailures),
         })
         // Do NOT call clearFiber here. updateAfterJudge is inlined into
         // GoalLoop.afterIdle (loop.ts:122), so the fiber running this code
@@ -476,7 +476,7 @@ export const layer = Layer.effect(
           last_verdict: "continue",
           last_reason: reason,
           paused_reason: pauseReason,
-          consecutive_parse_failures: newParseFailures as any,
+          consecutive_parse_failures: GoalState.nni(newParseFailures),
         })
         // Same self-interrupt hazard as the parse-failure branch above: we
         // are running inside the afterIdle loop fiber, so clearFiber would
@@ -497,7 +497,7 @@ export const layer = Layer.effect(
         last_turn_at: now,
         last_verdict: "continue",
         last_reason: reason,
-        consecutive_parse_failures: newParseFailures as any,
+        consecutive_parse_failures: GoalState.nni(newParseFailures),
       })
       yield* saveState(sessionID, updated)
       yield* publishGoal(sessionID, updated)
@@ -528,6 +528,11 @@ export const layer = Layer.effect(
             text: "Session 正在执行中。请先 /stop 中断后再设定新目标。",
           }
         }
+        // Known TOCTOU: `get` above then goal.set + continuation dispatch below
+        // is not atomic — the session could flip to busy in between. Accepted:
+        // the loop's idle gating and judge-preempt guard handle that case
+        // gracefully; an atomic check-and-set would need a session-level lock
+        // outside this module's scope.
       }
 
       if (lower === "" || lower === "status") {

--- a/packages/opencode/src/goal/loop.ts
+++ b/packages/opencode/src/goal/loop.ts
@@ -1,6 +1,6 @@
 export * as GoalLoop from "./loop"
 
-import { Effect, Layer, Context, Option, Stream, Scope, Fiber } from "effect"
+import { Effect, Layer, Context, Option, Stream, Scope, Fiber, Cause } from "effect"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { InstanceState } from "@/effect/instance-state"
 import { EventV2Bridge } from "@/event-v2-bridge"
@@ -318,10 +318,28 @@ export const layer = Layer.effect(
         lastJudgeReason: reloadedState.last_reason,
       })
 
-      yield* promptSvc.prompt({
-        sessionID,
-        parts: [{ type: "text", text: continuationText }],
-      })
+      // Continuation dispatch can fail (provider fault, session write error,
+      // …). Previously the error escaped to the fork-point Effect.ignore and
+      // was swallowed, leaving the goal silently `active` with no idle event
+      // to drive the next turn — a permanent, invisible stall. Catch the full
+      // cause (recoverable failures + defects) and transition to a recoverable
+      // paused state via the fiber-safe pauseAndPublish (goal.pause would
+      // clearFiber — us — mid-publish; see the preempt branches above).
+      yield* promptSvc
+        .prompt({
+          sessionID,
+          parts: [{ type: "text", text: continuationText }],
+        })
+        .pipe(
+          Effect.catchCause((cause) =>
+            Effect.gen(function* () {
+              yield* Effect.logWarning("goal continuation dispatch failed", { error: Cause.pretty(cause) })
+              yield* goal.pauseAndPublish(sessionID, `continuation dispatch failed: ${Cause.pretty(cause)}`).pipe(
+                Effect.ignore,
+              )
+            }),
+          ),
+        )
 
       // NOTE: We deliberately DO NOT call goal.clearLoopFiber here. The
       // promptSvc.prompt above triggers a fresh agent loop, which when it

--- a/packages/opencode/src/goal/prompts.ts
+++ b/packages/opencode/src/goal/prompts.ts
@@ -7,6 +7,11 @@ export const DEFAULT_MAX_TURNS = 20
 // Was 30_000 (ms) which produced "30000 seconds" = 8.3h (effectively no timeout).
 export const DEFAULT_JUDGE_TIMEOUT_SECONDS = 30
 export const MAX_CONSECUTIVE_PARSE_FAILURES = 3
+// Known tradeoff: the judge only sees the last JUDGE_RESPONSE_SNIPPET_CHARS of
+// the final assistant message. This bounds judge cost/latency but means a long
+// response that buries a problem in an earlier section can pass review. The
+// budget is generous for normal replies; the limit is also surfaced in
+// tool/goal.txt so operators know the judge's view is tail-bounded.
 export const JUDGE_RESPONSE_SNIPPET_CHARS = 4000
 // Zombie-goal freshness guard threshold (D6). A goal that is still active with
 // turns_used 0 after this many ms, and whose initial kick produced no assistant

--- a/packages/opencode/src/goal/state.ts
+++ b/packages/opencode/src/goal/state.ts
@@ -23,3 +23,13 @@ export class Info extends Schema.Class<Info>("GoalState")({
   consecutive_parse_failures: NonNegativeInt,
   subgoals: Schema.Array(Schema.String).pipe(Schema.optional, Schema.withDecodingDefault(Effect.succeed([] as ReadonlyArray<string>))),
 }) {}
+
+/**
+ * Construct a goal NonNegativeInt field from a plain number, centralizing the
+ * one unavoidable cast. Every call site computes these from validated
+ * arithmetic (0, prev+1, clamped parse-failure counters) so the runtime ≥0
+ * filter is redundant here; this keeps the escape hatch at a single audited
+ * site instead of `as any` scattered across goal.ts.
+ */
+export const nni = (value: number): Schema.Schema.Type<typeof NonNegativeInt> =>
+  value as Schema.Schema.Type<typeof NonNegativeInt>

--- a/packages/opencode/src/hook/extensions/condition-filter.ts
+++ b/packages/opencode/src/hook/extensions/condition-filter.ts
@@ -31,8 +31,17 @@ export function evaluate(
   const condition = entry.if
   if (!condition || condition.trim() === "" || condition.trim() === "*") return true
 
-  // Only tool events support condition filtering
-  if (event !== "PreToolUse" && event !== "PostToolUse" && event !== "PostToolUseFailure") {
+  // Tool events that match by tool_name support `if` condition filtering.
+  // This set MUST stay in sync with `matcherTarget` in settings.ts — matcher and
+  // `if` must agree on which events are tool-bound, otherwise `if` would be
+  // silently ignored on events where the matcher still matches by tool_name.
+  if (
+    event !== "PreToolUse" &&
+    event !== "PostToolUse" &&
+    event !== "PostToolUseFailure" &&
+    event !== "PermissionRequest" &&
+    event !== "PermissionDenied"
+  ) {
     return true
   }
 

--- a/packages/opencode/src/hook/session-hooks.ts
+++ b/packages/opencode/src/hook/session-hooks.ts
@@ -1,8 +1,10 @@
 /**
  * Session-scoped hook store (WP-5D).
  *
- * Holds hook entries that were dynamically attached to a single session
- * (e.g. injected by a Claude Code skill / agent frontmatter at runtime).
+ * Holds hook entries that were dynamically attached to a single session. The
+ * canonical producer is the HTTP API session-hook endpoints (POST/GET/DELETE
+ * under `/session/:id/hook`); anything that can speak HTTP — plugins, the TUI,
+ * external clients, tests — can register a hook for the session's lifetime.
  * These hooks live alongside the 6-layer settings file chain — `SettingsHook.trigger`
  * concatenates session entries into the matcher list so they participate in
  * the same matcher / aggregation pipeline as on-disk hooks.
@@ -10,10 +12,13 @@
  * Lifecycle:
  *   - `add(sessionID, entry)` — append; returns a uuid for later precise removal
  *   - `list(sessionID, event)` — query active entries for one event
+ *   - `listAll(sessionID)` — query all active entries for a session (HTTP GET)
  *   - `remove(sessionID, id)` — drop a single entry (used by `once: true` cleanup)
  *   - `clear(sessionID)` — drop the whole session bucket (call on session end)
  *
  * Uses `InstanceState` for per-directory isolation (mirrors `start-context.ts`).
+ * Storage is process-local memory — entries do NOT survive a restart; users
+ * wanting persistent hooks should use the on-disk hooks.json chain.
  */
 import { Context, Effect, Layer } from "effect"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
@@ -27,7 +32,12 @@ import type { HookEvent, HookJSONOutput } from "./settings"
 // import cycle (settings.ts already depends on session-hooks for the trigger merge).
 export interface SessionHookCommand {
   type: "command" | "mcp" | "http" | "prompt" | "agent"
-  command: string
+  command?: string
+  /** Claude Code `type:"http"` endpoint. Legacy configs may still use `command`. */
+  url?: string
+  /** Claude Code `type:"prompt" | "agent"` prompt. Legacy configs may still use `command`. */
+  prompt?: string
+  headers?: Record<string, string>
   timeout?: number
   shell?: "bash" | "powershell"
   if?: string
@@ -57,6 +67,8 @@ export interface Interface {
   readonly add: (sessionID: SessionID, entry: SessionHookEntryInput) => Effect.Effect<string>
   readonly remove: (sessionID: SessionID, id: string) => Effect.Effect<void>
   readonly list: (sessionID: SessionID, event: HookEvent) => Effect.Effect<readonly SessionHookEntry[]>
+  /** All entries for a session across every event (backs the HTTP GET endpoint). */
+  readonly listAll: (sessionID: SessionID) => Effect.Effect<readonly SessionHookEntry[]>
   /**
    * O(1) existence probe — answers "does this session have any hook for this event?"
    * Used by WP-6A short-circuit in SettingsHook.trigger to skip the matcher pipeline
@@ -99,6 +111,11 @@ export const layer = Layer.effect(
       return arr.filter((e) => e.event === event) as readonly SessionHookEntry[]
     })
 
+    const listAll = Effect.fn("SessionHooks.listAll")(function* (sessionID: SessionID) {
+      const data = yield* InstanceState.get(state)
+      return (data.get(sessionID) ?? []) as readonly SessionHookEntry[]
+    })
+
     const hasForEvent = Effect.fn("SessionHooks.hasForEvent")(function* (sessionID: SessionID, event: HookEvent) {
       const data = yield* InstanceState.get(state)
       const arr = data.get(sessionID)
@@ -111,7 +128,7 @@ export const layer = Layer.effect(
       data.delete(sessionID)
     })
 
-    return Service.of({ add, remove, list, hasForEvent, clear })
+    return Service.of({ add, remove, list, listAll, hasForEvent, clear })
   }),
 )
 

--- a/packages/opencode/src/hook/settings.ts
+++ b/packages/opencode/src/hook/settings.ts
@@ -1617,6 +1617,7 @@ const agentHandler: HookHandler = {
           log.warn("agent hook timeout / aborted (non-blocking)", {
             error: cause,
             command: prompt.slice(0, 80),
+            hint: "deep-investigation hooks must also raise entry.timeout — the 60s default aborts well before MAX_AGENT_TURNS (200) is reached",
           })
         } else {
           log.warn("agent hook generateText failed (non-blocking)", {
@@ -1647,8 +1648,37 @@ const agentHandler: HookHandler = {
 // WP-4D-2 constants. MAX_AGENT_TURNS pinned at 200 by user m0021 — gives the LLM
 // enough headroom for deep-investigation hooks before the loop bails. Default
 // timeout matches DEFAULT_TIMEOUT_MS (60s) used by command/http handlers.
+// Note: the 60s default entry.timeout will abort most deep investigations far
+// below 200 turns — to actually exploit the full turn budget, raise entry.timeout
+// on the hook (the turn budget itself is not per-hook configurable).
 const MAX_AGENT_TURNS = 200
 const DEFAULT_AGENT_TIMEOUT_MS = 60_000
+
+// Per-session additionalContext dedup bucket cap. A normal session never
+// approaches this; the bound exists for the headless "" bucket (sessionID=""),
+// which is shared across every prompt of a long-lived headless process and
+// would otherwise accumulate without limit. Eviction is insertion-order-oldest
+// (Set iterates in insertion order), so the least-recently-injected context is
+// dropped first — acceptable since re-injection only matters within a session.
+const MAX_SEEN_PER_BUCKET = 1000
+
+/**
+ * Add `text` to the per-session dedup bucket; returns true when newly added
+ * (the caller then injects it into additionalContexts). Caps the bucket at
+ * MAX_SEEN_PER_BUCKET by evicting the oldest entry — see the constant comment
+ * for why the headless "" bucket needs this.
+ */
+const addSeen = (seen: Map<string, Set<string>>, sessionID: string, text: string): boolean => {
+  const bucket = seen.get(sessionID) ?? new Set<string>()
+  if (bucket.has(text)) return false
+  bucket.add(text)
+  if (bucket.size > MAX_SEEN_PER_BUCKET) {
+    const oldest = bucket.values().next().value
+    if (oldest !== undefined) bucket.delete(oldest)
+  }
+  seen.set(sessionID, bucket)
+  return true
+}
 
 export const layer = Layer.effect(
   Service,
@@ -2020,13 +2050,8 @@ export const layer = Layer.effect(
               (payload.event === "UserPromptSubmit" || payload.event === "SessionStart")
             ) {
               const text = rawStdout.trim()
-              if (text) {
-                const bucket = s.seen.get(ctx.sessionID) ?? new Set<string>()
-                if (!bucket.has(text)) {
-                  bucket.add(text)
-                  s.seen.set(ctx.sessionID, bucket)
-                  result.additionalContexts.push(text)
-                }
+              if (text && addSeen(s.seen, ctx.sessionID, text)) {
+                result.additionalContexts.push(text)
               }
             }
             // once: true entries are cleared after running, regardless of result.
@@ -2056,10 +2081,7 @@ export const layer = Layer.effect(
             // session, not once per process lifetime. ctx here is the
             // TriggerContext (sessionID is its bucket key); the local was
             // renamed off `ctx` so the outer TriggerContext stays reachable.
-            const bucket = s.seen.get(ctx.sessionID) ?? new Set<string>()
-            if (!bucket.has(additionalContext)) {
-              bucket.add(additionalContext)
-              s.seen.set(ctx.sessionID, bucket)
+            if (addSeen(s.seen, ctx.sessionID, additionalContext)) {
               result.additionalContexts.push(additionalContext)
             }
           }

--- a/packages/opencode/src/hook/workspace-trust.ts
+++ b/packages/opencode/src/hook/workspace-trust.ts
@@ -87,3 +87,69 @@ export function addTrusted(dir: string): void {
     log.warn("failed to persist trusted-workspaces.json entry", { dir, error: String(err) })
   }
 }
+
+/**
+ * Scan the hooks.json chain (global / project / worktree) for a `requireTrust:
+ * true` top-level key, without importing `loadChain` from settings.ts (that
+ * would form a settings → workspace-trust → settings cycle). Mirrors the
+ * chain semantics in settings.ts:requireTrust — any single layer opting in
+ * enables enforcement. Used only by `/trust status` to report the gate source.
+ */
+function configRequireTrust(directory: string, worktree?: string): boolean {
+  const files = [
+    path.join(Global.Path.config, "hooks.json"),
+    path.join(directory, ".opencode", "hooks.json"),
+    ...(worktree && worktree !== directory ? [path.join(worktree, ".opencode", "hooks.json")] : []),
+  ]
+  for (const file of files) {
+    try {
+      if (!existsSync(file)) continue
+      const parsed = JSON.parse(readFileSync(file, "utf8"))
+      if (parsed && typeof parsed === "object" && parsed.requireTrust === true) return true
+    } catch {
+      // unreadable / unparseable — treat as not opting in
+    }
+  }
+  return false
+}
+
+/**
+ * `/trust` command dispatch (D3). Pure function — prompt.ts wires it via the
+ * same early-return path as `/goal` and renders `{ text }` as a non-synthetic
+ * text part. Trust writes are NEVER delegated to the LLM (security-sensitive).
+ *
+ * - `args === ""`        → add `directory` to the trust list (idempotent via
+ *                          `addTrusted`'s never-throw dedup) and confirm.
+ * - `args === "status"`  → trust judgment + requireTrust gate source
+ *                          (hooks.json / env / off) + trust file path.
+ */
+export function dispatchTrust(directory: string, args: string, worktree?: string): { text: string } {
+  const sub = args.trim().toLowerCase()
+  const envForced = process.env.OPENCODE_HOOKS_REQUIRE_TRUST === "1"
+  const cfgForced = configRequireTrust(directory, worktree)
+  const gateActive = envForced || cfgForced
+
+  if (sub === "status") {
+    const trusted = isTrusted(directory)
+    const sources: string[] = []
+    if (cfgForced) sources.push("hooks.json requireTrust")
+    if (envForced) sources.push("OPENCODE_HOOKS_REQUIRE_TRUST=1")
+    return {
+      text:
+        `工作区信任状态：\n` +
+        `• 目录：${directory}\n` +
+        `• 信任：${trusted ? "已信任" : "未信任"}\n` +
+        `• requireTrust 门禁：${sources.length > 0 ? sources.join(" + ") : "未启用"}\n` +
+        `• 信任文件：${trustFilePath()}`,
+    }
+  }
+
+  // default: add current workspace to the trust list
+  const already = isTrusted(directory)
+  addTrusted(directory)
+  return {
+    text: already
+      ? `${directory} 已在信任列表中（幂等，未重复追加）。`
+      : `已将 ${directory} 追加到信任列表。${gateActive ? "" : "\n（提示：requireTrust 门禁当前未启用；在 hooks.json 设置 \"requireTrust\": true 或 OPENCODE_HOOKS_REQUIRE_TRUST=1 后，信任列表才会门控 hook 执行。）"}`,
+  }
+}

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
@@ -26,6 +26,7 @@ import { described } from "./metadata"
 import { QueryBoolean } from "./query"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 import { ModelV2 } from "@opencode-ai/core/model"
+import { VALID_HOOK_EVENTS, type HookEvent } from "@/hook/settings"
 
 const root = "/session"
 export const ListQuery = Schema.Struct({
@@ -76,6 +77,37 @@ export const PermissionResponsePayload = Schema.Struct({
   response: PermissionV1.Reply,
 })
 
+// Session-scoped hook registration (D2). Event/type membership is validated
+// declaratively by the literal schemas (unknown event/type → 4xx); the
+// non-empty hooks[] guard is enforced at the handler boundary.
+const HookEventParam = Schema.Literals([...VALID_HOOK_EVENTS])
+const HookTypeParam = Schema.Literals(["command", "mcp", "http", "prompt", "agent"])
+export const SessionHookCommandPayload = Schema.Struct({
+  type: HookTypeParam,
+  command: Schema.optional(Schema.String),
+  url: Schema.optional(Schema.String),
+  prompt: Schema.optional(Schema.String),
+  headers: Schema.optional(Schema.Record(Schema.String, Schema.String)),
+  timeout: Schema.optional(Schema.Number),
+  if: Schema.optional(Schema.String),
+  async: Schema.optional(Schema.Boolean),
+  asyncRewake: Schema.optional(Schema.Boolean),
+})
+export const SessionHookAddPayload = Schema.Struct({
+  event: HookEventParam,
+  matcher: Schema.optional(Schema.String),
+  hooks: Schema.Array(SessionHookCommandPayload),
+  once: Schema.optional(Schema.Boolean),
+})
+export const SessionHookEntryResponse = Schema.Struct({
+  id: Schema.String,
+  event: HookEventParam,
+  matcher: Schema.optional(Schema.String),
+  hooks: Schema.Array(SessionHookCommandPayload),
+  once: Schema.optional(Schema.Boolean),
+})
+export type SessionHookAddPayload = typeof SessionHookAddPayload.Type
+
 export const SessionPaths = {
   list: root,
   status: `${root}/status`,
@@ -83,6 +115,8 @@ export const SessionPaths = {
   children: `${root}/:sessionID/children`,
   todo: `${root}/:sessionID/todo`,
   goal: `${root}/:sessionID/goal`,
+  hook: `${root}/:sessionID/hook`,
+  hookRemove: `${root}/:sessionID/hook/:hookID`,
   diff: `${root}/:sessionID/diff`,
   messages: `${root}/:sessionID/message`,
   message: `${root}/:sessionID/message/:messageID`,
@@ -177,6 +211,44 @@ export const SessionApi = HttpApi.make("session")
             identifier: "session.goal",
             summary: "Get session goal",
             description: "Retrieve the autonomous goal state for a session, if one is set.",
+          }),
+        ),
+        HttpApiEndpoint.post("hookAdd", SessionPaths.hook, {
+          params: { sessionID: SessionID },
+          query: WorkspaceRoutingQuery,
+          payload: SessionHookAddPayload,
+          success: described(Schema.Struct({ id: Schema.String }), "Created hook entry id"),
+          error: [HttpApiError.BadRequest, ApiNotFoundError],
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "session.hook.add",
+            summary: "Register a session-scoped hook",
+            description:
+              "Register a hook entry scoped to this session. The entry joins the same matcher/aggregation pipeline as on-disk hooks; once:true entries auto-remove after first execution. Storage is in-memory and is cleared on SessionEnd.",
+          }),
+        ),
+        HttpApiEndpoint.get("hookList", SessionPaths.hook, {
+          params: { sessionID: SessionID },
+          query: WorkspaceRoutingQuery,
+          success: described(Schema.Array(SessionHookEntryResponse), "Session hook entries"),
+          error: [HttpApiError.BadRequest, ApiNotFoundError],
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "session.hook.list",
+            summary: "List session-scoped hooks",
+            description: "List all hook entries currently registered for this session.",
+          }),
+        ),
+        HttpApiEndpoint.delete("hookRemove", SessionPaths.hookRemove, {
+          params: { sessionID: SessionID, hookID: Schema.String },
+          query: WorkspaceRoutingQuery,
+          success: described(HttpApiSchema.NoContent, "Hook removed"),
+          error: [HttpApiError.BadRequest, ApiNotFoundError],
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "session.hook.remove",
+            summary: "Remove a session-scoped hook",
+            description: "Remove a session hook entry by id. Idempotent — deleting a non-existent id succeeds.",
           }),
         ),
         HttpApiEndpoint.get("diff", SessionPaths.diff, {

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
@@ -15,6 +15,8 @@ import { SessionStatus } from "@/session/status"
 import { SessionSummary } from "@/session/summary"
 import { Todo } from "@/session/todo"
 import { Goal } from "@/goal/goal"
+import { SessionHooks, type SessionHookCommand } from "@/hook/session-hooks"
+import { type HookEvent } from "@/hook/settings"
 import { MessageID, PartID, SessionID } from "@/session/schema"
 import { NamedError } from "@opencode-ai/core/util/error"
 import { Cause, Effect, Option, Schema, Scope } from "effect"
@@ -35,6 +37,7 @@ import {
   ShellPayload,
   SummarizePayload,
   UpdatePayload,
+  SessionHookAddPayload,
 } from "../groups/session"
 import { PermissionNotFoundError } from "../errors"
 import * as SessionError from "./session-errors"
@@ -58,6 +61,7 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
     const statusSvc = yield* SessionStatus.Service
     const todoSvc = yield* Todo.Service
     const goalSvc = yield* Goal.Service
+    const sessionHooks = yield* SessionHooks.Service
     const summary = yield* SessionSummary.Service
     const events = yield* EventV2Bridge.Service
     const scope = yield* Scope.Scope
@@ -427,6 +431,36 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
       return yield* session.updatePart(payload)
     })
 
+    const hookAdd = Effect.fn("SessionHttpApi.hookAdd")(function* (ctx: {
+      params: { sessionID: SessionID }
+      payload: typeof SessionHookAddPayload.Type
+    }) {
+      yield* requireSession(ctx.params.sessionID)
+      // Non-empty hooks[] guard → 4xx. event/type membership is already enforced
+      // by the payload's literal schemas; this completes the validation contract.
+      if (ctx.payload.hooks.length === 0) return yield* new HttpApiError.BadRequest({})
+      const id = yield* sessionHooks.add(ctx.params.sessionID, {
+        event: ctx.payload.event as HookEvent,
+        matcher: ctx.payload.matcher,
+        hooks: ctx.payload.hooks as SessionHookCommand[],
+        once: ctx.payload.once,
+      })
+      return { id }
+    })
+
+    const hookList = Effect.fn("SessionHttpApi.hookList")(function* (ctx: { params: { sessionID: SessionID } }) {
+      yield* requireSession(ctx.params.sessionID)
+      return yield* sessionHooks.listAll(ctx.params.sessionID)
+    })
+
+    const hookRemove = Effect.fn("SessionHttpApi.hookRemove")(function* (ctx: {
+      params: { sessionID: SessionID; hookID: string }
+    }) {
+      yield* requireSession(ctx.params.sessionID)
+      // remove() is idempotent — a missing id is a no-op, so DELETE always succeeds.
+      yield* sessionHooks.remove(ctx.params.sessionID, ctx.params.hookID)
+    })
+
     return handlers
       .handle("list", list)
       .handle("status", status)
@@ -434,6 +468,9 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
       .handle("children", children)
       .handle("todo", todo)
       .handle("goal", goal)
+      .handle("hookAdd", hookAdd)
+      .handle("hookList", hookList)
+      .handle("hookRemove", hookRemove)
       .handle("diff", diff)
       .handle("messages", messages)
       .handle("message", message)

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -62,6 +62,7 @@ import { SessionTools } from "./tools"
 import { LLMEvent } from "@opencode-ai/llm"
 import { SettingsHook, HOOK_REWAKE_SENTINEL, type TriggerResult } from "@/hook/settings"
 import { applyPreHookDecision } from "@/hook/pre-hook-decision"
+import { dispatchTrust } from "@/hook/workspace-trust"
 import { HookStartContext } from "@/hook/start-context"
 import { Goal } from "@/goal/goal"
 
@@ -1768,6 +1769,43 @@ export const layer = Layer.effect(
         command: input.command,
         agent: input.agent,
       })
+      // /trust command dispatch — early return BEFORE command registry lookup.
+      // Trust writes are security-sensitive and MUST NOT be delegated to the
+      // LLM-driven command template path; mirror /goal's early-return dispatch
+      // (prompt.ts only wires + renders; the domain logic lives in workspace-trust.ts).
+      if (input.command === "trust") {
+        const ctx = yield* InstanceState.context
+        const result = dispatchTrust(ctx.directory, input.arguments, ctx.worktree)
+        const m = yield* currentModel(input.sessionID)
+        const agentName = input.agent ?? (yield* agents.defaultAgent())
+        const userMsg: SessionV1.User = {
+          id: input.messageID ?? MessageID.ascending(),
+          role: "user",
+          sessionID: input.sessionID,
+          time: { created: Date.now() },
+          agent: agentName,
+          model: { providerID: m.providerID, modelID: m.modelID },
+        }
+        yield* sessions.updateMessage(userMsg)
+        const cmdText: SessionV1.TextPart = {
+          id: PartID.ascending(),
+          messageID: userMsg.id,
+          sessionID: input.sessionID,
+          type: "text",
+          text: `/trust ${input.arguments}`.trim(),
+        }
+        yield* sessions.updatePart(cmdText)
+        const responsePart: SessionV1.TextPart = {
+          id: PartID.ascending(),
+          messageID: userMsg.id,
+          sessionID: input.sessionID,
+          type: "text",
+          text: result.text,
+        }
+        yield* sessions.updatePart(responsePart)
+        yield* sessions.touch(input.sessionID)
+        return { info: userMsg, parts: [cmdText, responsePart] }
+      }
       // Goal/Subgoal command dispatch — early return BEFORE command registry lookup
       if (goal && (input.command === "goal" || input.command === "subgoal")) {
         const dispatch = input.command === "goal" ? goal.dispatch : goal.dispatchSubgoal

--- a/packages/opencode/src/tool/goal.ts
+++ b/packages/opencode/src/tool/goal.ts
@@ -117,12 +117,14 @@ export const GoalTool = Tool.define<typeof Parameters, Metadata, never>(
               metadata: { goal: null },
             }
           }
-          // markDone performs: clearFiber → saveState(turns_used+1) →
-          // deleteAndPublishDone (publish goal.updated(done) → deleteState →
-          // publish goal.cleared). It returns the post-increment snapshot,
-          // so use its return value (NOT the pre-call `state` above) for
-          // the completion message — otherwise the "N turns" count shown
-          // to the user would be 1 less than what was persisted.
+          // markDone performs: clearFiber → deleteAndPublishDone (publish
+          // goal.updated(done) → deleteState → publish goal.cleared). It is
+          // budget-neutral — turns_used counts continuation dispatches only, so
+          // markDone does NOT increment it (see goal.ts markDone).
+          // deleteAndPublishDone re-loads the current row, so use its return
+          // value (NOT the pre-call `state` above) for the completion message —
+          // otherwise a turn a prior continue dispatch already accounted for
+          // could be missed in the "N turns" count shown to the user.
           const finalState = yield* goal.markDone(ctx.sessionID, params.reason.trim())
 
           const displayState = finalState ?? state

--- a/packages/opencode/src/tool/goal.txt
+++ b/packages/opencode/src/tool/goal.txt
@@ -28,3 +28,7 @@ Interact with the autonomous goal loop that drives your session (when one is run
 {"action": "status"}
 {"action": "complete", "reason": "Goal delivered: 3 test files created, all assertions pass after refactor."}
 ```
+
+## Notes
+
+- The external judge that decides whether the goal is `done` or should `continue` only inspects the last 4000 characters of your final assistant message each turn (see `JUDGE_RESPONSE_SNIPPET_CHARS`). Keep the substantive outcome of the turn visible in that tail — e.g. end with a one-line summary of what was delivered/verified. A long response that buries the result earlier in the message may be judged as incomplete even when the work is done.

--- a/packages/opencode/test/goal/e2e-loop.test.ts
+++ b/packages/opencode/test/goal/e2e-loop.test.ts
@@ -141,3 +141,112 @@ describe("GoalLoop end-to-end — continue → done lifecycle (P2b)", () => {
     }),
   )
 })
+
+// D1 (hooks-goal-completeness): a continuation dispatch failure must surface as a
+// recoverable paused state, not a silent stall. Reuses the e2e harness with a
+// prompt mock that always fails — the only prompt in this flow is the
+// continuation after judge(continue), so it fails and exercises the catchCause
+// → pauseAndPublish branch added in loop.ts.
+describe("GoalLoop — continuation dispatch failure → recoverable pause (D1)", () => {
+  let judgeCalls = 0
+  const reset = () => {
+    judgeCalls = 0
+  }
+
+  const sessionMock = Layer.succeed(Session.Service, {
+    messages: () => Effect.succeed([mkAssistant()]),
+  } as never)
+  // Always-failing prompt — simulates provider fault / session write error.
+  const promptFailMock = Layer.succeed(SessionPrompt.Service, {
+    prompt: () => Effect.fail(new Error("continuation provider down")),
+  } as never)
+  const providerMock = Layer.succeed(Provider.Service, {} as never)
+  const judgeMock = Layer.succeed(
+    GoalLoopJudgeLLM,
+    GoalLoopJudgeLLM.of({
+      call: () =>
+        Effect.sync(() => {
+          judgeCalls += 1
+          return JSON.stringify({ done: false, reason: "more steps needed" })
+        }),
+    }),
+  )
+  const failLayer = GoalLoop.layer.pipe(
+    Layer.provide(sessionMock),
+    Layer.provide(promptFailMock),
+    Layer.provide(providerMock),
+    Layer.provide(judgeMock),
+    Layer.provideMerge(Goal.defaultLayer),
+    Layer.provide(SessionStatus.defaultLayer),
+    Layer.provideMerge(EventV2Bridge.defaultLayer),
+  )
+  const it = testEffect(failLayer)
+
+  // 1.2 — continuation prompt fails → goal transitions to paused with a reason
+  // and a goal.updated(paused) event; afterIdle does not propagate the error.
+  it.instance("continuation prompt 失败 → goal paused + reason + 事件发布", () =>
+    Effect.gen(function* () {
+      reset()
+      const loop = yield* GoalLoop.Service
+      const goal = yield* Goal.Service
+      const events = yield* EventV2Bridge.Service
+      const seen = yield* captureEvents(events)
+      yield* loop.init()
+      const sid = SessionID.descending()
+      yield* goal.set(sid, "ship the feature", 10)
+      // Let the idle subscription wire (InstanceState builds on first init).
+      yield* Effect.sleep(200)
+
+      // idle → judge(continue) → continuation prompt fails → catchCause → pause
+      yield* events.publish(SessionStatus.Event.Status, { sessionID: sid, status: { type: "idle" } })
+      yield* pollWithTimeout(
+        Effect.gen(function* () {
+          const g = yield* goal.load(sid)
+          return g?.status === "paused" ? true : undefined
+        }),
+        "goal never transitioned to paused after continuation failure",
+        "5 seconds",
+      )
+
+      const paused = yield* goal.load(sid)
+      expect(paused?.status).toBe("paused")
+      expect(String(paused?.paused_reason)).toContain("continuation dispatch failed")
+      // goal.updated(paused) published (SSE/TUI visible)
+      expect(seen.some((e) => e.type === GoalEvent.Updated.type && e.status === "paused")).toBe(true)
+      // The continuation was actually attempted: judge ran, turns_used advanced.
+      expect(judgeCalls).toBeGreaterThanOrEqual(1)
+      expect(Number(paused?.turns_used)).toBe(1)
+    }),
+  )
+
+  // 1.3 — after the failure-induced pause, /goal resume restores active and
+  // preserves the turns_used budget (resume must not silently grant a fresh budget).
+  it.instance("paused 后 resume 恢复 active，turns_used 保留", () =>
+    Effect.gen(function* () {
+      reset()
+      const loop = yield* GoalLoop.Service
+      const goal = yield* Goal.Service
+      const events = yield* EventV2Bridge.Service
+      yield* loop.init()
+      const sid = SessionID.descending()
+      yield* goal.set(sid, "ship the feature", 10)
+      yield* Effect.sleep(200)
+      yield* events.publish(SessionStatus.Event.Status, { sessionID: sid, status: { type: "idle" } })
+      yield* pollWithTimeout(
+        Effect.gen(function* () {
+          const g = yield* goal.load(sid)
+          return g?.status === "paused" ? true : undefined
+        }),
+        "goal never transitioned to paused before resume",
+        "5 seconds",
+      )
+      const before = yield* goal.load(sid)
+      const turnsBefore = Number(before?.turns_used)
+
+      const resumed = yield* goal.resume(sid)
+      expect(resumed?.status).toBe("active")
+      expect(Number(resumed?.turns_used)).toBe(turnsBefore) // budget preserved, not reset
+      expect(resumed?.paused_reason).toBeUndefined()
+    }),
+  )
+})

--- a/packages/opencode/test/hook/condition-filter.test.ts
+++ b/packages/opencode/test/hook/condition-filter.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test"
+import { evaluate } from "@/hook/extensions/condition-filter"
+import type { HookCommand, HookEvent } from "@/hook/settings"
+
+// `evaluate` only reads `entry.if`; `type` is the one required field on
+// HookCommand, so this is the minimal valid fixture.
+const entry = (ifCond: string): HookCommand => ({ type: "command", if: ifCond })
+
+describe("condition-filter evaluate", () => {
+  test("PermissionRequest: if 不匹配 → 跳过", () => {
+    // delta spec scenario: Bash(rm *) against a `ls` command → no match
+    const result = evaluate(entry("Bash(rm *)"), { tool_name: "bash", tool_input: { command: "ls" } }, "PermissionRequest")
+    expect(result).toBe(false)
+  })
+
+  test("PermissionDenied: if 匹配 → 执行", () => {
+    // delta spec scenario: Edit(*.ts) against filePath a.ts → match
+    const result = evaluate(
+      entry("Edit(*.ts)"),
+      { tool_name: "edit", tool_input: { filePath: "a.ts" } },
+      "PermissionDenied",
+    )
+    expect(result).toBe(true)
+  })
+
+  test("非工具事件 (Stop) if 恒为真（被忽略）", () => {
+    // delta spec scenario: any if on a non-tool event is ignored
+    expect(evaluate(entry("Bash(rm *)"), { prompt: "hi" }, "Stop")).toBe(true)
+    expect(evaluate(entry("Edit(*.ts)"), {}, "UserPromptSubmit")).toBe(true)
+  })
+
+  test("PreToolUse 既有行为保持（匹配/不匹配）", () => {
+    expect(
+      evaluate(entry("Bash(npm install *)"), { tool_name: "bash", tool_input: { command: "npm install foo" } }, "PreToolUse"),
+    ).toBe(true)
+    expect(
+      evaluate(entry("Bash(npm install *)"), { tool_name: "bash", tool_input: { command: "rm -rf /" } }, "PreToolUse"),
+    ).toBe(false)
+  })
+
+  test("PostToolUse/PostToolUseFailure 仍受 if 过滤", () => {
+    expect(
+      evaluate(entry("Read(*.ts)"), { tool_name: "read", tool_input: { filePath: "x.ts" } }, "PostToolUse"),
+    ).toBe(true)
+    expect(
+      evaluate(entry("Read(*.ts)"), { tool_name: "read", tool_input: { filePath: "x.py" } }, "PostToolUseFailure"),
+    ).toBe(false)
+  })
+
+  test("空/* /undefined 条件恒为真", () => {
+    const events: HookEvent[] = ["PreToolUse", "PermissionRequest", "Stop", "UserPromptSubmit"]
+    for (const ev of events) {
+      expect(evaluate({ type: "command" }, { tool_name: "bash" }, ev)).toBe(true)
+      expect(evaluate({ type: "command", if: "" }, { tool_name: "bash" }, ev)).toBe(true)
+      expect(evaluate({ type: "command", if: "*" }, { tool_name: "bash" }, ev)).toBe(true)
+    }
+  })
+})

--- a/packages/opencode/test/hook/session-hooks-trigger.test.ts
+++ b/packages/opencode/test/hook/session-hooks-trigger.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect } from "bun:test"
+import { Effect, Layer } from "effect"
+import { SettingsHook } from "@/hook/settings"
+import { SessionHooks } from "@/hook/session-hooks"
+import { EventV2Bridge } from "@/event-v2-bridge"
+import { Database } from "@opencode-ai/core/database/database"
+import { SessionID } from "@/session/schema"
+import { testEffect } from "../lib/effect"
+
+// D2 (hooks-goal-completeness): session-scoped hooks registered via
+// SessionHooks.add (the in-memory store the HTTP API now feeds) participate in
+// the SettingsHook.trigger pipeline identically to on-disk hooks. Covers the
+// producer-side behaviors the route contract relies on:
+//   register → fires on matching event
+//   once:true → fires once then auto-removes
+//   SessionEnd → clears the session's hook store
+
+const testLayer = SettingsHook.layer.pipe(
+  Layer.provide(EventV2Bridge.defaultLayer),
+  Layer.provide(Database.defaultLayer),
+  Layer.provideMerge(SessionHooks.defaultLayer),
+)
+const it = testEffect(testLayer)
+
+const CTX = "session-hook-fired-ctx"
+
+describe("SessionHooks → SettingsHook.trigger integration (D2)", () => {
+  it.instance("registered hook fires on the matching event", () =>
+    Effect.gen(function* () {
+      const sessionHooks = yield* SessionHooks.Service
+      const hook = yield* SettingsHook.Service
+      const sessionID = SessionID.descending()
+      yield* sessionHooks.add(sessionID, {
+        event: "UserPromptSubmit",
+        hooks: [{ type: "command", command: `printf '%s' '${CTX}'` }],
+      })
+      const r = yield* hook.trigger(
+        { event: "UserPromptSubmit", prompt: "hi" },
+        { sessionID, transcriptPath: "" },
+      )
+      expect(r.additionalContexts).toContain(CTX)
+    }),
+  )
+
+  it.instance("once:true hook fires once then is auto-removed", () =>
+    Effect.gen(function* () {
+      const sessionHooks = yield* SessionHooks.Service
+      const hook = yield* SettingsHook.Service
+      const sessionID = SessionID.descending()
+      yield* sessionHooks.add(sessionID, {
+        event: "UserPromptSubmit",
+        once: true,
+        hooks: [{ type: "command", command: `printf '%s' '${CTX}'` }],
+      })
+
+      const r1 = yield* hook.trigger(
+        { event: "UserPromptSubmit", prompt: "first" },
+        { sessionID, transcriptPath: "" },
+      )
+      expect(r1.additionalContexts).toContain(CTX)
+      // Auto-removed after its first execution (trigger's once-cleanup path).
+      expect(yield* sessionHooks.list(sessionID, "UserPromptSubmit")).toHaveLength(0)
+
+      const r2 = yield* hook.trigger(
+        { event: "UserPromptSubmit", prompt: "second" },
+        { sessionID, transcriptPath: "" },
+      )
+      expect(r2.additionalContexts).not.toContain(CTX)
+    }),
+  )
+
+  it.instance("SessionEnd clears the session hook store", () =>
+    Effect.gen(function* () {
+      const sessionHooks = yield* SessionHooks.Service
+      const hook = yield* SettingsHook.Service
+      const sessionID = SessionID.descending()
+      yield* sessionHooks.add(sessionID, {
+        event: "UserPromptSubmit",
+        hooks: [{ type: "command", command: `printf '%s' '${CTX}'` }],
+      })
+      expect((yield* sessionHooks.listAll(sessionID)).length).toBe(1)
+
+      yield* hook.trigger({ event: "SessionEnd", reason: "delete" }, { sessionID, transcriptPath: "" })
+
+      expect((yield* sessionHooks.listAll(sessionID)).length).toBe(0)
+    }),
+  )
+})

--- a/packages/opencode/test/hook/workspace-trust.test.ts
+++ b/packages/opencode/test/hook/workspace-trust.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test"
+import { beforeAll, afterAll, beforeEach, describe, expect, test } from "bun:test"
 import { Effect, Layer } from "effect"
 import * as fs from "fs"
 import * as os from "os"
@@ -7,7 +7,7 @@ import { SettingsHook } from "@/hook/settings"
 import { SessionHooks } from "@/hook/session-hooks"
 import { EventV2Bridge } from "@/event-v2-bridge"
 import { Database } from "@opencode-ai/core/database/database"
-import { isTrustedDir, loadTrustedList } from "@/hook/workspace-trust"
+import { dispatchTrust, isTrusted, isTrustedDir, loadTrustedList, trustFilePath } from "@/hook/workspace-trust"
 import { testEffect } from "../lib/effect"
 
 // WP-6B workspace-trust gate. Two layers of tests:
@@ -124,4 +124,88 @@ describe("SettingsHook workspace-trust gate (WP-6B)", () => {
       }),
     { init: writeHooks(sessionStartHook({})) },
   )
+})
+
+// ── /trust command dispatch (D3) ───────────────────────────────────
+// dispatchTrust hits the real trust file (trustFilePath) and the hooks.json
+// chain, so the block saves/restores the real trust file and uses a clean tmp
+// directory per test. Gate-source assertions target the deterministic paths
+// (env var and the project hooks.json we write) rather than the global
+// hooks.json, which this machine may or may not have set.
+
+describe("dispatchTrust (/trust command) — D3", () => {
+  const realTrustFile = trustFilePath()
+  let saved: string | undefined
+
+  beforeAll(() => {
+    saved = fs.existsSync(realTrustFile) ? fs.readFileSync(realTrustFile, "utf8") : undefined
+  })
+  afterAll(() => {
+    try {
+      if (saved === undefined) fs.rmSync(realTrustFile, { force: true })
+      else fs.writeFileSync(realTrustFile, saved)
+    } catch {
+      // best-effort restore
+    }
+  })
+  beforeEach(() => {
+    try {
+      fs.rmSync(realTrustFile, { force: true })
+    } catch {
+      // best-effort clean slate
+    }
+    delete process.env.OPENCODE_HOOKS_REQUIRE_TRUST
+  })
+
+  const tmpdir = () => fs.mkdtempSync(path.join(os.tmpdir(), "trust-cmd-"))
+
+  test("/trust 追加目录到信任列表（含目录路径）", () => {
+    const dir = tmpdir()
+    const r = dispatchTrust(dir, "")
+    expect(r.text).toContain(dir)
+    expect(isTrusted(dir)).toBe(true)
+  })
+
+  test("/trust 幂等（重复不重复追加）", () => {
+    const dir = tmpdir()
+    dispatchTrust(dir, "")
+    dispatchTrust(dir, "")
+    // exactly one entry for dir
+    expect(loadTrustedList().filter((d) => d === dir).length).toBe(1)
+    // confirmation text notes already-trusted
+    expect(dispatchTrust(dir, "").text).toContain("已在信任列表")
+  })
+
+  test("/trust status 显示信任判定 + 信任文件路径", () => {
+    const dir = tmpdir()
+    const r = dispatchTrust(dir, "status")
+    expect(r.text).toContain("未信任")
+    expect(r.text).toContain(realTrustFile)
+    expect(r.text).toContain("requireTrust 门禁")
+  })
+
+  test("/trust status — hooks.json requireTrust 来源", () => {
+    const dir = tmpdir()
+    fs.mkdirSync(path.join(dir, ".opencode"), { recursive: true })
+    fs.writeFileSync(path.join(dir, ".opencode", "hooks.json"), JSON.stringify({ requireTrust: true }))
+    const r = dispatchTrust(dir, "status")
+    expect(r.text).toContain("hooks.json requireTrust")
+  })
+
+  test("/trust status — OPENCODE_HOOKS_REQUIRE_TRUST 来源", () => {
+    const dir = tmpdir()
+    process.env.OPENCODE_HOOKS_REQUIRE_TRUST = "1"
+    try {
+      const r = dispatchTrust(dir, "status")
+      expect(r.text).toContain("OPENCODE_HOOKS_REQUIRE_TRUST=1")
+    } finally {
+      delete process.env.OPENCODE_HOOKS_REQUIRE_TRUST
+    }
+  })
+
+  test("/trust 写入失败不 throw（沿用 addTrusted never-throw）", () => {
+    // dispatchTrust always returns { text }; addTrusted swallows write errors.
+    const r = dispatchTrust(tmpdir(), "")
+    expect(typeof r.text).toBe("string")
+  })
 })

--- a/packages/opencode/test/server/httpapi-exercise/index.ts
+++ b/packages/opencode/test/server/httpapi-exercise/index.ts
@@ -1205,6 +1205,50 @@ const scenarios: Scenario[] = [
       check(!("pausedReason" in body), "pausedReason should be absent when goal is active")
     }),
   http.protected
+    .post("/session/{sessionID}/hook", "session.hook.add")
+    .seeded((ctx) => ctx.session({ title: "Hook session" }))
+    .at((ctx) => ({
+      path: route("/session/{sessionID}/hook", { sessionID: ctx.state.id }),
+      headers: ctx.headers(),
+      body: {
+        event: "UserPromptSubmit",
+        hooks: [{ type: "command", command: "printf '%s' 'hook-ran'" }],
+      },
+    }))
+    .json(200, (body) => {
+      object(body)
+      check(typeof body.id === "string" && body.id.length > 0, "hook add should return an entry id")
+    }),
+  http.protected
+    .post("/session/{sessionID}/hook", "session.hook.add.invalid")
+    .seeded((ctx) => ctx.session({ title: "Hook invalid session" }))
+    .at((ctx) => ({
+      path: route("/session/{sessionID}/hook", { sessionID: ctx.state.id }),
+      headers: ctx.headers(),
+      body: { event: "NotAnEvent", hooks: [{ type: "command", command: "printf '%s' 'x'" }] },
+    }))
+    .status(400),
+  http.protected
+    .get("/session/{sessionID}/hook", "session.hook.list")
+    .seeded((ctx) => ctx.session({ title: "Hook list session" }))
+    .at((ctx) => ({
+      path: route("/session/{sessionID}/hook", { sessionID: ctx.state.id }),
+      headers: ctx.headers(),
+    }))
+    .json(200, array),
+  http.protected
+    .delete("/session/{sessionID}/hook/{hookID}", "session.hook.remove")
+    .seeded((ctx) => ctx.session({ title: "Hook remove session" }))
+    .at((ctx) => ({
+      path: route("/session/{sessionID}/hook/{hookID}", {
+        sessionID: ctx.state.id,
+        hookID: "does-not-exist",
+      }),
+      headers: ctx.headers(),
+    }))
+    // DELETE is idempotent — a non-existent hookID succeeds (204 NoContent).
+    .status(204),
+  http.protected
     .get("/session/{sessionID}/diff", "session.diff")
     .seeded((ctx) => ctx.session({ title: "Diff session" }))
     .at((ctx) => ({ path: route("/session/{sessionID}/diff", { sessionID: ctx.state.id }), headers: ctx.headers() }))

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -191,6 +191,12 @@ import type {
   SessionGetResponses,
   SessionGoalErrors,
   SessionGoalResponses,
+  SessionHookAddErrors,
+  SessionHookAddResponses,
+  SessionHookListErrors,
+  SessionHookListResponses,
+  SessionHookRemoveErrors,
+  SessionHookRemoveResponses,
   SessionInitErrors,
   SessionInitResponses,
   SessionListErrors,
@@ -3352,6 +3358,157 @@ export class Provider extends HeyApiClient {
   }
 }
 
+export class Hook extends HeyApiClient {
+  /**
+   * List session-scoped hooks
+   *
+   * List all hook entries currently registered for this session.
+   */
+  public list<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<SessionHookListResponses, SessionHookListErrors, ThrowOnError>({
+      url: "/session/{sessionID}/hook",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Register a session-scoped hook
+   *
+   * Register a hook entry scoped to this session. The entry joins the same matcher/aggregation pipeline as on-disk hooks; once:true entries auto-remove after first execution. Storage is in-memory and is cleared on SessionEnd.
+   */
+  public add<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      directory?: string
+      workspace?: string
+      event?:
+        | "PreToolUse"
+        | "PostToolUse"
+        | "PostToolUseFailure"
+        | "Notification"
+        | "UserPromptSubmit"
+        | "PermissionRequest"
+        | "PermissionDenied"
+        | "Setup"
+        | "Stop"
+        | "StopFailure"
+        | "SubagentStart"
+        | "SubagentStop"
+        | "PreCompact"
+        | "PostCompact"
+        | "SessionStart"
+        | "SessionEnd"
+        | "TaskCreated"
+        | "TaskCompleted"
+        | "Elicitation"
+        | "ElicitationResult"
+        | "ConfigChange"
+        | "WorktreeCreate"
+        | "WorktreeRemove"
+        | "InstructionsLoaded"
+        | "CwdChanged"
+        | "FileChanged"
+      matcher?: string
+      hooks?: Array<{
+        type: "command" | "mcp" | "http" | "prompt" | "agent"
+        command?: string
+        url?: string
+        prompt?: string
+        headers?: {
+          [key: string]: string
+        }
+        timeout?: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
+        if?: string
+        async?: boolean
+        asyncRewake?: boolean
+      }>
+      once?: boolean
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "body", key: "event" },
+            { in: "body", key: "matcher" },
+            { in: "body", key: "hooks" },
+            { in: "body", key: "once" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<SessionHookAddResponses, SessionHookAddErrors, ThrowOnError>({
+      url: "/session/{sessionID}/hook",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+
+  /**
+   * Remove a session-scoped hook
+   *
+   * Remove a session hook entry by id. Idempotent — deleting a non-existent id succeeds.
+   */
+  public remove<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      hookID: string
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "path", key: "hookID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).delete<SessionHookRemoveResponses, SessionHookRemoveErrors, ThrowOnError>({
+      url: "/session/{sessionID}/hook/{hookID}",
+      ...options,
+      ...params,
+    })
+  }
+}
+
 export class Session2 extends HeyApiClient {
   /**
    * List sessions
@@ -4349,6 +4506,11 @@ export class Session2 extends HeyApiClient {
       ...options,
       ...params,
     })
+  }
+
+  private _hook?: Hook
+  get hook(): Hook {
+    return (this._hook ??= new Hook({ client: this.client }))
   }
 }
 

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -9932,6 +9932,198 @@ export type SessionGoalResponses = {
 
 export type SessionGoalResponse = SessionGoalResponses[keyof SessionGoalResponses]
 
+export type SessionHookListData = {
+  body?: never
+  path: {
+    sessionID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/session/{sessionID}/hook"
+}
+
+export type SessionHookListErrors = {
+  /**
+   * BadRequest | InvalidRequestError
+   */
+  400: EffectHttpApiErrorBadRequest | InvalidRequestError
+  /**
+   * NotFoundError
+   */
+  404: NotFoundError
+}
+
+export type SessionHookListError = SessionHookListErrors[keyof SessionHookListErrors]
+
+export type SessionHookListResponses = {
+  /**
+   * Session hook entries
+   */
+  200: Array<{
+    id: string
+    event:
+      | "PreToolUse"
+      | "PostToolUse"
+      | "PostToolUseFailure"
+      | "Notification"
+      | "UserPromptSubmit"
+      | "PermissionRequest"
+      | "PermissionDenied"
+      | "Setup"
+      | "Stop"
+      | "StopFailure"
+      | "SubagentStart"
+      | "SubagentStop"
+      | "PreCompact"
+      | "PostCompact"
+      | "SessionStart"
+      | "SessionEnd"
+      | "TaskCreated"
+      | "TaskCompleted"
+      | "Elicitation"
+      | "ElicitationResult"
+      | "ConfigChange"
+      | "WorktreeCreate"
+      | "WorktreeRemove"
+      | "InstructionsLoaded"
+      | "CwdChanged"
+      | "FileChanged"
+    matcher?: string
+    hooks: Array<{
+      type: "command" | "mcp" | "http" | "prompt" | "agent"
+      command?: string
+      url?: string
+      prompt?: string
+      headers?: {
+        [key: string]: string
+      }
+      timeout?: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
+      if?: string
+      async?: boolean
+      asyncRewake?: boolean
+    }>
+    once?: boolean
+  }>
+}
+
+export type SessionHookListResponse = SessionHookListResponses[keyof SessionHookListResponses]
+
+export type SessionHookAddData = {
+  body?: {
+    event:
+      | "PreToolUse"
+      | "PostToolUse"
+      | "PostToolUseFailure"
+      | "Notification"
+      | "UserPromptSubmit"
+      | "PermissionRequest"
+      | "PermissionDenied"
+      | "Setup"
+      | "Stop"
+      | "StopFailure"
+      | "SubagentStart"
+      | "SubagentStop"
+      | "PreCompact"
+      | "PostCompact"
+      | "SessionStart"
+      | "SessionEnd"
+      | "TaskCreated"
+      | "TaskCompleted"
+      | "Elicitation"
+      | "ElicitationResult"
+      | "ConfigChange"
+      | "WorktreeCreate"
+      | "WorktreeRemove"
+      | "InstructionsLoaded"
+      | "CwdChanged"
+      | "FileChanged"
+    matcher?: string
+    hooks: Array<{
+      type: "command" | "mcp" | "http" | "prompt" | "agent"
+      command?: string
+      url?: string
+      prompt?: string
+      headers?: {
+        [key: string]: string
+      }
+      timeout?: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
+      if?: string
+      async?: boolean
+      asyncRewake?: boolean
+    }>
+    once?: boolean
+  }
+  path: {
+    sessionID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/session/{sessionID}/hook"
+}
+
+export type SessionHookAddErrors = {
+  /**
+   * BadRequest | InvalidRequestError
+   */
+  400: EffectHttpApiErrorBadRequest | InvalidRequestError
+  /**
+   * NotFoundError
+   */
+  404: NotFoundError
+}
+
+export type SessionHookAddError = SessionHookAddErrors[keyof SessionHookAddErrors]
+
+export type SessionHookAddResponses = {
+  /**
+   * Created hook entry id
+   */
+  200: {
+    id: string
+  }
+}
+
+export type SessionHookAddResponse = SessionHookAddResponses[keyof SessionHookAddResponses]
+
+export type SessionHookRemoveData = {
+  body?: never
+  path: {
+    sessionID: string
+    hookID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/session/{sessionID}/hook/{hookID}"
+}
+
+export type SessionHookRemoveErrors = {
+  /**
+   * BadRequest | InvalidRequestError
+   */
+  400: EffectHttpApiErrorBadRequest | InvalidRequestError
+  /**
+   * NotFoundError
+   */
+  404: NotFoundError
+}
+
+export type SessionHookRemoveError = SessionHookRemoveErrors[keyof SessionHookRemoveErrors]
+
+export type SessionHookRemoveResponses = {
+  /**
+   * Hook removed
+   */
+  204: void
+}
+
+export type SessionHookRemoveResponse = SessionHookRemoveResponses[keyof SessionHookRemoveResponses]
+
 export type SessionDiffData = {
   body?: never
   path: {


### PR DESCRIPTION
## What

Closes four product-loop gaps and several hygiene items from the 2026-07-05 HOOKS/GOAL review. **No architecture changes, no TUI modifications.**

## Changes

- **goal continuation failure → recoverable pause** — `afterIdle`'s continuation prompt is wrapped in `Effect.catchCause`; a dispatch failure now transitions the goal to `paused` with a `continuation dispatch failed` reason + `goal.updated(paused)` event, instead of silently stalling `active` with no idle driver. Recoverable via `/goal resume` (budget preserved).
- **session-scoped hook HTTP API** — `POST/GET/DELETE /session/:id/hook[/...]`, delegating to the existing `SessionHooks` store (the pipeline's first production producer). Schema-validated (unknown event/type → 4xx); `once` entries auto-remove; `SessionEnd` clears the store.
- **`/trust` command** — in-session **text** entry point for the workspace-trust gate (prompt.ts early-return dispatch, logic in workspace-trust.ts; renders as transcript text, **no TUI/popup**). `/trust` adds the cwd (idempotent); `/trust status` shows trust + requireTrust source (hooks.json / env / off) + trust file path. Orthogonal to the permission `allow:*` config.
- **`if` coverage (BEHAVIOR CHANGE)** — `condition-filter` now evaluates `if` on `PermissionRequest`/`PermissionDenied` too. Previously `if` was always-true on those two events even though `matcherTarget` matched them by tool_name.

### Hygiene
`SessionHookCommand` fields aligned (`command` optional + url/prompt/headers), headless seen-bucket cap (`MAX_SEEN_PER_BUCKET=1000`), goal `NonNegativeInt` `as any` consolidated into `GoalState.nni()`, corrected comments (markDone budget-neutral, `MAX_AGENT_TURNS`↔timeout, judge 4000-char snippet tradeoff, dispatch TOCTOU).

## Verification
- `bun typecheck` clean
- `bun test test/hook test/goal` → **206 pass / 0 fail** (incl. new tests: condition-filter ×6, e2e-loop D1 ×2, session-hooks-trigger ×3, dispatchTrust ×6)
- httpapi-exercise → **pass=204 fail=0 missing=0** (4 new session-hook scenarios)
- JS SDK regenerated for the new session-hook routes
- No files touched under `packages/tui` or `packages/app`

## Notes
- The `if`-on-PermissionRequest/PermissionDenied change is a behavior change (D4): configs that declared `if` on those events and relied on it being ignored will now have the condition respected — treated as a bug fix.
- Trust entry point is intentionally a text command, not a TUI/popup. `requireTrust` is off by default, so `/trust` is dormant unless a hooks.json sets `requireTrust: true`.