### PR TITLE
fix(core): bundle plugin SDK and degrade references for offline startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,8 @@ tsconfig.tsbuildinfo
 
 # OpenSpec artifacts (local-only, not tracked)
 /openspec/
+.opencode/commands/
+.opencode/skills/
 
 # hooks file
 .opencode/hooks.json

--- a/packages/core/src/npm.ts
+++ b/packages/core/src/npm.ts
@@ -11,12 +11,21 @@ import { LayerNode } from "./effect/layer-node"
 import { filesystem } from "./effect/layer-node-platform"
 import { makeRuntime } from "./effect/runtime"
 import { NpmConfig } from "./npm-config"
+import { PluginSdk } from "./plugin-sdk"
 
 export class InstallFailedError extends Schema.TaggedErrorClass<InstallFailedError>()("NpmInstallFailedError", {
   add: Schema.Array(Schema.String).pipe(Schema.optional),
   dir: Schema.String,
   cause: Schema.optional(Schema.Defect()),
 }) {}
+
+export class BundledPackageUnavailableError extends Schema.TaggedErrorClass<BundledPackageUnavailableError>()(
+  "NpmBundledPackageUnavailableError",
+  {
+    name: Schema.String,
+    path: Schema.String,
+  },
+) {}
 
 export interface EntryPoint {
   readonly directory: string
@@ -66,6 +75,10 @@ interface ArboristNode {
 
 interface ArboristTree {
   edgesOut: Map<string, { to?: ArboristNode }>
+}
+
+function packagePath(dir: string, name: string) {
+  return path.join(dir, "node_modules", ...name.split("/"))
 }
 
 export const layer = Layer.effect(
@@ -142,12 +155,86 @@ export const layer = Layer.effect(
       )
       if (!canWrite) return
 
-      const add = input?.add.map((pkg) => [pkg.name, pkg.version].filter(Boolean).join("@")) ?? []
+      const requested = input?.add ?? []
+      const add = requested.map((pkg) => [pkg.name, pkg.version].filter(Boolean).join("@"))
+      const remaining: typeof requested = []
+
+      for (const pkg of requested) {
+        if (pkg.name !== PluginSdk.packageName) {
+          remaining.push(pkg)
+          continue
+        }
+
+        const target = packagePath(dir, pkg.name)
+        if (yield* afs.existsSafe(target)) {
+          yield* Effect.logInfo("npm dependency source selected", {
+            source: "project-local",
+            dir,
+            package: pkg.name,
+            version: pkg.version,
+            target,
+          })
+          continue
+        }
+
+        const bundled = PluginSdk.bundledPath()
+        if (yield* afs.existsSafe(path.join(bundled, "package.json"))) {
+          yield* fs.makeDirectory(path.dirname(target), { recursive: true }).pipe(Effect.orElseSucceed(() => undefined))
+          yield* fs.copy(bundled, target).pipe(
+            Effect.tap(() =>
+              Effect.logInfo("npm dependency source selected", {
+                source: "bundled",
+                dir,
+                package: pkg.name,
+                version: pkg.version,
+                bundled,
+                target,
+              }),
+            ),
+            Effect.catch((cause) =>
+              Effect.logWarning("npm bundled dependency unavailable", {
+                source: "unavailable",
+                dir,
+                package: pkg.name,
+                version: pkg.version,
+                bundled,
+                target,
+                cause,
+              }            ).pipe(Effect.andThen(Effect.sync(() => remaining.push(pkg)))),
+            ),
+          )
+          continue
+        }
+
+        yield* Effect.logWarning("npm bundled dependency unavailable", {
+          source: "unavailable",
+          dir,
+          package: pkg.name,
+          version: pkg.version,
+          bundled,
+          cause: new BundledPackageUnavailableError({ name: pkg.name, path: bundled }),
+        })
+        remaining.push(pkg)
+      }
+
+      if (remaining.length !== requested.length) {
+        yield* fs.remove(path.join(dir, "package-lock.json")).pipe(Effect.orElseSucceed(() => undefined))
+      }
+
+      if (remaining.length) {
+        yield* Effect.logInfo("npm dependency source selected", {
+          source: "registry",
+          dir,
+          packages: remaining.map((pkg) => ({ name: pkg.name, version: pkg.version })),
+        })
+      }
+
+      const installAdd = remaining.map((pkg) => [pkg.name, pkg.version].filter(Boolean).join("@"))
       if (
         yield* Effect.gen(function* () {
           const nodeModulesExists = yield* afs.existsSafe(path.join(dir, "node_modules"))
           if (!nodeModulesExists) {
-            yield* reify({ add, dir })
+            yield* reify({ add: installAdd, dir })
             return true
           }
           return false
@@ -166,7 +253,7 @@ export const layer = Layer.effect(
           ...Object.keys(pkgAny?.devDependencies || {}),
           ...Object.keys(pkgAny?.peerDependencies || {}),
           ...Object.keys(pkgAny?.optionalDependencies || {}),
-          ...(input?.add || []).map((pkg) => pkg.name),
+          ...remaining.map((pkg) => pkg.name),
         ])
 
         const root = lockAny?.packages?.[""] || {}
@@ -179,7 +266,7 @@ export const layer = Layer.effect(
 
         for (const name of declared) {
           if (!locked.has(name)) {
-            yield* reify({ dir, add })
+            yield* reify({ dir, add: installAdd })
             return
           }
         }

--- a/packages/core/src/plugin-sdk.ts
+++ b/packages/core/src/plugin-sdk.ts
@@ -1,0 +1,11 @@
+export * as PluginSdk from "./plugin-sdk"
+
+import path from "path"
+
+export const packageName = "@opencode-ai/plugin"
+export const vendorPath = path.join("vendor", "npm", "@opencode-ai", "plugin")
+
+export function bundledPath(base = path.dirname(process.execPath)) {
+  if (process.env.OPENCODE_PLUGIN_SDK_PATH) return process.env.OPENCODE_PLUGIN_SDK_PATH
+  return path.join(base, vendorPath)
+}

--- a/packages/core/src/reference.ts
+++ b/packages/core/src/reference.ts
@@ -1,5 +1,6 @@
 export * as Reference from "./reference"
 
+import { existsSync } from "fs"
 import { Context, Effect, Layer, Scope, Types } from "effect"
 import { Reference } from "@opencode-ai/schema/reference"
 import { Global } from "./global"
@@ -84,21 +85,44 @@ export const layer = Layer.effect(
             const target = Repository.cachePath(global.repos, repository)
             if (seen.has(target) && seen.get(target) !== source.branch) continue
             seen.set(target, source.branch)
-            materialized.set(
-              name,
-              new Info({
+            if (existsSync(target)) {
+              materialized.set(
                 name,
-                path: AbsolutePath.make(target),
-                description: source.description,
-                hidden: source.hidden,
-                source,
-              }),
-            )
+                new Info({
+                  name,
+                  path: AbsolutePath.make(target),
+                  description: source.description,
+                  hidden: source.hidden,
+                  source,
+                }),
+              )
+            } else {
+              yield* Effect.logWarning("reference unavailable", {
+                name,
+                repository: source.repository,
+                branch: source.branch,
+                reason: "no cached materialization",
+              })
+            }
             yield* cache.ensure({ reference: repository, branch: source.branch, refresh: true }).pipe(
+              Effect.tap((result) => {
+                materialized.set(
+                  name,
+                  new Info({
+                    name,
+                    path: AbsolutePath.make(result.localPath),
+                    description: source.description,
+                    hidden: source.hidden,
+                    source,
+                  }),
+                )
+                return events.publish(Event.Updated, {})
+              }),
               Effect.catchCause((cause) =>
-                Effect.logWarning("failed to materialize reference", {
+                Effect.logWarning("reference unavailable", {
                   name,
                   repository: source.repository,
+                  branch: source.branch,
                   cause,
                 }),
               ),

--- a/packages/core/test/npm.test.ts
+++ b/packages/core/test/npm.test.ts
@@ -6,6 +6,7 @@ import { Effect, Layer, Option } from "effect"
 import { FSUtil } from "@opencode-ai/core/fs-util"
 import { Global } from "@opencode-ai/core/global"
 import { Npm } from "@opencode-ai/core/npm"
+import { PluginSdk } from "@opencode-ai/core/plugin-sdk"
 import { EffectFlock } from "@opencode-ai/core/util/effect-flock"
 import { tmpdir } from "./fixture/tmpdir"
 
@@ -87,5 +88,40 @@ describe("Npm.install", () => {
 
     await expect(fs.stat(path.join(tmp.path, "node_modules", "prod-pkg"))).resolves.toBeDefined()
     await expect(fs.stat(path.join(tmp.path, "node_modules", "dev-pkg"))).rejects.toThrow()
+  })
+
+  test("skips registry when plugin dependency already exists locally", async () => {
+    await using tmp = await tmpdir()
+    await fs.mkdir(path.join(tmp.path, "node_modules", "@opencode-ai", "plugin"), { recursive: true })
+    await writePackage(path.join(tmp.path, "node_modules", "@opencode-ai", "plugin"), { name: "@opencode-ai/plugin" })
+
+    await Effect.gen(function* () {
+      const npm = yield* Npm.Service
+      yield* npm.install(tmp.path, { add: [{ name: "@opencode-ai/plugin", version: "1.17.11-main.3" }] })
+    }).pipe(Effect.scoped, Effect.provide(npmLayer(path.join(tmp.path, "cache"))), Effect.runPromise)
+
+    await expect(fs.stat(path.join(tmp.path, "package-lock.json"))).rejects.toThrow()
+  })
+
+  test("copies bundled plugin dependency before registry fallback", async () => {
+    await using tmp = await tmpdir()
+    const bundled = path.join(tmp.path, "bundled-plugin-sdk")
+    process.env.OPENCODE_PLUGIN_SDK_PATH = bundled
+    await fs.mkdir(path.join(bundled, "src"), { recursive: true })
+    await writePackage(bundled, { name: "@opencode-ai/plugin", exports: { ".": "./src/index.ts", "./tui": "./src/tui.ts" } })
+    await Bun.write(path.join(bundled, "src", "index.ts"), "export const plugin = true\n")
+    await Bun.write(path.join(bundled, "src", "tui.ts"), "export const tui = true\n")
+
+    try {
+      await Effect.gen(function* () {
+        const npm = yield* Npm.Service
+        yield* npm.install(tmp.path, { add: [{ name: "@opencode-ai/plugin" }] })
+      }).pipe(Effect.scoped, Effect.provide(npmLayer(path.join(tmp.path, "cache"))), Effect.runPromise)
+
+      await expect(fs.stat(path.join(tmp.path, "node_modules", "@opencode-ai", "plugin", "src", "tui.ts"))).resolves.toBeDefined()
+      await expect(fs.stat(path.join(tmp.path, "package-lock.json"))).rejects.toThrow()
+    } finally {
+      delete process.env.OPENCODE_PLUGIN_SDK_PATH
+    }
   })
 })

--- a/packages/core/test/reference.test.ts
+++ b/packages/core/test/reference.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect } from "bun:test"
+import fs from "fs/promises"
+import path from "path"
 import { Effect, Exit, Layer, Scope } from "effect"
 import { AbsolutePath } from "@opencode-ai/core/schema"
 import { Global } from "@opencode-ai/core/global"
@@ -7,6 +9,7 @@ import { Repository } from "@opencode-ai/core/repository"
 import { RepositoryCache } from "@opencode-ai/core/repository-cache"
 import { EventV2 } from "@opencode-ai/core/event"
 import { it } from "./lib/effect"
+import { tmpdir } from "./fixture/tmpdir"
 
 const cache = Layer.mock(RepositoryCache.Service, {
   ensure: () => Effect.die("unexpected Git materialization"),
@@ -44,6 +47,7 @@ describe("Reference", () => {
     Effect.gen(function* () {
       const references = yield* Reference.Service
       const repository = Repository.parseRemote("owner/repo")
+      yield* Effect.promise(() => fs.mkdir(Repository.cachePath(Global.Path.repos, repository), { recursive: true }))
       const source = Reference.GitSource.make({ type: "git", repository: "owner/repo", branch: "main" })
       yield* references.transform((editor) => editor.add("sdk", source))
 
@@ -67,6 +71,7 @@ describe("Reference", () => {
     Effect.gen(function* () {
       const references = yield* Reference.Service
       const repository = Repository.parseRemote("owner/repo")
+      yield* Effect.promise(() => fs.mkdir(Repository.cachePath(Global.Path.repos, repository), { recursive: true }))
       const source = Reference.GitSource.make({
         type: "git",
         repository: "owner/repo",
@@ -88,6 +93,27 @@ describe("Reference", () => {
       Effect.provide(cache),
       Effect.provide(EventV2.defaultLayer),
       Effect.provide(Global.defaultLayer),
+    ),
+  )
+
+  it.effect("omits uncached Git references while refresh fails", () =>
+    Effect.acquireUseRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) =>
+        Effect.gen(function* () {
+          const references = yield* Reference.Service
+          const source = Reference.GitSource.make({ type: "git", repository: "owner/repo", branch: "main" })
+          yield* references.transform((editor) => editor.add("sdk", source))
+
+          expect(yield* references.list()).toEqual([])
+        }).pipe(
+          Effect.scoped,
+          Effect.provide(Reference.layer),
+          Effect.provide(cache),
+          Effect.provide(EventV2.defaultLayer),
+          Effect.provide(Global.layerWith({ state: path.join(tmp.path, "state"), repos: path.join(tmp.path, "repos") })),
+        ),
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
     ),
   )
 })

--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -5,6 +5,7 @@ import fs from "fs"
 import path from "path"
 import { fileURLToPath } from "url"
 import { createSolidTransformPlugin } from "@opentui/solid/bun-plugin"
+import { PluginSdk } from "@opencode-ai/core/plugin-sdk"
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -46,6 +47,15 @@ const createEmbeddedWebUIBundle = async () => {
     ...entries,
     `}`,
   ].join("\n")
+}
+
+const copyBundledPluginSdk = async (targetDir: string) => {
+  const source = path.resolve(dir, "../plugin")
+  const target = path.join(targetDir, PluginSdk.vendorPath)
+  await fs.promises.rm(target, { recursive: true, force: true })
+  await fs.promises.mkdir(path.dirname(target), { recursive: true })
+  await fs.promises.cp(path.join(source, "src"), path.join(target, "src"), { recursive: true })
+  await fs.promises.copyFile(path.join(source, "package.json"), path.join(target, "package.json"))
 }
 
 const embeddedFileMap = skipEmbedWebUi ? null : await createEmbeddedWebUIBundle()
@@ -226,6 +236,7 @@ for (const item of targets) {
       2,
     ),
   )
+  await copyBundledPluginSdk(`dist/${name}/bin`)
   binaries[name] = Script.version
 }
 

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -11,7 +11,6 @@ import { Flag } from "@opencode-ai/core/flag/flag"
 import { Auth } from "../auth"
 import { Env } from "../env"
 import { applyEdits, modify } from "jsonc-parser"
-import { InstallationLocal, InstallationVersion } from "@opencode-ai/core/installation/version"
 import { existsSync } from "fs"
 import { Account } from "@/account/account"
 import { isRecord } from "@/util/record"
@@ -439,7 +438,7 @@ export const layer = Layer.effect(
               add: [
                 {
                   name: "@opencode-ai/plugin",
-                  version: InstallationLocal ? undefined : InstallationVersion,
+                  version: ConfigPlugin.dependencyVersion(),
                 },
               ],
             })

--- a/packages/opencode/src/config/plugin.ts
+++ b/packages/opencode/src/config/plugin.ts
@@ -1,4 +1,5 @@
 import { Glob } from "@opencode-ai/core/util/glob"
+import { InstallationChannel, InstallationVersion } from "@opencode-ai/core/installation/version"
 import { ConfigPluginV1 } from "@opencode-ai/core/v1/config/plugin"
 import { pathToFileURL } from "url"
 import { isPathPluginSpec, parsePluginSpecifier, resolvePathPluginTarget } from "@/plugin/shared"
@@ -35,6 +36,12 @@ export function pluginSpecifier(plugin: ConfigPluginV1.Spec): string {
 
 export function pluginOptions(plugin: ConfigPluginV1.Spec): ConfigPluginV1.Options | undefined {
   return Array.isArray(plugin) ? plugin[1] : undefined
+}
+
+export function dependencyVersion(input = { channel: InstallationChannel, version: InstallationVersion }) {
+  if (input.channel !== "latest") return undefined
+  if (!/^\d+\.\d+\.\d+$/.test(input.version)) return undefined
+  return input.version
 }
 
 // Path-like specs are resolved relative to the config file that declared them so merges later on do not

--- a/packages/opencode/src/config/tui.ts
+++ b/packages/opencode/src/config/tui.ts
@@ -14,7 +14,6 @@ import { FSUtil } from "@opencode-ai/core/fs-util"
 import { CurrentWorkingDirectory } from "./tui-cwd"
 import { ConfigPlugin } from "@/config/plugin"
 import { TuiKeybind } from "@opencode-ai/tui/config/keybind"
-import { InstallationLocal, InstallationVersion } from "@opencode-ai/core/installation/version"
 import { makeRuntime } from "@opencode-ai/core/effect/runtime"
 import { Filesystem } from "@/util/filesystem"
 import { ConfigVariable } from "@/config/variable"
@@ -237,7 +236,7 @@ export const layer = Layer.effect(
             add: [
               {
                 name: "@opencode-ai/plugin",
-                version: InstallationLocal ? undefined : InstallationVersion,
+                version: ConfigPlugin.dependencyVersion(),
               },
             ],
           })

--- a/packages/opencode/test/config/plugin.test.ts
+++ b/packages/opencode/test/config/plugin.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test"
+import { ConfigPlugin } from "@/config/plugin"
+
+describe("ConfigPlugin.dependencyVersion", () => {
+  test("pins stable latest releases", () => {
+    expect(ConfigPlugin.dependencyVersion({ channel: "latest", version: "1.17.11" })).toBe("1.17.11")
+  })
+
+  test("does not pin local builds", () => {
+    expect(ConfigPlugin.dependencyVersion({ channel: "local", version: "1.17.11" })).toBeUndefined()
+  })
+
+  test("does not pin fork or prerelease versions", () => {
+    expect(ConfigPlugin.dependencyVersion({ channel: "latest", version: "1.17.11-main.3" })).toBeUndefined()
+    expect(ConfigPlugin.dependencyVersion({ channel: "latest", version: "1.17.11-beta.1" })).toBeUndefined()
+  })
+
+  test("does not pin branch channels", () => {
+    expect(ConfigPlugin.dependencyVersion({ channel: "dev", version: "1.17.11" })).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

Offline / restricted-network startup improvements that complement but are not covered by the already-merged offline-catalog PRs (#88–#91).

Three changes:

**1. Plugin SDK offline bundling** (`plugin-sdk.ts`, `npm.ts`, `build.ts`)
- `build.ts` copies the plugin source into a vendored directory (`vendor/npm/@opencode-ai/plugin`) next to each binary at build time
- At runtime, `npm.install` resolves `@opencode-ai/plugin` via three-tier fallback: **project-local** (already in `node_modules`) → **bundled copy** → **registry** (network install)
- Uses `BundledPackageUnavailableError` for diagnostics when the bundled copy is missing or unreadable

**2. dependencyVersion()** (`config/plugin.ts`, `config.ts`, `tui.ts`)
- Only pins the version on stable latest releases (`channel=latest` + pure semver `x.y.z`)
- Fork/prerelease/local/dev builds get `undefined` so the install doesn't request a non-existent registry version
- Replaces the old `InstallationLocal ? undefined : InstallationVersion` ternary

**3. Reference offline degradation** (`reference.ts`)
- Only registers a Git reference when its cache directory actually exists (`existsSync`)
- Updates the entry after a successful `cache.ensure` refresh
- Missing references are omitted with a warning instead of carrying a stale path

## Test plan
- [x] `bun typecheck` passes (pre-commit hook, full turbo)
- [x] `npm.test.ts`: covers project-local skip + bundled copy fallback
- [x] `reference.test.ts`: covers uncached Git references omitted on failure
- [x] `plugin.test.ts`: covers dependencyVersion for latest/local/fork/prerelease/branch

## Related
Complements #88–#91 (offline catalog + Windows spinner). These were part of an earlier heavier approach on `fix/offline-startup` that was never committed; this PR extracts the pieces that remain useful.