### PR TITLE
fix(test): update event manifest count for models-dev.fetch_failed

### DIFF
--- a/packages/opencode/test/event-manifest.test.ts
+++ b/packages/opencode/test/event-manifest.test.ts
@@ -10,7 +10,7 @@ describe("public event manifest", () => {
     expect(EventManifest.Definitions).toBe(SchemaEventManifest.Definitions)
     expect(EventManifest.Latest).toBe(SchemaEventManifest.Latest)
     expect(EventManifest.Durable).toBe(SchemaEventManifest.Durable)
-    expect(EventManifest.Latest.size).toBe(90)
+    expect(EventManifest.Latest.size).toBe(91)
     expect(EventManifest.Latest.get("session.next.step.ended")).toBe(SessionEvent.Step.Ended)
     expect(EventManifest.Latest.get("todo.updated")).toBe(Todo.Event.Updated)
     expect(EventManifest.Latest.get("goal.updated")).toBe(GoalEvent.Updated)


### PR DESCRIPTION
## Problem

The dev → main PR (#92) fails :

```
expect(EventManifest.Latest.size).toBe(90)
Expected: 90
Received: 91
  at event-manifest.test.ts:13
```

## Root cause

The offline catalog startup work (#88) added a new `models-dev.fetch_failed` event to `ModelsDev.Event.Definitions` (`packages/schema/src/models-dev.ts`). That event has no `durable` field, so it lands in `EventManifest.Latest`, bumping `Latest.size` from 90 to 91. The count assertion in `event-manifest.test.ts` was not updated.

## Fix

Update the assertion from `.toBe(90)` to `.toBe(91)`.

## Verification

```
bun test test/event-manifest.test.ts
  2 pass, 0 fail
bun typecheck (packages/opencode)
  PASS
```