### PR TITLE
fix(tui): explicitly register spinner to survive Windows tree-shaking

### DIFF
--- a/packages/opencode/src/cli/cmd/run/footer.subagent.tsx
+++ b/packages/opencode/src/cli/cmd/run/footer.subagent.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource @opentui/solid */
 import type { ScrollBoxRenderable } from "@opentui/core"
 import { useKeyboard } from "@opentui/solid"
-import "opentui-spinner/solid"
+import "./spinner-register"
 import { Show, createMemo, indexArray } from "solid-js"
 import { SPINNER_FRAMES } from "@opencode-ai/tui/component/spinner"
 import { RunEntryContent, separatorRows } from "./scrollback.writer"

--- a/packages/opencode/src/cli/cmd/run/footer.view.tsx
+++ b/packages/opencode/src/cli/cmd/run/footer.view.tsx
@@ -10,7 +10,7 @@
 /** @jsxImportSource @opentui/solid */
 import { useTerminalDimensions } from "@opentui/solid"
 import { For, Match, Show, Switch, createEffect, createMemo, createSignal, onCleanup } from "solid-js"
-import "opentui-spinner/solid"
+import "./spinner-register"
 import { createColors, createFrames } from "@opencode-ai/tui/ui/spinner"
 import {
   RUN_SUBAGENT_PANEL_ROWS,

--- a/packages/opencode/src/cli/cmd/run/spinner-register.ts
+++ b/packages/opencode/src/cli/cmd/run/spinner-register.ts
@@ -1,0 +1,15 @@
+import { extend } from "@opentui/solid"
+import { SpinnerRenderable } from "opentui-spinner"
+import "opentui-spinner/solid"
+
+// Explicit registration is load-bearing. `bun build` on a Windows host drops
+// the side-effect-only `opentui-spinner/solid` import (its package.json
+// `sideEffects` path glob does not match backslash paths), so `<spinner>`
+// crashed with "[Reconciler] Unknown component type: spinner" on Windows.
+// The explicit extend() below survives tree-shaking and fixes it.
+//
+// The retained side-effect import is NOT redundant: it provides JSX type
+// augmentation for `<spinner>` in the Solid JSX runtime. At runtime it also
+// re-registers, but extend() is Object.assign over a flat catalogue, so the
+// duplicate registration is harmless.
+extend({ spinner: SpinnerRenderable })

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -10,7 +10,7 @@ import {
 } from "@opentui/core"
 import type { CommandContext } from "@opentui/keymap"
 import { createEffect, createMemo, onMount, createSignal, onCleanup, on, Show, Switch, Match } from "solid-js"
-import "opentui-spinner/solid"
+import "../../ui/spinner-register"
 import path from "path"
 import { fileURLToPath } from "url"
 import { useLocal } from "../../context/local"

--- a/packages/tui/src/component/spinner.tsx
+++ b/packages/tui/src/component/spinner.tsx
@@ -3,7 +3,7 @@ import { useTheme } from "../context/theme"
 import { useKV } from "../context/kv"
 import type { JSX } from "@opentui/solid"
 import type { RGBA } from "@opentui/core"
-import "opentui-spinner/solid"
+import "../ui/spinner-register"
 
 export const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
 

--- a/packages/tui/src/ui/spinner-register.ts
+++ b/packages/tui/src/ui/spinner-register.ts
@@ -1,0 +1,15 @@
+import { extend } from "@opentui/solid"
+import { SpinnerRenderable } from "opentui-spinner"
+import "opentui-spinner/solid"
+
+// Explicit registration is load-bearing. `bun build` on a Windows host drops
+// the side-effect-only `opentui-spinner/solid` import (its package.json
+// `sideEffects` path glob does not match backslash paths), so `<spinner>`
+// crashed with "[Reconciler] Unknown component type: spinner" on Windows.
+// The explicit extend() below survives tree-shaking and fixes it.
+//
+// The retained side-effect import is NOT redundant: it provides JSX type
+// augmentation for `<spinner>` in the Solid JSX runtime. At runtime it also
+// re-registers, but extend() is Object.assign over a flat catalogue, so the
+// duplicate registration is harmless.
+extend({ spinner: SpinnerRenderable })


### PR DESCRIPTION
## Problem

The Windows release binary (`opencode.exe`) crashes at runtime with `[Reconciler] Unknown component type: spinner` the first time `<spinner>` renders. The prior fix (#90, lockfile dedupe) did not stop it.

## Root cause

On a **Windows host**, `bun build` drops the side-effect-only `import "opentui-spinner/solid"`. That package declares `sideEffects: ["./dist/solid.mjs"]` as a forward-slash glob, which Bun does not match against backslash paths on a Windows builder. The `extend({ spinner })` call inside it never executes, so the reconciler has no `spinner` component registered. macOS/Linux match fine (forward-slash paths), which is why only Windows crashes.

Verified against the released **v1.17.11-dev.10** artifacts:

| Binary | `Spinner interval must be a finite` | `createPulse requires at least one color` |
|---|---|---|
| `opencode.exe` (Windows) | **0** | **0** |
| `opencode` (macOS) | 1 | 1 |

The Windows binary contains zero spinner runtime code — the registration was tree-shaken out.

## Fix

Register the spinner explicitly via `extend({ spinner: SpinnerRenderable })` in a local module imported by every `<spinner>` render path. The explicit `extend(...)` carries a real value dependency the bundler cannot drop.

- `packages/tui/src/ui/spinner-register.ts` (new) — used by the TUI
- `packages/opencode/src/cli/cmd/run/spinner-register.ts` (new) — used by the `opencode run` footer
- 4 call sites swap `import "opentui-spinner/solid"` → the local registration module

The retained `opentui-spinner/solid` side-effect import is **not** redundant: it provides JSX type augmentation for `<spinner>`. At runtime it re-registers too, but `extend` is `Object.assign` over a flat catalogue, so double registration is harmless. This mirrors the existing `extend({ go_upsell_art })` pattern in `packages/tui/src/component/bg-pulse.tsx`.

## Verification

- `bun typecheck` in `packages/tui` — PASS
- `bun typecheck` in `packages/opencode` — PASS
- Local `./packages/opencode/script/build.ts --single --skip-install --skip-embed-web-ui` — PASS, smoke test `--version` PASS
- Local compiled binary string inspection: spinner runtime strings present (were absent in the failing Windows release)

## Follow-up (not in this PR)

A real end-to-end fix confirmation requires the Windows CI build. Suggested: add a post-build check on the Windows artifact that greps `opencode.exe` for `Spinner interval must be a finite` (>0) so this regression cannot recur silently.

## Checklist

- [x] Branch cut from `main`, PR targets `dev`
- [x] Conventional commit title
- [x] Only spinner-related files changed (6 files, no unrelated diff)