### PR TITLE
fix(mcp): isolate elicitation Client import from Bun mock registry

### DIFF
--- a/packages/opencode/test/mcp/elicitation-transport.test.ts
+++ b/packages/opencode/test/mcp/elicitation-transport.test.ts
@@ -1,9 +1,19 @@
-import { afterEach, beforeEach, describe, expect } from "bun:test"
+import { afterEach, beforeEach, describe, expect, mock } from "bun:test"
 import { Cause, Effect, Fiber, Layer, Exit } from "effect"
-import { Client } from "@modelcontextprotocol/sdk/client/index.js"
 import { Server } from "@modelcontextprotocol/sdk/server/index.js"
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js"
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js"
+
+// Bypass Bun's process-global mock registry. Sibling MCP tests register
+// `mock.module("@modelcontextprotocol/sdk/client/index.js", ...)` with reduced
+// MockClient implementations (intentionally no transport, no `callTool`);
+// under Bun's --only-failures retry, that mock can still be in place when this
+// file's failure is re-run in the second test pass, yielding `client.callTool
+// is not a function`. Restore the registry first, then dynamically import the
+// real Client (dynamic import is required here because static imports hoist
+// and would resolve from the already-mocked module cache entry before this code).
+mock.restore()
+const { Client } = await import("@modelcontextprotocol/sdk/client/index.js")
 import { Question } from "@/question"
 import { Notification } from "@/notification"
 import { SettingsHook, type HookPayload } from "@/hook/settings"


### PR DESCRIPTION
## What

Follow-up to PR #69, which restored the Bun mock registry after mock-heavy MCP test files but left dev `Unit Tests (linux)` still red under `--only-failures` retry.

## Why #69 alone was not enough

`--only-failures` re-runs only the failing tests, typically in the same worker. When this happens:

- The mock-using test files' `afterAll(() => mock.restore())` has already run (files considered done in the first pass).
- The module cache still holds the previously-resolved `@modelcontextprotocol/sdk/client/index.js` binding — which points at the reduced MockClient (no `callTool`, no transport).
- `elicitation-transport.test.ts` statically imports `Client` from that specifier; the hoisted static import resolves from the already-cached mock; `client.callTool is not a function` on retry.

## Fix (defense-in-depth)

Add a complementary guard on the consumer side:

1. `mock.restore()` at the top of the file before loading the Client — clears any stale process-global mock.
2. Replace the static `import { Client }` with a top-level dynamic `await import("@modelcontextprotocol/sdk/client/index.js")` — dynamic imports execute after surrounding top-level code, so the `Client` binding resolves against the restored registry rather than a pre-cached mock entry.

Combined with #69's producer-side `afterAll(() => mock.restore())`, the leak is closed from both ends.

## Verification

- `bun test test/mcp/elicitation-transport.test.ts` → 1 pass
- `bun test test/mcp/oauth-browser.test.ts test/mcp/oauth-auto-connect.test.ts test/mcp/lifecycle.test.ts test/mcp/elicitation-transport.test.ts` → 42 pass (mock-heavy followed by elicitation in the same process)
- `bun test test/mcp` → 83 pass
- `bun typecheck` clean