### PR TITLE
fix(hook,goal): close trust-gate self-escape + dead layer deps + single-pass chain + judge small model

### DIFF
--- a/packages/opencode/src/goal/loop.ts
+++ b/packages/opencode/src/goal/loop.ts
@@ -202,7 +202,13 @@ export const layer = Layer.effect(
         ((opts) =>
           Effect.gen(function* () {
             const defaultM = yield* provider.defaultModel()
-            const model = yield* provider.getModel(defaultM.providerID, defaultM.modelID)
+            // Judge is a ~200-token JSON binary classification — prefer the
+            // provider's small/fast model (config `small_model`, plugin hint,
+            // or the built-in haiku/flash/nano priority list). Fall back to
+            // the default model when no small model is resolvable, keeping
+            // the prior behavior byte-for-byte for those providers.
+            const small = yield* provider.getSmallModel(defaultM.providerID)
+            const model = small ?? (yield* provider.getModel(defaultM.providerID, defaultM.modelID))
             const language = yield* provider.getLanguage(model)
             const result = yield* Effect.tryPromise({
               try: (signal) =>

--- a/packages/opencode/src/hook/settings.ts
+++ b/packages/opencode/src/hook/settings.ts
@@ -59,8 +59,6 @@ import { Auth } from "@/auth"
 import { withTransientReadRetry } from "@/util/effect-http-client"
 import { buildAgentTools } from "./agent-tools"
 import { SessionHooks } from "./session-hooks"
-import { EventV2Bridge } from "@/event-v2-bridge"
-import { Database } from "@opencode-ai/core/database/database"
 import type { SessionHookEntry } from "./session-hooks"
 import { SessionID } from "@/session/schema"
 import { HookRewake } from "./rewake"
@@ -215,10 +213,12 @@ export interface Settings {
    */
   requireTrust?: boolean
   /**
-   * Per-layer escape hatch for the workspace-trust gate. When enforcement is on
-   * and the working directory is untrusted, a layer declaring `allowUntrusted:
-   * true` still executes its hooks (silent allow). Matches Claude Code /
-   * VS Code workspace-trust opt-out semantics.
+   * Escape hatch for the workspace-trust gate. Only honored from the GLOBAL
+   * hooks.json layer (`~/.config/opencode/hooks.json`): project / worktree
+   * hooks.json files are controlled by the (potentially untrusted) repository
+   * itself, so letting them declare `allowUntrusted: true` would let a
+   * malicious repo bypass the very gate meant to contain it. `readChain`
+   * strips the field from non-global layers with a log.warn.
    */
   allowUntrusted?: boolean
 }
@@ -726,7 +726,8 @@ export function mergeSettings(layers: Settings[]): Settings {
     }
   }
   // requireTrust is chain-wide: any layer opting in enables enforcement.
-  // allowUntrusted likewise: any layer declaring it escapes the gate.
+  // allowUntrusted merges the same way here, but readChain strips it from
+  // non-global layers before merge — only the global layer's opt-out survives.
   if (layers.some((l) => l.requireTrust === true)) out.requireTrust = true
   if (layers.some((l) => l.allowUntrusted === true)) out.allowUntrusted = true
   return out
@@ -789,6 +790,18 @@ function readChain(
   for (const { scope, file } of chainCandidates(directory, worktree, globalConfig)) {
     const data = readJSON(file)
     if (!data) continue
+    // Trust-gate escape (`allowUntrusted`) is only honored from the global
+    // layer. Project / worktree hooks.json are authored by the repository the
+    // gate is meant to contain — honoring their opt-out would let an untrusted
+    // repo bypass a globally-enforced `requireTrust` by declaring
+    // `allowUntrusted: true` in its own .opencode/hooks.json.
+    if (scope !== "global" && data.allowUntrusted !== undefined) {
+      log.warn("allowUntrusted ignored: only the global hooks.json layer may opt out of the trust gate", {
+        file,
+        scope,
+      })
+      data.allowUntrusted = undefined
+    }
     warnUnsupportedFields(data.hooks, path.dirname(file))
     layers.push(data)
     if (!data.hooks) continue
@@ -826,7 +839,22 @@ export function summarizeChain(directory: string, worktree: string, globalConfig
 // `globalConfig` overrides the resolved OpenCode global config dir so tests can
 // point it at an isolated temp dir instead of the real ~/.config/opencode.
 export function loadChain(directory: string, worktree: string, globalConfig?: string): Settings {
-  const { settings } = readChain(directory, worktree, globalConfig)
+  return loadChainWithSummaries(directory, worktree, globalConfig).settings
+}
+
+/**
+ * Single-call variant returning both the merged settings and the scope-tagged
+ * summaries from ONE pass over the chain files. The SettingsHook layer (initial
+ * state + hot-reload callback) uses this instead of calling `loadChain` and
+ * `summarizeChain` back-to-back, which would read every hooks.json twice and
+ * reopen the transient-inconsistency window `readChain` exists to close.
+ */
+export function loadChainWithSummaries(
+  directory: string,
+  worktree: string,
+  globalConfig?: string,
+): { settings: Settings; summaries: HookSummary[] } {
+  const chain = readChain(directory, worktree, globalConfig)
 
   // Deprecation scan: warn once per OpenCode-owned settings.json that still
   // carries a `hooks` field (D4). Hooks there are NOT loaded — the warning is
@@ -838,7 +866,7 @@ export function loadChain(directory: string, worktree: string, globalConfig?: st
     warnDeprecatedHooksField(fp)
   }
 
-  return settings
+  return chain
 }
 
 /**
@@ -1683,16 +1711,14 @@ const addSeen = (seen: Map<string, Set<string>>, sessionID: string, text: string
 export const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
-    const events = yield* EventV2Bridge.Service
-    const { db } = yield* Database.Service
     const sessionHooks = yield* SessionHooks.Service
 
     const state = yield* InstanceState.make(
       Effect.fn("SettingsHook.state")(function* (instCtx) {
-        const settings = loadChain(instCtx.directory, instCtx.worktree)
+        const chain = loadChainWithSummaries(instCtx.directory, instCtx.worktree)
         const stateObj = {
-          settings,
-          hooksList: summarizeChain(instCtx.directory, instCtx.worktree, Global.Path.config),
+          settings: chain.settings,
+          hooksList: chain.summaries,
           cwd: instCtx.directory,
           seen: new Map<string, Set<string>>(),
         } satisfies State
@@ -1716,9 +1742,9 @@ export const layer = Layer.effect(
           instCtx.directory,
           instCtx.worktree,
           () => Effect.sync(() => {
-            const newSettings = loadChain(instCtx.directory, instCtx.worktree)
-            lastSummaries = summarizeChain(instCtx.directory, instCtx.worktree, Global.Path.config)
-            return newSettings
+            const reloaded = loadChainWithSummaries(instCtx.directory, instCtx.worktree)
+            lastSummaries = reloaded.summaries
+            return reloaded.settings
           }),
           (newSettings, changedFile) => {
             stateObj.settings = newSettings
@@ -1740,8 +1766,8 @@ export const layer = Layer.effect(
     )
 
     // Handlers resolve their deps lazily at trigger time from the ambient context.
-    // This keeps the layer lightweight (only EventV2Bridge + Database + SessionHooks
-    // needed at construction), following the Todo pattern exactly.
+    // This keeps the layer lightweight (only SessionHooks needed at
+    // construction), following the Todo pattern exactly.
     const handlers: Record<string, HookHandler> = {
       command: commandHandler,
       mcp: mcpHandler,
@@ -2133,16 +2159,11 @@ export const layer = Layer.effect(
   }),
 )
 
-// defaultLayer provides MCP, HttpClient, Provider, Auth, FileSystem, and
-// ChildProcessSpawner. The agent handler (WP-4D-2) yields the latter two for
-// its bash / read_file / list_dir / grep tools. Every module that consumes
-// these spawn/fs services closes them in its own defaultLayer (see
-// Only provide deps needed at layer construction (EventV2Bridge + Database + SessionHooks).
-// Handler deps (MCP/Provider/Auth/FSUtil/HttpClient/CrossSpawnSpawner) are resolved
-// lazily at trigger time from whatever ambient context the Effect runs in.
+// Only provide deps needed at layer construction (SessionHooks — the sole
+// service yielded in the layer body). Handler deps (MCP/Provider/Auth/FSUtil/
+// HttpClient/CrossSpawnSpawner/HookRewake) are resolved lazily at trigger time
+// from whatever ambient context the Effect runs in.
 export const defaultLayer = layer.pipe(
-  Layer.provide(EventV2Bridge.defaultLayer),
-  Layer.provide(Database.defaultLayer),
   Layer.provide(SessionHooks.defaultLayer),
 )
 
@@ -2223,10 +2244,6 @@ function invokeMcpHook(
   })
 }
 
-export const node = LayerNode.make(layer, [
-  EventV2Bridge.node,
-  Database.node,
-  SessionHooks.node,
-])
+export const node = LayerNode.make(layer, [SessionHooks.node])
 
 export * as SettingsHook from "./settings"

--- a/packages/opencode/test/hook/load-chain.test.ts
+++ b/packages/opencode/test/hook/load-chain.test.ts
@@ -125,6 +125,66 @@ describe("§4.2 merge order is global → project → worktree concat-append (no
   })
 })
 
+describe("§4.2b allowUntrusted is only honored from the global layer (trust-gate self-escape)", () => {
+  test("project-layer allowUntrusted is stripped; global requireTrust survives", async () => {
+    const globalDir = await mktmp("global")
+    const projectDir = await mktmp("project")
+    try {
+      await writeGlobalHooksJson(globalDir, { requireTrust: true, ...hooksJsonTopLevel("g") })
+      await writeHooksJson(projectDir, { allowUntrusted: true, ...hooksJsonTopLevel("p") })
+
+      const merged = loadChain(projectDir, "", globalDir)
+      // The untrusted repo's own hooks.json must not be able to opt out of a
+      // globally-enforced trust gate.
+      expect(merged.requireTrust).toBe(true)
+      expect(merged.allowUntrusted).toBeUndefined()
+    } finally {
+      await Promise.all([
+        fs.rm(globalDir, { recursive: true, force: true }),
+        fs.rm(projectDir, { recursive: true, force: true }),
+      ])
+    }
+  })
+
+  test("worktree-layer allowUntrusted is stripped too", async () => {
+    const globalDir = await mktmp("global")
+    const projectDir = await mktmp("project")
+    const worktreeDir = await mktmp("worktree")
+    try {
+      await writeGlobalHooksJson(globalDir, { requireTrust: true })
+      await writeHooksJson(worktreeDir, { allowUntrusted: true, ...hooksJsonTopLevel("w") })
+
+      const merged = loadChain(projectDir, worktreeDir, globalDir)
+      expect(merged.requireTrust).toBe(true)
+      expect(merged.allowUntrusted).toBeUndefined()
+    } finally {
+      await Promise.all([
+        fs.rm(globalDir, { recursive: true, force: true }),
+        fs.rm(projectDir, { recursive: true, force: true }),
+        fs.rm(worktreeDir, { recursive: true, force: true }),
+      ])
+    }
+  })
+
+  test("global-layer allowUntrusted is honored", async () => {
+    const globalDir = await mktmp("global")
+    const projectDir = await mktmp("project")
+    try {
+      await writeGlobalHooksJson(globalDir, { requireTrust: true, allowUntrusted: true })
+      await writeHooksJson(projectDir, hooksJsonTopLevel("p"))
+
+      const merged = loadChain(projectDir, "", globalDir)
+      expect(merged.requireTrust).toBe(true)
+      expect(merged.allowUntrusted).toBe(true)
+    } finally {
+      await Promise.all([
+        fs.rm(globalDir, { recursive: true, force: true }),
+        fs.rm(projectDir, { recursive: true, force: true }),
+      ])
+    }
+  })
+})
+
 describe("§4.3 top-level events format (no wrapper) parses correctly", () => {
   test("readJSON parses {PreToolUse: [...]} and stamps __sourceDir to the hooks.json dir", async () => {
     const dir = await mktmp("fmt")

--- a/packages/opencode/test/hook/workspace-trust.test.ts
+++ b/packages/opencode/test/hook/workspace-trust.test.ts
@@ -98,7 +98,7 @@ describe("SettingsHook workspace-trust gate (WP-6B)", () => {
   )
 
   trustIt.instance(
-    "enforcement ON + allowUntrusted:true → hooks execute normally",
+    "enforcement ON + project-layer allowUntrusted:true → still skipped (no self-escape)",
     () =>
       Effect.gen(function* () {
         const hook = yield* SettingsHook.Service
@@ -106,7 +106,11 @@ describe("SettingsHook workspace-trust gate (WP-6B)", () => {
           { event: "SessionStart", source: "startup" },
           { sessionID: "ses-trust-allow", transcriptPath: "" },
         )
-        expect(r.additionalContexts).toEqual([CONTEXT])
+        // The project .opencode/hooks.json is authored by the untrusted repo
+        // itself — its allowUntrusted opt-out is stripped by readChain, so the
+        // gate still silently skips all hooks.
+        expect(r.additionalContexts).toEqual([])
+        expect(r.blocked).toBeUndefined()
       }),
     { init: writeHooks(sessionStartHook({ requireTrust: true, allowUntrusted: true })) },
   )


### PR DESCRIPTION
## 背景

对 dev 上的 HOOKS / GOAL 子系统做全盘 review 后发现的 4 个问题修复（F1 高危安全 + F2/F3 清理 + F4 成本）。

## 改动

**F1（安全·高危）**：trust-gate 自我逃逸
- `readChain` 现在剥离非 global 层的 `allowUntrusted`，因为 project/worktree 的 `.opencode/hooks.json` 由被门禁对象自己编写，声明 `allowUntrusted: true` 即可绕过全局 `requireTrust`。
- 更新 `Settings.allowUntrusted` 与 `mergeSettings` 文档注释。
- 测试：反转原 "project 层 allowUntrusted → hooks 执行" 集成用例为 "不得自我逃逸"；load-chain.test.ts 新增 3 条 unit（project/worktree 剥离、global 仍然生效）。

**F2（死依赖）**：settings.ts layer 体内 `events`/`db` yield 后从未使用
- 删除未使用 yield 与 import；`defaultLayer` / `node` 现在只依赖 `SessionHooks`，与文件自己声明的 "构造期轻量" 原则一致。

**F3（双读窗口）**：`readChain` 单遍读取优化在调用点被绕开
- 新增 `loadChainWithSummaries`（一次 `readChain` + deprecation 扫描）；`loadChain` 变为 thin shell。
- layer 初始 state 构建和 hot-reload 回调都改为单次调用同时取 settings + summaries，每个 hooks.json 每轮只读一次，消除 settings 与 Active Hooks 摘要来自两次不同读取的窗口。

**F4（judge 成本）**：goal judge 每轮用全尺寸主模型做 ~200-token JSON 判定
- loop.ts 生产 judge 路径改为优先 `provider.getSmallModel(providerID)`（尊重 `small_model` 配置、plugin hint 和内置 haiku/flash/nano 优先级表），解析不到时逐字回退到原 default-model 路径。

## 验证
- `bun typecheck` 干净
- `bun test test/hook test/goal test/tool/goal-tool.test.ts` → **215 pass / 0 fail**

## 风险
- F1 是行为变更：现在依赖 project/worktree 层 `allowUntrusted` 的用户（本身就是不安全用法）会被静默改为受门禁，并伴随 log.warn 指引。
- F2 移除了 defaultLayer 的两个 provide，但 app-runtime/httpapi 侧 EventV2Bridge/Database 由其他服务（如 Goal.defaultLayer）自带，无影响。
- F4 默认行为不变（解析不到 small model 时回退到原路径）。