### PR TITLE
fix(mcp): restore SDK client mocks after MCP tests

### DIFF
--- a/packages/opencode/test/mcp/lifecycle.test.ts
+++ b/packages/opencode/test/mcp/lifecycle.test.ts
@@ -1,6 +1,6 @@
 import path from "node:path"
 import { pathToFileURL } from "node:url"
-import { expect, mock, beforeEach } from "bun:test"
+import { expect, mock, beforeEach, afterAll } from "bun:test"
 import { ListRootsRequestSchema, ToolListChangedNotificationSchema } from "@modelcontextprotocol/sdk/types.js"
 import { Cause, Effect, Exit } from "effect"
 import type { MCP as MCPNS } from "../../src/mcp/index"
@@ -269,6 +269,13 @@ beforeEach(() => {
   connectError = "Mock transport cannot connect"
   clientCreateCount = 0
   transportCloseCount = 0
+})
+
+afterAll(() => {
+  // These MCP SDK mocks are file-scoped fixtures, but Bun's mock.module registry
+  // is process-global during the full suite. Restore it so tests that exercise
+  // a real SDK Client don't inherit this reduced mock implementation.
+  mock.restore()
 })
 
 // Import after mocks

--- a/packages/opencode/test/mcp/oauth-auto-connect.test.ts
+++ b/packages/opencode/test/mcp/oauth-auto-connect.test.ts
@@ -1,4 +1,4 @@
-import { expect, mock, beforeEach } from "bun:test"
+import { expect, mock, beforeEach, afterAll } from "bun:test"
 import { Effect, Layer } from "effect"
 import { testEffect } from "../lib/effect"
 
@@ -125,6 +125,12 @@ beforeEach(() => {
   connectSucceedsImmediately = false
   serverCapabilities = { tools: {} }
   listToolsCalls = 0
+})
+
+afterAll(() => {
+  // Prevent this file's MCP SDK module mocks from leaking into later tests that
+  // need the real Client implementation (notably elicitation-transport).
+  mock.restore()
 })
 
 // Import modules after mocking

--- a/packages/opencode/test/mcp/oauth-browser.test.ts
+++ b/packages/opencode/test/mcp/oauth-browser.test.ts
@@ -1,4 +1,4 @@
-import { expect, mock, beforeEach } from "bun:test"
+import { expect, mock, beforeEach, afterAll } from "bun:test"
 import { EventEmitter } from "events"
 import { Deferred, Effect, Layer, Option } from "effect"
 import { awaitWithTimeout, testEffect } from "../lib/effect"
@@ -111,6 +111,13 @@ beforeEach(() => {
   openCalledWith = undefined
   openDeferred = undefined
   transportCalls.length = 0
+})
+
+afterAll(() => {
+  // Bun's module mocks are process-global across the full test run. Restore the
+  // MCP SDK Client mock so later real-transport tests receive the real Client
+  // (not this reduced MockClient, which intentionally lacks callTool()).
+  mock.restore()
 })
 
 // Import modules after mocking


### PR DESCRIPTION
## What

Unblocks dev `Unit Tests (linux)` by removing the pollution that was hiding the real dev health signal.

The MCP OAuth/lifecycle tests mock `@modelcontextprotocol/sdk/client/index.js` with reduced `MockClient` implementations (no transport, no `callTool`). Bun's `mock.module` registry is process-global across the full suite, so when those mocks leak into later tests, the real `elicitation-transport` test imports a mock `Client` whose `callTool` is undefined — producing the enriched diagnostic:

```
callFiber: failed: TypeError: client.callTool is not a function
```

## Fix

Add `afterAll(() => mock.restore())` in the MCP test files that mock the SDK `Client` module (oauth-browser, oauth-auto-connect, lifecycle). The mocks are file-scoped fixtures for those tests; restoring after completion keeps later real-transport tests on the real SDK implementation.

## Verification
- `bun test test/mcp` → **83 pass / 0 fail** (covers the affected MCP files + elicitation-transport)
- `bun typecheck` clean
- No source/runtime changes; test-only

## Why this matters now

`Unit Tests (linux)` has been red on dev for several runs due to this flake, masking any true regression in the `hook`/`goal` modules that recently landed. Once this merges and dev CI turns green, `test/hook` and `test/goal` regressions will be visible again.