### PR TITLE
fix(mcp): use query string cache-busting for Client import

### DIFF
--- a/packages/opencode/test/mcp/elicitation-transport.test.ts
+++ b/packages/opencode/test/mcp/elicitation-transport.test.ts
@@ -14,13 +14,14 @@ import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprot
 import type { Client as ClientType } from "@modelcontextprotocol/sdk/client/index.js"
 
 mock.restore()
-// Load Client via a sibling specifier (`/client` rather than `/client/index.js`)
-// that resolves to the same underlying `./client` exports entry. The mock-using
-// sibling test files register `mock.module` for `.../client/index.js`, which is a
-// different specifier — so Bun's module cache does NOT serve the previously-cached
-// MockClient module when we import via this alternate key, AND the mock registry
-// does not intercept this specifier either. `callTool` is therefore available.
-const { Client } = (await import("@modelcontextprotocol/sdk/client")) as unknown as {
+// Cache-bust the import: add a unique query string to force Bun to load a fresh
+// module instance. Turbo runs tests from multiple packages in parallel, and
+// other packages' `mock.module` calls can pollute the global module cache even
+// after `mock.restore()`. A unique query string per import ensures we bypass
+// any cached (mocked) module instances and get the real SDK Client with full
+// `callTool` support.
+const cacheBuster = `?bust=${Date.now()}`
+const { Client } = (await import(`@modelcontextprotocol/sdk/client${cacheBuster}`)) as unknown as {
   Client: typeof ClientType
 }
 import { Question } from "@/question"


### PR DESCRIPTION
## What

Third fix for the elicitation transport test flake: use query string cache-busting to bypass Bun's module cache pollution from Turbo's parallel test runs.

## Why PRs #69 and #72 were not enough

- **PR #69** added `mock.restore()` in mock-using test files (producer-side cleanup).
- **PR #72** added `mock.restore()` + dynamic import via sibling specifier `@modelcontextprotocol/sdk/client` (consumer-side cleanup).
- Both fixes closed the mock registry leak, but **Turbo runs tests from multiple packages in parallel**, and other packages' `mock.module` calls can pollute the global module cache across package boundaries. The cache is keyed by specifier, and even the alternate specifier resolves to a cached (mocked) module instance from a parallel test run.

## Fix

Add a unique query string (`?bust=timestamp`) to the dynamic import. This forces Bun to load a fresh module instance on each import, bypassing any cached (mocked) module instances regardless of what other packages' tests have done to the global module cache.

```typescript
const cacheBuster = `?bust=${Date.now()}`
const { Client } = await import(`@modelcontextprotocol/sdk/client${cacheBuster}`)
```

## Verification

- `bun test test/mcp/elicitation-transport.test.ts` → 1 pass
- `bun test test/mcp/` → 83 pass (including mock-heavy OAuth tests)
- `bun typecheck` clean

## Context

This addresses the persistent `client.callTool is not a function` error that's been blocking dev CI since commit f0f062a88f. The diagnostic added in PR #67 confirmed the root cause (mock cache pollution from parallel Turbo runs), and this fix provides the most robust isolation mechanism available.