### PR TITLE
release: 1.17.11 (offline startup + Windows spinner fix)

### DIFF
--- a/.github/workflows/release-fork.yml
+++ b/.github/workflows/release-fork.yml
@@ -95,6 +95,27 @@ jobs:
           # macOS has no other job in the repo, so it's safe to save here.
           save-cache: ${{ matrix.name == 'macos' }}
 
+      # Embed a models.dev catalog snapshot into the binary so air-gapped
+      # users can start opencode without reaching https://models.dev at
+      # runtime (see packages/opencode/script/generate.ts fallback order).
+      - name: Fetch models.dev Snapshot
+        if: inputs.platforms == '' || contains(inputs.platforms, matrix.name)
+        run: |
+          snapshot_path="$RUNNER_TEMP/models-dev-api.json"
+          if command -v cygpath &>/dev/null; then
+            snapshot_path="$(cygpath -m "$snapshot_path")"
+          fi
+          for attempt in 1 2 3; do
+            if curl -fsSL --max-time 30 https://models.dev/api.json -o "$snapshot_path"; then
+              echo "models.dev snapshot downloaded (attempt $attempt)"
+              echo "MODELS_DEV_API_JSON=$snapshot_path" >> "$GITHUB_ENV"
+              exit 0
+            fi
+            echo "models.dev download failed (attempt $attempt), retrying..."
+            sleep 5
+          done
+          echo "::warning::Failed to download models.dev api.json; build will fall back to @opencode-ai/models snapshot or an empty catalog"
+
       - name: Build CLI
         if: inputs.platforms == '' || contains(inputs.platforms, matrix.name)
         run: ./packages/opencode/script/build.ts --single --skip-install

--- a/bun.lock
+++ b/bun.lock
@@ -6417,10 +6417,6 @@
 
     "openid-client/lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="],
 
-    "opentui-spinner/@opentui/core": ["@opentui/core@0.4.2", "", { "dependencies": { "bun-ffi-structs": "0.2.3", "diff": "9.0.0", "marked": "17.0.1", "string-width": "7.2.0", "strip-ansi": "7.1.2" }, "optionalDependencies": { "@opentui/core-darwin-arm64": "0.4.2", "@opentui/core-darwin-x64": "0.4.2", "@opentui/core-linux-arm64": "0.4.2", "@opentui/core-linux-arm64-musl": "0.4.2", "@opentui/core-linux-x64": "0.4.2", "@opentui/core-linux-x64-musl": "0.4.2", "@opentui/core-win32-arm64": "0.4.2", "@opentui/core-win32-x64": "0.4.2" }, "peerDependencies": { "web-tree-sitter": "0.25.10" } }, "sha512-ulx6RMqftf2fm7Itf9e81GcCDMNY6NAhmnKYhllDOMYD+PxYXR+vomy2bxQNV5ow31RE7s8WQFnb7hWTRUbx2g=="],
-
-    "opentui-spinner/@opentui/solid": ["@opentui/solid@0.4.2", "", { "dependencies": { "@babel/core": "7.28.0", "@babel/preset-typescript": "7.27.1", "@opentui/core": "0.4.2", "babel-plugin-module-resolver": "5.0.2", "babel-preset-solid": "1.9.12", "entities": "7.0.1", "s-js": "^0.4.9" }, "peerDependencies": { "solid-js": "1.9.12" } }, "sha512-zuYXsnrlsMtnXrS7QCYBdPzMtUSonG2LqnJikBR2NjEE2O4zEKvJd48n3eB1igcxjv96tiotTXRNCylYS0SNdQ=="],
-
     "p-locate/p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
 
     "p-retry/retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
@@ -7293,28 +7289,6 @@
 
     "opencode-gitlab-auth/open/wsl-utils": ["wsl-utils@0.1.0", "", { "dependencies": { "is-wsl": "^3.1.0" } }, "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw=="],
 
-    "opentui-spinner/@opentui/core/@opentui/core-darwin-arm64": ["@opentui/core-darwin-arm64@0.4.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-is+O+sS/l3E9cZXyM9pRF1WhqnE+hYSPYoZkbseR9CthJcaWPGi3R3jUJa1cLj325252jWgxVupnDqFUtKg36w=="],
-
-    "opentui-spinner/@opentui/core/@opentui/core-darwin-x64": ["@opentui/core-darwin-x64@0.4.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-ACi42h81DurSeybUAD1XyKT6xmXZcKeTxS54lZFi0CVZh46w0g99vNj8PlQzIFXvvFLT0e0IlRS//eWSWS2zGQ=="],
-
-    "opentui-spinner/@opentui/core/@opentui/core-linux-arm64": ["@opentui/core-linux-arm64@0.4.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-RjOx2HcjLRtGSy9WrAGSdr5M9SpJuPifPORpImx6Mciovw0ltnE0uoYjIyor82uf6/LExWC7YA2AcAl+YBxayA=="],
-
-    "opentui-spinner/@opentui/core/@opentui/core-linux-arm64-musl": ["@opentui/core-linux-arm64-musl@0.4.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-heNciL2ngPU+kq1h01PHLsxn6Fr8iqTFtbxSdVbhaY3XihuIjkuXyEhFeuoa1lsXY7Bb2gpWnX5EQVWnZsAuDQ=="],
-
-    "opentui-spinner/@opentui/core/@opentui/core-linux-x64": ["@opentui/core-linux-x64@0.4.2", "", { "os": "linux", "cpu": "x64" }, "sha512-9s0s/ooK+AhWP306By3gu+XhzcVEThC2sqKMPK1nQmGDujQhd+xOrtbtfCVcJSx62UzAovC2VNqypvP8vHByOg=="],
-
-    "opentui-spinner/@opentui/core/@opentui/core-linux-x64-musl": ["@opentui/core-linux-x64-musl@0.4.2", "", { "os": "linux", "cpu": "x64" }, "sha512-Cjv6Bv7l3p/KLNJr5RyqCS0FmRlAGJnkA2IK3S+HkHhCOv/O02S1G+DBUY6POnyjp1eNy95vauustApobhdbig=="],
-
-    "opentui-spinner/@opentui/core/@opentui/core-win32-arm64": ["@opentui/core-win32-arm64@0.4.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-mfJZrJ0TNPFRZUzXNsxAPe1YdiWsy/vbTl93+yeXGHPI1B8Qnk9V5hpzSxxEyBGhlTHSfGNtgiO+VrrdRC3kZA=="],
-
-    "opentui-spinner/@opentui/core/@opentui/core-win32-x64": ["@opentui/core-win32-x64@0.4.2", "", { "os": "win32", "cpu": "x64" }, "sha512-P2oguG3ng3OMjAdasFSA3GhHaQXtzDUsIRDGbzWFOimpZ/zMemidp+JQ0V8V6XwK6Utk5G0aQ03oBaRCoLyYDw=="],
-
-    "opentui-spinner/@opentui/core/bun-ffi-structs": ["bun-ffi-structs@0.2.3", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-pgJiXP+hEgFo9qG51J6ItfY4ocs3vniwNzJ9WhoakB3QB2GdzQxX2EXssentPYlB2hOfJrTjO6iIQkWYzUodpg=="],
-
-    "opentui-spinner/@opentui/core/diff": ["diff@9.0.0", "", {}, "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw=="],
-
-    "opentui-spinner/@opentui/solid/@babel/core": ["@babel/core@7.28.0", "", { "dependencies": { "@ampproject/remapping": "^2.2.0", "@babel/code-frame": "^7.27.1", "@babel/generator": "^7.28.0", "@babel/helper-compilation-targets": "^7.27.2", "@babel/helper-module-transforms": "^7.27.3", "@babel/helpers": "^7.27.6", "@babel/parser": "^7.28.0", "@babel/template": "^7.27.2", "@babel/traverse": "^7.28.0", "@babel/types": "^7.28.0", "convert-source-map": "^2.0.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.2", "json5": "^2.2.3", "semver": "^6.3.1" } }, "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ=="],
-
     "p-locate/p-limit/yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
     "pkg-dir/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
@@ -8042,8 +8016,6 @@
     "js-beautify/glob/minimatch/brace-expansion": ["brace-expansion@2.1.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA=="],
 
     "js-beautify/glob/path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
-
-    "opentui-spinner/@opentui/solid/@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "pkg-dir/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
 

--- a/packages/core/src/models-dev.ts
+++ b/packages/core/src/models-dev.ts
@@ -1,5 +1,5 @@
 import path from "path"
-import { Context, Duration, Effect, Layer, Option, Schedule, Schema } from "effect"
+import { Cause, Context, Duration, Effect, Layer, Option, Schedule, Schema } from "effect"
 import { FetchHttpClient, HttpClient, HttpClientRequest } from "effect/unstable/http"
 import { ModelsDev } from "@opencode-ai/schema/models-dev"
 import { Global } from "./global"
@@ -142,6 +142,14 @@ export const layer = Layer.effect(
     )
     const ttl = Duration.minutes(5)
     const lockKey = `models-dev:${filepath}`
+    let fetchFailed = false
+    let emptyFallback = false
+
+    const publishFetchFailed = Effect.fn("ModelsDev.publishFetchFailed")(function* () {
+      if (fetchFailed) return
+      fetchFailed = true
+      yield* events.publish(Event.FetchFailed, { source })
+    })
 
     const fresh = Effect.fnUntraced(function* () {
       const stat = yield* fs.stat(filepath).pipe(Effect.catch(() => Effect.succeed(undefined)))
@@ -173,9 +181,11 @@ export const layer = Layer.effect(
       Effect.map((v) => v as Record<string, Provider> | undefined),
     )
 
-    const loadSnapshot = Effect.sync(() =>
-      typeof OPENCODE_MODELS_DEV === "undefined" ? undefined : OPENCODE_MODELS_DEV,
-    )
+    const loadSnapshot = Effect.sync(() => {
+      if (typeof OPENCODE_MODELS_DEV === "undefined") return undefined
+      if (Object.keys(OPENCODE_MODELS_DEV).length === 0) return undefined
+      return OPENCODE_MODELS_DEV
+    })
 
     const fetchAndWrite = Effect.fn("ModelsDev.fetchAndWrite")(function* () {
       const text = yield* fetchApi()
@@ -204,7 +214,20 @@ export const layer = Layer.effect(
           yield* Flock.effect(lockKey)
           return yield* fetchAndWrite()
         }),
+      ).pipe(
+        Effect.catchCauseIf(
+          (cause) => !Cause.hasInterruptsOnly(cause),
+          (cause) =>
+            Effect.logError("Failed to fetch models.dev", { cause: cause }).pipe(
+              Effect.andThen(publishFetchFailed()),
+              Effect.as(undefined),
+            ),
+        ),
       )
+      if (!text) {
+        emptyFallback = true
+        return {}
+      }
       return JSON.parse(text) as Record<string, Provider>
     }).pipe(Effect.withSpan("ModelsDev.populate"), Effect.orDie)
 
@@ -221,11 +244,19 @@ export const layer = Layer.effect(
           // our outer check and lock acquisition.
           if (!force && (yield* fresh())) return
           yield* fetchAndWrite()
+          fetchFailed = false
+          emptyFallback = false
           yield* invalidate
           yield* events.publish(Event.Refreshed, {})
         }),
       ).pipe(
-        Effect.tapCause((cause) => Effect.logError("Failed to fetch models.dev", { cause: cause })),
+        Effect.catchCauseIf(
+          (cause) => !Cause.hasInterruptsOnly(cause),
+          (cause) =>
+            Effect.logError("Failed to fetch models.dev", { cause: cause }).pipe(
+              Effect.andThen(emptyFallback ? publishFetchFailed() : Effect.void),
+            ),
+        ),
         Effect.ignore,
       )
     })

--- a/packages/core/test/models-dev.test.ts
+++ b/packages/core/test/models-dev.test.ts
@@ -1,0 +1,133 @@
+import path from "path"
+import { afterEach, describe, expect, test } from "bun:test"
+import { Effect, Fiber, Layer, Stream } from "effect"
+import type { Scope } from "effect/Scope"
+import { EventV2 } from "@opencode-ai/core/event"
+import { Flag } from "@opencode-ai/core/flag/flag"
+import { ModelsDev } from "@opencode-ai/core/models-dev"
+
+const eventLayer = EventV2.defaultLayer
+const layer = ModelsDev.defaultLayer.pipe(Layer.provideMerge(eventLayer))
+const original = {
+  path: Flag.OPENCODE_MODELS_PATH,
+  url: Flag.OPENCODE_MODELS_URL,
+  disabled: Flag.OPENCODE_DISABLE_MODELS_FETCH,
+}
+
+const fixture = {
+  acme: {
+    api: "https://acme.test",
+    name: "Acme",
+    env: ["ACME_API_KEY"],
+    id: "acme",
+    models: {
+      "acme-large": {
+        id: "acme-large",
+        name: "Acme Large",
+        release_date: "2026-01-01",
+        attachment: false,
+        reasoning: false,
+        temperature: true,
+        tool_call: true,
+        limit: { context: 128_000, output: 4096 },
+      },
+    },
+  },
+} satisfies Record<string, ModelsDev.Provider>
+
+afterEach(() => {
+  Flag.OPENCODE_MODELS_PATH = original.path
+  Flag.OPENCODE_MODELS_URL = original.url
+  Flag.OPENCODE_DISABLE_MODELS_FETCH = original.disabled
+})
+
+describe("ModelsDev", () => {
+  test("returns empty catalog and publishes fetch_failed when offline without cache or snapshot", () =>
+    runWithFlags(
+      {
+        path: path.join(import.meta.dir, "fixtures", "missing-models-dev.json"),
+        url: "http://127.0.0.1:9",
+        disabled: false,
+      },
+      Effect.gen(function* () {
+        const events = yield* EventV2.Service
+        const failed = yield* events.subscribe(ModelsDev.Event.FetchFailed).pipe(
+          Stream.take(1),
+          Stream.runCollect,
+          Effect.forkScoped,
+        )
+        const models = yield* ModelsDev.Service.use((service) => service.get())
+
+        expect(models).toEqual({})
+        expect((yield* Fiber.join(failed)).map((event) => event.data)).toEqual([{ source: "http://127.0.0.1:9" }])
+      }),
+    ),
+  )
+
+  test("loads disk cache before network", () =>
+    runWithFlags(
+      {
+        path: path.join(import.meta.dir, "plugin", "fixtures", "models-dev.json"),
+        url: "http://127.0.0.1:9",
+        disabled: false,
+      },
+      Effect.gen(function* () {
+        const models = yield* ModelsDev.Service.use((service) => service.get())
+
+        expect(Object.keys(models)).toEqual(["acme", "local"])
+        expect(models.acme.name).toEqual("Acme")
+      }),
+    ),
+  )
+
+  test("successful refresh after fallback repopulates the cached catalog", async () => {
+    let online = false
+    const server = Bun.serve({
+      port: 0,
+      fetch() {
+        if (!online) return new Response("offline", { status: 503 })
+        return Response.json(fixture)
+      },
+    })
+    try {
+      await runWithFlags(
+        {
+          path: path.join(import.meta.dir, "fixtures", "missing-models-dev-refresh.json"),
+          url: server.url.origin,
+          disabled: false,
+        },
+        Effect.gen(function* () {
+          const events = yield* EventV2.Service
+          const refreshed = yield* events.subscribe(ModelsDev.Event.Refreshed).pipe(
+            Stream.take(1),
+            Stream.runCollect,
+            Effect.forkScoped,
+          )
+          const service = yield* ModelsDev.Service
+
+          expect(yield* service.get()).toEqual({})
+          online = true
+          yield* service.refresh(true)
+          expect(yield* Fiber.join(refreshed)).toHaveLength(1)
+          expect(yield* service.get()).toEqual(fixture)
+        }),
+      )
+    } finally {
+      server.stop(true)
+    }
+  })
+})
+
+function run<A, E>(effect: Effect.Effect<A, E, EventV2.Service | ModelsDev.Service | Scope>) {
+  return Effect.runPromise(effect.pipe(Effect.scoped, Effect.provide(layer)))
+}
+
+function runWithFlags<A, E, R>(
+  next: { path: string | undefined; url: string | undefined; disabled: boolean },
+  effect: Effect.Effect<A, E, EventV2.Service | ModelsDev.Service | Scope>,
+) {
+  Flag.OPENCODE_MODELS_PATH = next.path
+  Flag.OPENCODE_MODELS_URL = next.url
+  Flag.OPENCODE_DISABLE_MODELS_FETCH = next.disabled
+  return run(effect)
+}

--- a/packages/opencode/script/generate.ts
+++ b/packages/opencode/script/generate.ts
@@ -8,7 +8,28 @@ const dir = path.resolve(__dirname, "..")
 process.chdir(dir)
 
 const modelsUrl = process.env.OPENCODE_MODELS_URL || "https://models.dev"
-export const modelsData = process.env.MODELS_DEV_API_JSON
-  ? await Bun.file(process.env.MODELS_DEV_API_JSON).text()
-  : await fetch(`${modelsUrl}/api.json`).then((x) => x.text())
-console.log("Loaded models.dev snapshot")
+
+async function loadModelsData() {
+  if (process.env.MODELS_DEV_API_JSON) {
+    console.log("Loaded models.dev snapshot from MODELS_DEV_API_JSON")
+    return Bun.file(process.env.MODELS_DEV_API_JSON).text()
+  }
+
+  const response = await fetch(`${modelsUrl}/api.json`).catch(() => undefined)
+  if (response?.ok) {
+    console.log("Loaded models.dev snapshot from api.json")
+    return response.text()
+  }
+
+  const snapshotSpecifier = "@opencode-ai/models/snapshot"
+  const snapshot = await import(snapshotSpecifier).catch(() => undefined)
+  if (snapshot) {
+    console.log("Loaded models.dev snapshot from @opencode-ai/models")
+    return JSON.stringify(snapshot.providers)
+  }
+
+  console.log("Loaded no models.dev snapshot")
+  return "undefined"
+}
+
+export const modelsData = await loadModelsData()

--- a/packages/opencode/src/cli/cmd/run/footer.subagent.tsx
+++ b/packages/opencode/src/cli/cmd/run/footer.subagent.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource @opentui/solid */
 import type { ScrollBoxRenderable } from "@opentui/core"
 import { useKeyboard } from "@opentui/solid"
-import "opentui-spinner/solid"
+import "./spinner-register"
 import { Show, createMemo, indexArray } from "solid-js"
 import { SPINNER_FRAMES } from "@opencode-ai/tui/component/spinner"
 import { RunEntryContent, separatorRows } from "./scrollback.writer"

--- a/packages/opencode/src/cli/cmd/run/footer.view.tsx
+++ b/packages/opencode/src/cli/cmd/run/footer.view.tsx
@@ -10,7 +10,7 @@
 /** @jsxImportSource @opentui/solid */
 import { useTerminalDimensions } from "@opentui/solid"
 import { For, Match, Show, Switch, createEffect, createMemo, createSignal, onCleanup } from "solid-js"
-import "opentui-spinner/solid"
+import "./spinner-register"
 import { createColors, createFrames } from "@opencode-ai/tui/ui/spinner"
 import {
   RUN_SUBAGENT_PANEL_ROWS,

--- a/packages/opencode/src/cli/cmd/run/spinner-register.ts
+++ b/packages/opencode/src/cli/cmd/run/spinner-register.ts
@@ -1,0 +1,15 @@
+import { extend } from "@opentui/solid"
+import { SpinnerRenderable } from "opentui-spinner"
+import "opentui-spinner/solid"
+
+// Explicit registration is load-bearing. `bun build` on a Windows host drops
+// the side-effect-only `opentui-spinner/solid` import (its package.json
+// `sideEffects` path glob does not match backslash paths), so `<spinner>`
+// crashed with "[Reconciler] Unknown component type: spinner" on Windows.
+// The explicit extend() below survives tree-shaking and fixes it.
+//
+// The retained side-effect import is NOT redundant: it provides JSX type
+// augmentation for `<spinner>` in the Solid JSX runtime. At runtime it also
+// re-registers, but extend() is Object.assign over a flat catalogue, so the
+// duplicate registration is harmless.
+extend({ spinner: SpinnerRenderable })

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1103,7 +1103,7 @@ export class InitError extends Schema.TaggedErrorClass<InitError>()("ProviderIni
 
 export class NoProvidersError extends Schema.TaggedErrorClass<NoProvidersError>()("ProviderNoProvidersError", {}) {
   override get message() {
-    return "No providers are available"
+    return "No providers are available. Configure a provider or restore network access to load the model catalog."
   }
 
   static isInstance(input: unknown): input is NoProvidersError {
@@ -1115,7 +1115,7 @@ export class NoModelsError extends Schema.TaggedErrorClass<NoModelsError>()("Pro
   providerID: ProviderV2.ID,
 }) {
   override get message() {
-    return `No models are available for provider: ${this.providerID}`
+    return `No models are available for provider: ${this.providerID}. Configure a model for this provider or restore network access to load the model catalog.`
   }
 
   static isInstance(input: unknown): input is NoModelsError {

--- a/packages/opencode/src/server/routes/instance/httpapi/middleware/error.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/middleware/error.ts
@@ -1,5 +1,6 @@
 import { NamedError } from "@opencode-ai/core/util/error"
 import { ConfigErrorV1 } from "@opencode-ai/core/v1/config/error"
+import { Provider } from "@/provider/provider"
 import { Cause, Effect } from "effect"
 import { HttpRouter, HttpServerError, HttpServerRespondable, HttpServerResponse } from "effect/unstable/http"
 
@@ -23,6 +24,14 @@ export const errorLayer = HttpRouter.middleware<{ handles: unknown }>()((effect)
         ConfigErrorV1.DirectoryTypoError.isInstance(error)
       ) {
         return Effect.succeed(HttpServerResponse.jsonUnsafe(error.toObject(), { status: 400 }))
+      }
+
+      // Degraded-state provider failures (e.g. offline with empty model catalog) must surface as
+      // named, actionable errors instead of the generic 500 defect path.
+      if (Provider.NoProvidersError.isInstance(error) || Provider.NoModelsError.isInstance(error)) {
+        return Effect.succeed(
+          HttpServerResponse.jsonUnsafe({ name: error._tag, data: { message: error.message } }, { status: 400 }),
+        )
       }
 
       const ref = `err_${crypto.randomUUID().slice(0, 8)}`

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -786,7 +786,16 @@ export const layer = Layer.effect(
         .findMessage(sessionID, (m) => m.info.role === "user" && !!m.info.model)
         .pipe(Effect.orDie)
       if (Option.isSome(match) && match.value.info.role === "user") return match.value.info.model
-      return yield* provider.defaultModel().pipe(Effect.orDie)
+      const exit = yield* provider.defaultModel().pipe(Effect.exit)
+      if (Exit.isSuccess(exit)) return exit.value
+      const err = Cause.squash(exit.cause)
+      if (Provider.NoProvidersError.isInstance(err) || Provider.NoModelsError.isInstance(err)) {
+        yield* events.publish(Session.Event.Error, {
+          sessionID,
+          error: new NamedError.Unknown({ message: err.message }).toObject(),
+        })
+      }
+      return yield* Effect.die(err)
     })
 
     const createUserMessage = Effect.fn("SessionPrompt.createUserMessage")(function* (input: PromptInput) {

--- a/packages/opencode/test/event-manifest.test.ts
+++ b/packages/opencode/test/event-manifest.test.ts
@@ -10,7 +10,7 @@ describe("public event manifest", () => {
     expect(EventManifest.Definitions).toBe(SchemaEventManifest.Definitions)
     expect(EventManifest.Latest).toBe(SchemaEventManifest.Latest)
     expect(EventManifest.Durable).toBe(SchemaEventManifest.Durable)
-    expect(EventManifest.Latest.size).toBe(90)
+    expect(EventManifest.Latest.size).toBe(91)
     expect(EventManifest.Latest.get("session.next.step.ended")).toBe(SessionEvent.Step.Ended)
     expect(EventManifest.Latest.get("todo.updated")).toBe(Todo.Event.Updated)
     expect(EventManifest.Latest.get("goal.updated")).toBe(GoalEvent.Updated)

--- a/packages/opencode/test/server/httpapi-error-middleware.test.ts
+++ b/packages/opencode/test/server/httpapi-error-middleware.test.ts
@@ -2,9 +2,11 @@ import { NodeHttpServer, NodeServices } from "@effect/platform-node"
 import { NamedError } from "@opencode-ai/core/util/error"
 import { describe, expect } from "bun:test"
 import { ConfigErrorV1 } from "@opencode-ai/core/v1/config/error"
+import { ProviderV2 } from "@opencode-ai/core/provider"
 import { Effect, Layer } from "effect"
 import { HttpClient, HttpClientRequest, HttpRouter } from "effect/unstable/http"
 import { errorLayer } from "../../src/server/routes/instance/httpapi/middleware/error"
+import { Provider } from "../../src/provider/provider"
 import { NotFoundError } from "../../src/storage/storage"
 import { testEffect } from "../lib/effect"
 
@@ -96,6 +98,45 @@ describe("HttpApi error middleware", () => {
 
       expect(response.status).toBe(500)
       expectUnknownErrorBody(body)
+    }),
+  )
+
+  it.live("returns provider no-providers defects as named actionable client errors", () =>
+    Effect.gen(function* () {
+      yield* HttpRouter.add("GET", "/no-providers", Effect.die(new Provider.NoProvidersError({}))).pipe(
+        Layer.provide(errorLayer),
+        HttpRouter.serve,
+        Layer.build,
+      )
+
+      const response = yield* HttpClientRequest.get("/no-providers").pipe(HttpClient.execute)
+      const body = yield* response.json
+
+      expect(response.status).toBe(400)
+      expect(body).toMatchObject({
+        name: "ProviderNoProvidersError",
+        data: { message: new Provider.NoProvidersError({}).message },
+      })
+    }),
+  )
+
+  it.live("returns provider no-models defects as named actionable client errors", () =>
+    Effect.gen(function* () {
+      const error = new Provider.NoModelsError({ providerID: ProviderV2.ID.make("anthropic") })
+      yield* HttpRouter.add("GET", "/no-models", Effect.die(error)).pipe(
+        Layer.provide(errorLayer),
+        HttpRouter.serve,
+        Layer.build,
+      )
+
+      const response = yield* HttpClientRequest.get("/no-models").pipe(HttpClient.execute)
+      const body = yield* response.json
+
+      expect(response.status).toBe(400)
+      expect(body).toMatchObject({
+        name: "ProviderNoModelsError",
+        data: { message: error.message },
+      })
     }),
   )
 })

--- a/packages/schema/src/models-dev.ts
+++ b/packages/schema/src/models-dev.ts
@@ -1,9 +1,18 @@
 export * as ModelsDev from "./models-dev"
 
+import { Schema } from "effect"
 import { define, inventory } from "./event"
 
 const Refreshed = define({
   type: "models-dev.refreshed",
   schema: {},
 })
-export const Event = { Refreshed, Definitions: inventory(Refreshed) }
+
+const FetchFailed = define({
+  type: "models-dev.fetch_failed",
+  schema: {
+    source: Schema.String,
+  },
+})
+
+export const Event = { Refreshed, FetchFailed, Definitions: inventory(Refreshed, FetchFailed) }

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -6,6 +6,7 @@ export type ClientOptions = {
 
 export type Event =
   | EventModelsDevRefreshed
+  | EventModelsDevFetchFailed
   | EventIntegrationUpdated
   | EventIntegrationConnectionUpdated
   | EventCatalogUpdated
@@ -754,6 +755,13 @@ export type GlobalEvent = {
         type: "models-dev.refreshed"
         properties: {
           [key: string]: unknown
+        }
+      }
+    | {
+        id: string
+        type: "models-dev.fetch_failed"
+        properties: {
+          source: string
         }
       }
     | {
@@ -2829,6 +2837,7 @@ export type ProviderNotFoundError = {
 
 export type V2Event =
   | V2EventModelsDevRefreshed
+  | V2EventModelsDevFetchFailed
   | V2EventIntegrationUpdated
   | V2EventIntegrationConnectionUpdated
   | V2EventCatalogUpdated
@@ -4392,6 +4401,23 @@ export type V2EventModelsDevRefreshed = {
   type: "models-dev.refreshed"
   data: {
     [key: string]: unknown
+  }
+}
+
+export type V2EventModelsDevFetchFailed = {
+  id: string
+  metadata?: {
+    [key: string]: unknown
+  }
+  durable?: {
+    aggregateID: string
+    seq: number
+    version: number
+  }
+  location?: LocationRef
+  type: "models-dev.fetch_failed"
+  data: {
+    source: string
   }
 }
 
@@ -6257,6 +6283,14 @@ export type EventModelsDevRefreshed = {
   type: "models-dev.refreshed"
   properties: {
     [key: string]: unknown
+  }
+}
+
+export type EventModelsDevFetchFailed = {
+  id: string
+  type: "models-dev.fetch_failed"
+  properties: {
+    source: string
   }
 }
 

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -83,6 +83,7 @@ import * as TuiAudio from "./audio"
 import { win32DisableProcessedInput, win32FlushInputBuffer } from "./terminal-win32"
 import { destroyRenderer } from "./util/renderer"
 import { cliErrorMessage, errorFormat } from "./util/error"
+import { TuiLog } from "./util/log"
 
 const appGlobalBindingCommands = [
   "session.list",
@@ -182,6 +183,10 @@ export const run = Effect.fn("Tui.run")(function* (input: TuiInput) {
   const exit = { epilogue: undefined as string | undefined, reason: undefined as unknown }
   const result = yield* Effect.scoped(
     Effect.gen(function* () {
+      yield* Effect.acquireRelease(
+        Effect.sync(() => TuiLog.installConsoleRedirect()),
+        (restoreConsole) => Effect.sync(restoreConsole),
+      )
       const renderer = yield* Effect.acquireRelease(
         Effect.tryPromise(() =>
           createCliRenderer({
@@ -214,7 +219,7 @@ export const run = Effect.fn("Tui.run")(function* (input: TuiInput) {
           try {
             await input.pluginHost.dispose()
           } catch (error) {
-            console.error("Failed to dispose TUI plugins", error)
+            TuiLog.write("error", "Failed to dispose TUI plugins", error)
           }
         }),
       )
@@ -403,7 +408,7 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
       dispose: () => attention.dispose(),
     })
     .catch((error) => {
-      console.error("Failed to load TUI plugins", error)
+      TuiLog.write("error", "Failed to load TUI plugins", error)
     })
     .finally(() => {
       setReady(true)
@@ -999,8 +1004,17 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
     })
   })
 
+  event.on("models-dev.fetch_failed", (evt) => {
+    toast.show({
+      variant: "warning",
+      title: "Model catalog unavailable",
+      message: `${evt.properties.source} is unreachable. Using cached or configured providers only. See ${TuiLog.logFilePath()} for details.`,
+      duration: 8000,
+    })
+  })
+
   event.on("installation.update-available", async (evt) => {
-    console.log("installation.update-available", evt)
+    TuiLog.write("log", "installation.update-available", evt)
     const version = evt.properties.version
 
     const skipped = kv.get("skipped_version")

--- a/packages/tui/src/component/dialog-mcp.tsx
+++ b/packages/tui/src/component/dialog-mcp.tsx
@@ -6,6 +6,7 @@ import { DialogSelect, type DialogSelectRef, type DialogSelectOption } from "../
 import { useTheme } from "../context/theme"
 import { TextAttributes } from "@opentui/core"
 import { useSDK } from "../context/sdk"
+import { TuiLog } from "../util/log"
 
 function Status(props: { enabled: boolean; loading: boolean }) {
   const { theme } = useTheme()
@@ -60,10 +61,10 @@ export function DialogMcp() {
           if (status.data) {
             sync.set("mcp", status.data)
           } else {
-            console.error("Failed to refresh MCP status: no data returned")
+            TuiLog.write("error", "Failed to refresh MCP status: no data returned")
           }
         } catch (error) {
-          console.error("Failed to toggle MCP:", error)
+          TuiLog.write("error", "Failed to toggle MCP", error)
         } finally {
           setLoading(null)
         }

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -56,6 +56,7 @@ import { useTuiConfig } from "../../config"
 import { usePromptWorkspace } from "./workspace"
 import { usePromptMove } from "./move"
 import { readLocalAttachment } from "./local-attachment"
+import { TuiLog } from "../../util/log"
 
 export type PromptProps = {
   sessionID?: string
@@ -1004,10 +1005,11 @@ export function Prompt(props: PromptProps) {
 
       if (res.error) {
         if (finishMoveProgress) move.finishSubmit()
-        console.log("Creating a session failed:", res.error)
+        TuiLog.write("error", "Creating a session failed", res.error)
 
         toast.show({
-          message: "Creating a session failed. Open console for more details.",
+          title: "Creating a session failed",
+          message: errorMessage(res.error),
           variant: "error",
         })
 

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -10,7 +10,7 @@ import {
 } from "@opentui/core"
 import type { CommandContext } from "@opentui/keymap"
 import { createEffect, createMemo, onMount, createSignal, onCleanup, on, Show, Switch, Match } from "solid-js"
-import "opentui-spinner/solid"
+import "../../ui/spinner-register"
 import path from "path"
 import { fileURLToPath } from "url"
 import { useLocal } from "../../context/local"

--- a/packages/tui/src/component/spinner.tsx
+++ b/packages/tui/src/component/spinner.tsx
@@ -3,7 +3,7 @@ import { useTheme } from "../context/theme"
 import { useKV } from "../context/kv"
 import type { JSX } from "@opentui/solid"
 import type { RGBA } from "@opentui/core"
-import "opentui-spinner/solid"
+import "../ui/spinner-register"
 
 export const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
 

--- a/packages/tui/src/context/data.tsx
+++ b/packages/tui/src/context/data.tsx
@@ -20,6 +20,7 @@ import type {
 } from "@opencode-ai/sdk/v2"
 import { createStore, produce } from "solid-js/store"
 import { createSimpleContext } from "./helper"
+import { TuiLog } from "../util/log"
 import { useSDK } from "./sdk"
 import { useEvent } from "./event"
 import { createSignal, onCleanup, onMount } from "solid-js"
@@ -560,7 +561,7 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
         result.location.skill.refresh(),
       ]).then((settled) => {
         for (const failure of settled.filter((item) => item.status === "rejected"))
-          console.error("Failed to refresh default location data", failure.reason)
+          TuiLog.write("error", "Failed to refresh default location data", failure.reason)
       })
     })
 

--- a/packages/tui/src/context/kv.tsx
+++ b/packages/tui/src/context/kv.tsx
@@ -5,6 +5,7 @@ import { Flock } from "@opencode-ai/core/util/flock"
 import { Global } from "@opencode-ai/core/global"
 import { readJson, writeJsonAtomic } from "../util/persistence"
 import { useTuiPaths } from "./runtime"
+import { TuiLog } from "../util/log"
 import path from "path"
 
 export const { use: useKV, provider: KVProvider } = createSimpleContext({
@@ -24,7 +25,7 @@ export const { use: useKV, provider: KVProvider } = createSimpleContext({
         setStore(x)
       })
       .catch((error) => {
-        console.error("Failed to read KV state", { error })
+        TuiLog.write("error", "Failed to read KV state", { error })
       })
       .finally(() => {
         setReady(true)
@@ -57,7 +58,7 @@ export const { use: useKV, provider: KVProvider } = createSimpleContext({
         write = write
           .then(() => Flock.withLock(lock, () => writeJsonAtomic(file, snapshot)))
           .catch((error) => {
-            console.error("Failed to write KV state", { error })
+            TuiLog.write("error", "Failed to write KV state", { error })
           })
       },
     }

--- a/packages/tui/src/context/sync.tsx
+++ b/packages/tui/src/context/sync.tsx
@@ -32,6 +32,7 @@ import { useArgs } from "./args"
 import { batch, onMount } from "solid-js"
 import path from "path"
 import { useKV } from "./kv"
+import { TuiLog } from "../util/log"
 
 const emptyConsoleState: ConsoleState = {
   consoleManagedProviders: [],
@@ -534,7 +535,7 @@ export const {
           })
         })
         .catch(async (e) => {
-          console.error("tui bootstrap failed", {
+          TuiLog.write("error", "tui bootstrap failed", {
             error: e instanceof Error ? e.message : String(e),
             name: e instanceof Error ? e.name : undefined,
             stack: e instanceof Error ? e.stack : undefined,

--- a/packages/tui/src/plugin/command-shim.ts
+++ b/packages/tui/src/plugin/command-shim.ts
@@ -2,6 +2,7 @@
 import type { TuiCommand, TuiPluginApi } from "@opencode-ai/plugin/tui"
 import { TuiKeybind } from "../config/keybind"
 import type { DialogContext } from "../ui/dialog"
+import { TuiLog } from "../util/log"
 
 const COMMAND_PALETTE_SHOW = "command.palette.show"
 const warned = new Set<string>()
@@ -13,7 +14,7 @@ type LegacyKeybinds = TuiPluginApi["tuiConfig"]["keybinds"]
 
 function warnCommandShim(api: string, replacement: string) {
   // Warn v1 plugins about deprecated `api.command`; remove this shim path in v2.
-  console.warn("[tui.plugin] deprecated TUI plugin API", { api, replacement })
+  TuiLog.write("warn", "[tui.plugin] deprecated TUI plugin API", { api, replacement })
 }
 
 function createCommandShimDialog(dialog: CommandShimDialog): LegacyDialog {

--- a/packages/tui/src/plugin/slots.tsx
+++ b/packages/tui/src/plugin/slots.tsx
@@ -2,6 +2,7 @@ import type { TuiPluginApi, TuiSlotContext, TuiSlotMap, TuiSlotProps } from "@op
 import { createSlot, createSolidSlotRegistry, type JSX, type SolidPlugin } from "@opentui/solid"
 import { createSignal } from "solid-js"
 import { isRecord } from "../util/record"
+import { TuiLog } from "../util/log"
 
 type RuntimeSlotMap = TuiSlotMap<Record<string, object>>
 type SlotView = <Name extends string>(props: TuiSlotProps<Name>) => JSX.Element | null
@@ -35,7 +36,7 @@ export function createSlots() {
         { theme: api.theme },
         {
           onPluginError(event) {
-            console.error("[tui.slot] plugin error", {
+            TuiLog.write("error", "[tui.slot] plugin error", {
               plugin: event.pluginId,
               slot: event.slot,
               phase: event.phase,

--- a/packages/tui/src/ui/spinner-register.ts
+++ b/packages/tui/src/ui/spinner-register.ts
@@ -1,0 +1,15 @@
+import { extend } from "@opentui/solid"
+import { SpinnerRenderable } from "opentui-spinner"
+import "opentui-spinner/solid"
+
+// Explicit registration is load-bearing. `bun build` on a Windows host drops
+// the side-effect-only `opentui-spinner/solid` import (its package.json
+// `sideEffects` path glob does not match backslash paths), so `<spinner>`
+// crashed with "[Reconciler] Unknown component type: spinner" on Windows.
+// The explicit extend() below survives tree-shaking and fixes it.
+//
+// The retained side-effect import is NOT redundant: it provides JSX type
+// augmentation for `<spinner>` in the Solid JSX runtime. At runtime it also
+// re-registers, but extend() is Object.assign over a flat catalogue, so the
+// duplicate registration is harmless.
+extend({ spinner: SpinnerRenderable })

--- a/packages/tui/src/util/log.ts
+++ b/packages/tui/src/util/log.ts
@@ -1,0 +1,49 @@
+import { Global } from "@opencode-ai/core/global"
+import fs from "fs/promises"
+import path from "path"
+import { formatWithOptions } from "util"
+
+type ConsoleMethod = "log" | "warn" | "error"
+
+const levelName = {
+  log: "INFO",
+  warn: "WARN",
+  error: "ERROR",
+} satisfies Record<ConsoleMethod, string>
+
+const original = {
+  log: console.log,
+  warn: console.warn,
+  error: console.error,
+}
+
+let installed = false
+
+export function logFilePath() {
+  return path.join(Global.Path.log, "opencode.log")
+}
+
+export function write(level: ConsoleMethod, ...args: unknown[]) {
+  void fs
+    .appendFile(
+      logFilePath(),
+      `${new Date().toISOString()} level=${levelName[level]} component=tui ${args.length ? formatWithOptions({ colors: false, depth: 8 }, ...args) : ""}\n`,
+    )
+    .catch(() => {})
+}
+
+export function installConsoleRedirect() {
+  if (installed) return () => {}
+  installed = true
+  console.log = (...args) => write("log", ...args)
+  console.warn = (...args) => write("warn", ...args)
+  console.error = (...args) => write("error", ...args)
+  return () => {
+    console.log = original.log
+    console.warn = original.warn
+    console.error = original.error
+    installed = false
+  }
+}
+
+export * as TuiLog from "./log"


### PR DESCRIPTION
# Release 1.17.11 — dev → main

Promotes the `1.17.11` prerelease line to `main` after prerelease validation. All three changes below shipped in `v1.17.11-dev.11`, built green across linux/macOS/Windows, and **Windows end-to-end smoke testing passed** (spinner crash resolved, conversation working).

## Changes

### 1. Offline model catalog startup (#88, #89)

`fix: support offline model catalog startup` · `fix(server): map provider defects to named 4xx for offline catalog`

- Models.dev catalog can be fetched/served when offline or unreachable, with graceful fallback to a bundled snapshot.
- Provider defects during catalog loading are now mapped to named 4xx responses instead of surfacing as generic 500s, so the client can react appropriately.
- Adds `models-dev` snapshot tests (`packages/core/test/models-dev.test.ts`) and an httpapi error-middleware test.

### 2. Windows spinner catalogue dedupe (#90)

`fix(tui): dedupe @opentui/solid in Windows hoisted install`

- Removed stale nested `@opentui/{core,solid}@0.4.2` lockfile entries under `opentui-spinner` that caused Windows CI's hoisted linker to materialize a second `@opentui/solid` instance. The bundle then held two `componentCatalogue` modules; the spinner's `extend()` registered into the wrong copy, crashing with `[Reconciler] Unknown component type: spinner`.
- macOS/Linux were unaffected (isolated linker symlinks to the shared 0.4.3 instance).
- This was the first of two spinner fixes — it fixed the duplicate-instance path but the Windows crash persisted for a second reason (see #91).

### 3. Windows spinner tree-shaking fix (#91) ⭐ root cause

`fix(tui): explicitly register spinner to survive Windows tree-shaking`

- **Root cause of the persistent Windows crash.** On a Windows builder, `bun build` dropped the side-effect-only `import "opentui-spinner/solid"` because that package's `sideEffects` path glob (`./dist/solid.mjs`) does not match backslash paths on a Windows host. The `extend({ spinner })` call inside never executed, so the reconciler had no `spinner` component registered → crash on first `<spinner>` render.
- macOS/Linux matched fine (forward-slash paths), which is why only Windows crashed and why #90 alone was insufficient.
- **Fix:** register the spinner explicitly via `extend({ spinner: SpinnerRenderable })` in local modules (`packages/tui/src/ui/spinner-register.ts`, `packages/opencode/src/cli/cmd/run/spinner-register.ts`) imported by every `<spinner>` render path. The explicit call carries a real value dependency the bundler cannot tree-shake. Mirrors the existing `extend({ go_upsell_art })` pattern in `bg-pulse.tsx`.
- **Verified against the released v1.17.11-dev.11 Windows artifact:** `opencode.exe` now contains the spinner runtime code (`Spinner interval must be a finite` present, was absent in dev.10).
- **Windows end-to-end smoke test passed** — spinner renders, conversation works, no crash.

## Diff scope

25 files, +439/-58. Touches `packages/{core,opencode,schema,sdk,tui}` plus `.github/workflows/release-fork.yml` and `bun.lock`.

## Gate

This PR is gated on the **full main quality gate**: Typecheck + Unit Tests (linux) + E2E Tests (linux) + E2E Tests (windows).

## Post-merge

Once merged to `main`, a manual `release-fork` run from `main` will produce the formal `v1.17.11` release (non-prerelease).

## Notes

- These changes have already been validated via the `v1.17.11-dev.11` prerelease (built from `dev`).
- A separate, unrelated `bundled plugin SDK` work unit exists on a local branch but is **not** part of this PR.