### PR TITLE
chore(opencode): add config.json schema stub

### DIFF
--- a/packages/opencode/config.json
+++ b/packages/opencode/config.json
@@ -1,0 +1,3 @@
+{
+  "$schema": "https://opencode.ai/config.json"
+}


### PR DESCRIPTION
Adds a minimal `packages/opencode/config.json` with the opencode schema reference, so the opencode package resolves as a config-bearing project root.