### PR TITLE
fix(core): generate pending db migration and stub network in plugin test

### DIFF
--- a/packages/core/schema.json
+++ b/packages/core/schema.json
@@ -1,9 +1,9 @@
 {
   "version": "7",
   "dialect": "sqlite",
-  "id": "e3e2e0f8-3856-4f47-956f-84113683c96b",
+  "id": "747f1cfb-b2d5-45f6-b46b-c38e470bb2d5",
   "prevIds": [
-    "5b6023af-92c0-43b1-8d1c-b1beafd6380c"
+    "e3e2e0f8-3856-4f47-956f-84113683c96b"
   ],
   "ddl": [
     {
@@ -48,10 +48,6 @@
     },
     {
       "name": "event",
-      "entityType": "tables"
-    },
-    {
-      "name": "goal_state",
       "entityType": "tables"
     },
     {
@@ -599,6 +595,16 @@
       "table": "workflow_node"
     },
     {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "captured_output",
+      "entityType": "columns",
+      "table": "workflow_node"
+    },
+    {
       "type": "integer",
       "notNull": false,
       "autoincrement": false,
@@ -977,36 +983,6 @@
       "name": "data",
       "entityType": "columns",
       "table": "event"
-    },
-    {
-      "type": "text",
-      "notNull": false,
-      "autoincrement": false,
-      "default": null,
-      "generated": null,
-      "name": "session_id",
-      "entityType": "columns",
-      "table": "goal_state"
-    },
-    {
-      "type": "text",
-      "notNull": true,
-      "autoincrement": false,
-      "default": null,
-      "generated": null,
-      "name": "payload",
-      "entityType": "columns",
-      "table": "goal_state"
-    },
-    {
-      "type": "integer",
-      "notNull": true,
-      "autoincrement": false,
-      "default": null,
-      "generated": null,
-      "name": "updated_at",
-      "entityType": "columns",
-      "table": "goal_state"
     },
     {
       "type": "text",
@@ -2325,15 +2301,6 @@
     },
     {
       "columns": [
-        "session_id"
-      ],
-      "nameExplicit": false,
-      "name": "goal_state_pk",
-      "table": "goal_state",
-      "entityType": "pks"
-    },
-    {
-      "columns": [
         "id"
       ],
       "nameExplicit": false,
@@ -2598,20 +2565,6 @@
       "name": "event_aggregate_type_seq_idx",
       "entityType": "indexes",
       "table": "event"
-    },
-    {
-      "columns": [
-        {
-          "value": "updated_at",
-          "isExpression": false
-        }
-      ],
-      "isUnique": false,
-      "where": null,
-      "origin": "manual",
-      "name": "goal_state_updated_at_idx",
-      "entityType": "indexes",
-      "table": "goal_state"
     },
     {
       "columns": [

--- a/packages/core/src/database/migration.gen.ts
+++ b/packages/core/src/database/migration.gen.ts
@@ -45,5 +45,6 @@ export const migrations = (
     import("./migration/20260714050622_awesome_bromley"),
     import("./migration/20260715035022_captured_output"),
     import("./migration/20260715040000_drop_retry_count"),
+    import("./migration/20260717034735_fearless_cammi"),
   ])
 ).map((module) => module.default) satisfies DatabaseMigration.Migration[]

--- a/packages/core/src/database/migration/20260717034735_fearless_cammi.ts
+++ b/packages/core/src/database/migration/20260717034735_fearless_cammi.ts
@@ -1,0 +1,13 @@
+import { Effect } from "effect"
+import type { DatabaseMigration } from "../migration"
+
+export default {
+  id: "20260717034735_fearless_cammi",
+  up(tx) {
+    return Effect.gen(function* () {
+      yield* tx.run(`ALTER TABLE \`workflow_node\` ADD \`captured_output\` text;`)
+      yield* tx.run(`DROP INDEX IF EXISTS \`goal_state_updated_at_idx\`;`)
+      yield* tx.run(`DROP TABLE \`goal_state\`;`)
+    })
+  },
+} satisfies DatabaseMigration.Migration

--- a/packages/core/src/database/schema.gen.ts
+++ b/packages/core/src/database/schema.gen.ts
@@ -146,13 +146,6 @@ export default {
         );
       `)
       yield* tx.run(`
-        CREATE TABLE \`goal_state\` (
-          \`session_id\` text PRIMARY KEY,
-          \`payload\` text NOT NULL,
-          \`updated_at\` integer NOT NULL
-        );
-      `)
-      yield* tx.run(`
         CREATE TABLE \`permission\` (
           \`id\` text PRIMARY KEY,
           \`project_id\` text NOT NULL,
@@ -319,7 +312,6 @@ export default {
       )
       yield* tx.run(`CREATE UNIQUE INDEX \`event_aggregate_seq_idx\` ON \`event\` (\`aggregate_id\`,\`seq\`);`)
       yield* tx.run(`CREATE INDEX \`event_aggregate_type_seq_idx\` ON \`event\` (\`aggregate_id\`,\`type\`,\`seq\`);`)
-      yield* tx.run(`CREATE INDEX \`goal_state_updated_at_idx\` ON \`goal_state\` (\`updated_at\`);`)
       yield* tx.run(
         `CREATE UNIQUE INDEX \`permission_project_action_resource_idx\` ON \`permission\` (\`project_id\`,\`action\`,\`resource\`);`,
       )

--- a/packages/core/test/plugin/provider-opencode.test.ts
+++ b/packages/core/test/plugin/provider-opencode.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect } from "bun:test"
-import { Effect } from "effect"
+import { Effect, Layer } from "effect"
+import { HttpClient, HttpClientResponse } from "effect/unstable/http"
 import { Catalog } from "@opencode-ai/core/catalog"
 import { Credential } from "@opencode-ai/core/credential"
 import { Integration } from "@opencode-ai/core/integration"
@@ -11,7 +12,20 @@ import { ProviderV2 } from "@opencode-ai/core/provider"
 import { testEffect } from "../lib/effect"
 import { PluginTestLayer } from "./fixture"
 
-const it = testEffect(PluginTestLayer)
+// OpencodePlugin fetches remote provider config from console.opencode.ai whenever a
+// credential is active. Stub the HttpClient so tests never hit the network; 404 means
+// "no remote config" and keeps the plugin on its local defaults.
+const stubHttpLayer = Layer.succeed(
+  HttpClient.HttpClient,
+  HttpClient.make((request) =>
+    Effect.succeed(HttpClientResponse.fromWeb(request, new Response(null, { status: 404 }))),
+  ),
+)
+
+const it = testEffect(Layer.mergeAll(PluginTestLayer, stubHttpLayer))
+
+// The connected-server test talks to a local Bun.serve and needs the real HttpClient.
+const itLive = testEffect(PluginTestLayer)
 
 const addPlugin = Effect.fn(function* () {
   const plugin = yield* PluginV2.Service
@@ -63,7 +77,7 @@ describe("OpencodePlugin", () => {
     }),
   )
 
-  it.live("loads providers and models from the connected OpenCode server", () =>
+  itLive.live("loads providers and models from the connected OpenCode server", () =>
     Effect.acquireUseRelease(
       Effect.sync(() => {
         const authorization: Array<string | null> = []


### PR DESCRIPTION
## Context
修复 dev 分支 CI run https://github.com/LeXwDeX/OpenCode-DAG/actions/runs/29549267626 (Unit Tests linux) 的两个失败。

## Changes

**1. 生成缺失的数据库迁移**
dynamic-workflow 的 schema 改动（`workflow_node.captured_output` 列、删除 `goal_state` 表）此前提交时未运行迁移生成器，导致 linux-only 测试 `DatabaseMigration > declared schema has no ungenerated migrations` 失败。运行 `bun script/migration.ts` 生成迁移 `20260717034735_fearless_cammi.ts` 并刷新 `schema.json` / `migration.gen.ts` / `schema.gen.ts`。

**2. 消除 plugin 测试的网络依赖**
`OpencodePlugin > uses configured provider env vars as credentials` 在 CI 超时（5000ms）。根因：测试注册 env 凭证后 `OpencodePlugin.load()` 经 `fetchProviders` 向 `console.opencode.ai` 发真实 HTTPS 请求，pass/fail 取决于网络可用性。用返回 404 的 stub `HttpClient` 替代（404 = 无远程配置，走本地默认），测试降到 ~7ms。唯一需要真实 HTTP 的 connected-server `it.live` 测试保留真实 client。

## Verification
- `bun script/migration.ts --check` exit 0
- `bun typecheck`（29 包）通过
- `provider-opencode.test.ts` + `database-migration.test.ts` 25/25 通过