### PR TITLE
fix(server): map provider defects to named 4xx for offline catalog

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/middleware/error.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/middleware/error.ts
@@ -1,5 +1,6 @@
 import { NamedError } from "@opencode-ai/core/util/error"
 import { ConfigErrorV1 } from "@opencode-ai/core/v1/config/error"
+import { Provider } from "@/provider/provider"
 import { Cause, Effect } from "effect"
 import { HttpRouter, HttpServerError, HttpServerRespondable, HttpServerResponse } from "effect/unstable/http"
 
@@ -23,6 +24,14 @@ export const errorLayer = HttpRouter.middleware<{ handles: unknown }>()((effect)
         ConfigErrorV1.DirectoryTypoError.isInstance(error)
       ) {
         return Effect.succeed(HttpServerResponse.jsonUnsafe(error.toObject(), { status: 400 }))
+      }
+
+      // Degraded-state provider failures (e.g. offline with empty model catalog) must surface as
+      // named, actionable errors instead of the generic 500 defect path.
+      if (Provider.NoProvidersError.isInstance(error) || Provider.NoModelsError.isInstance(error)) {
+        return Effect.succeed(
+          HttpServerResponse.jsonUnsafe({ name: error._tag, data: { message: error.message } }, { status: 400 }),
+        )
       }
 
       const ref = `err_${crypto.randomUUID().slice(0, 8)}`

--- a/packages/opencode/test/server/httpapi-error-middleware.test.ts
+++ b/packages/opencode/test/server/httpapi-error-middleware.test.ts
@@ -2,9 +2,11 @@ import { NodeHttpServer, NodeServices } from "@effect/platform-node"
 import { NamedError } from "@opencode-ai/core/util/error"
 import { describe, expect } from "bun:test"
 import { ConfigErrorV1 } from "@opencode-ai/core/v1/config/error"
+import { ProviderV2 } from "@opencode-ai/core/provider"
 import { Effect, Layer } from "effect"
 import { HttpClient, HttpClientRequest, HttpRouter } from "effect/unstable/http"
 import { errorLayer } from "../../src/server/routes/instance/httpapi/middleware/error"
+import { Provider } from "../../src/provider/provider"
 import { NotFoundError } from "../../src/storage/storage"
 import { testEffect } from "../lib/effect"
 
@@ -96,6 +98,45 @@ describe("HttpApi error middleware", () => {
 
       expect(response.status).toBe(500)
       expectUnknownErrorBody(body)
+    }),
+  )
+
+  it.live("returns provider no-providers defects as named actionable client errors", () =>
+    Effect.gen(function* () {
+      yield* HttpRouter.add("GET", "/no-providers", Effect.die(new Provider.NoProvidersError({}))).pipe(
+        Layer.provide(errorLayer),
+        HttpRouter.serve,
+        Layer.build,
+      )
+
+      const response = yield* HttpClientRequest.get("/no-providers").pipe(HttpClient.execute)
+      const body = yield* response.json
+
+      expect(response.status).toBe(400)
+      expect(body).toMatchObject({
+        name: "ProviderNoProvidersError",
+        data: { message: new Provider.NoProvidersError({}).message },
+      })
+    }),
+  )
+
+  it.live("returns provider no-models defects as named actionable client errors", () =>
+    Effect.gen(function* () {
+      const error = new Provider.NoModelsError({ providerID: ProviderV2.ID.make("anthropic") })
+      yield* HttpRouter.add("GET", "/no-models", Effect.die(error)).pipe(
+        Layer.provide(errorLayer),
+        HttpRouter.serve,
+        Layer.build,
+      )
+
+      const response = yield* HttpClientRequest.get("/no-models").pipe(HttpClient.execute)
+      const body = yield* response.json
+
+      expect(response.status).toBe(400)
+      expect(body).toMatchObject({
+        name: "ProviderNoModelsError",
+        data: { message: error.message },
+      })
     }),
   )
 })


### PR DESCRIPTION
## Summary

Follow-up to #87 (offline model catalog startup). When the model catalog is empty (offline, no configured provider), a prompt submit died as a defect through the HTTP error middleware, surfacing as a generic `500 "Unexpected server error"` and — on Windows — the `DialogRetryAction` retry-dialog loop. The offline-startup spec requires a **named, actionable error**, not the generic defect path.

## Changes

- `middleware/error.ts`: map `ProviderNoProvidersError` / `ProviderNoModelsError` defects to a `400 { name, data: { message } }` (same wire shape as existing `NamedError` payloads), alongside the existing `ConfigErrorV1` mapping. The TUI submit-failure toast (`errorMessage()`) renders `data.message`, so users now see e.g. *"No providers are available. Configure a provider or restore network access…"* instead of *"Unexpected server error"*.
- Retry-status path: `session.status = "retry"` is only set by the streaming retry policy (`processor.ts:~1015`). The offline no-provider failure dies at prompt admission (`currentModel`) before the processor runs, and the middleware now returns the named 400 first — so the retry dialog no longer engages for this cause. No retry-mapping change needed.
- No declared endpoint schema change → wire shape matches existing `NamedError.Unknown` 500, so **no SDK regeneration** required.
- Tests: two new middleware cases covering both provider error types (`httpapi-error-middleware.test.ts`).

## Verification

- `bun typecheck` (root, via turbo) — 29/29 green.
- `bun test test/server/httpapi-error-middleware.test.ts` — 6/6 pass.

## Notes

- The `openspec/` directory is gitignored in this repo, so the corresponding `tasks.md` checkbox updates (2.2 / 4.2 / 5.3) are local-only and not part of this commit.
- 5.3 (Windows smoke) is verified by code-path analysis here, not a physical Windows run.