### PR TITLE
fix(mcp): isolate elicitation Client binding from Bun mock cache

### DIFF
--- a/packages/opencode/test/mcp/elicitation-transport.test.ts
+++ b/packages/opencode/test/mcp/elicitation-transport.test.ts
@@ -1,19 +1,28 @@
+// Bypass Bun's process-global mock registry AND module cache. Sibling MCP
+// tests register `mock.module("@modelcontextprotocol/sdk/client/index.js", ...)`
+// with reduced MockClient implementations (no transport, no `callTool`);
+// `mock.restore()` clears the registry, but Bun's module cache is keyed by
+// specifier and retains the previously-resolved *mock instance* for that path.
+// We therefore pull types from the public path via a type-only import, but at
+// runtime load Client from the dist/esm path — a different specifier → a
+// different cache entry → the real SDK Client with full callTool support.
 import { afterEach, beforeEach, describe, expect, mock } from "bun:test"
 import { Cause, Effect, Fiber, Layer, Exit } from "effect"
 import { Server } from "@modelcontextprotocol/sdk/server/index.js"
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js"
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js"
+import type { Client as ClientType } from "@modelcontextprotocol/sdk/client/index.js"
 
-// Bypass Bun's process-global mock registry. Sibling MCP tests register
-// `mock.module("@modelcontextprotocol/sdk/client/index.js", ...)` with reduced
-// MockClient implementations (intentionally no transport, no `callTool`);
-// under Bun's --only-failures retry, that mock can still be in place when this
-// file's failure is re-run in the second test pass, yielding `client.callTool
-// is not a function`. Restore the registry first, then dynamically import the
-// real Client (dynamic import is required here because static imports hoist
-// and would resolve from the already-mocked module cache entry before this code).
 mock.restore()
-const { Client } = await import("@modelcontextprotocol/sdk/client/index.js")
+// Load Client via a sibling specifier (`/client` rather than `/client/index.js`)
+// that resolves to the same underlying `./client` exports entry. The mock-using
+// sibling test files register `mock.module` for `.../client/index.js`, which is a
+// different specifier — so Bun's module cache does NOT serve the previously-cached
+// MockClient module when we import via this alternate key, AND the mock registry
+// does not intercept this specifier either. `callTool` is therefore available.
+const { Client } = (await import("@modelcontextprotocol/sdk/client")) as unknown as {
+  Client: typeof ClientType
+}
 import { Question } from "@/question"
 import { Notification } from "@/notification"
 import { SettingsHook, type HookPayload } from "@/hook/settings"


### PR DESCRIPTION
## What

Third layer of the same defense-in-depth on the elicitation transport test, after PRs #69 and #71:

- **#69** restored Bun's mock registry in the MCP test files that mock `@modelcontextprotocol/sdk/client/index.js`.
- **#71** added `mock.restore()` on the consumer side (elicitation test file) to clear stale process-global mocks before the test runs.
- **This PR** loads the real SDK Client via an **alias specifier** — `@modelcontextprotocol/sdk/client` (no `/index.js`) — so Bun's module cache does NOT serve the previously-cached `MockClient` (which lacked `callTool`) even after the mock registry is cleared.

## Root cause confirmed

Dev CI still reds on `Unit Tests (linux)` with the same diagnostic (`client.callTool is not a function`) even after #69 + #71. Inspecting the Bun resolution behavior revealed:

- **Bun's module cache is keyed by specifier.** When a prior test file calls `mock.module("@modelcontextprotocol/sdk/client/index.js", ...)`, the cache entry for that specifier points at the mocked module.
- **`mock.restore()` clears the mock registry, not the module cache.** So a subsequent `await import("@modelcontextprotocol/sdk/client/index.js")` still resolves from the cache and returns a `MockClient` with no `callTool`.

## Fix

The package's `exports` map resolves both `@modelcontextprotocol/sdk/client/index.js` and the sibling specifier `@modelcontextprotocol/sdk/client` to the same `./client` entry (the real SDK Client). The shorter specifier:

- Is a **different key in Bun's module cache** → cache miss → loads the real module.
- Is **not registered in the mock registry** → mock registry can't intercept it.

Combined with the existing `mock.restore()`, this path reliably loads a real `Client` instance that has `callTool` available.

## Verification

- `bun test test/mcp/elicitation-transport.test.ts` → 1 pass
- `bun test test/mcp/oauth-browser.test.ts test/mcp/oauth-auto-connect.test.ts test/mcp/lifecycle.test.ts test/mcp/elicitation-transport.test.ts` → 42 pass
- `bun test test/mcp` → 83 pass
- `bun typecheck` clean

## Why this matters

`Unit Tests (linux)` has been red on dev since `f0f062a88f`. PR #68 landed the hooks/goal completeness changes cleanly, but the persistent red Unit Tests job has been masking any real regression there. This should finally unblock dev CI so hooks/goal regressions become visible again.