### PR TITLE
fix(dag): follow-up tests + event manifest count for #102

### DIFF
--- a/packages/opencode/test/dag/dag-summary-publisher-behavior.test.ts
+++ b/packages/opencode/test/dag/dag-summary-publisher-behavior.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "bun:test"
+import { DateTime, Effect, Layer } from "effect"
+import { Database } from "@opencode-ai/core/database/database"
+import { EventV2 } from "@opencode-ai/core/event"
+import { DagProjector } from "@opencode-ai/core/dag/projector"
+import { DagStore } from "@opencode-ai/core/dag/store"
+import { DagEvent } from "@opencode-ai/schema/dag-event"
+import { Project } from "@opencode-ai/core/project"
+import { ProjectTable } from "@opencode-ai/core/project/sql"
+import { SessionTable } from "@opencode-ai/core/session/sql"
+import { AbsolutePath } from "@opencode-ai/core/schema"
+import { EventV2Bridge } from "@/event-v2-bridge"
+import { InstanceRef } from "@/effect/instance-ref"
+import { DagSummaryPublisher } from "@/dag/runtime/summary-publisher"
+import { GlobalBus } from "@/bus/global"
+
+const ts = (n: number) => DateTime.makeUnsafe(n)
+const dagID = "dag_pub" as never
+const nodeID = "node-pub-1" as never
+const sessionID = "ses_pub" as never
+
+const baseLayer = Layer.mergeAll(
+  Database.defaultLayer,
+  EventV2.defaultLayer,
+  DagProjector.defaultLayer,
+  DagStore.defaultLayer,
+  EventV2Bridge.defaultLayer,
+)
+
+// Publisher layer sits on top of baseLayer; provide them together so the test
+// body (which also needs Database/EventV2 for setup) shares the same runtime.
+const runtimeLayer = Layer.provideMerge(DagSummaryPublisher.layer, baseLayer)
+
+const ctx = {
+  directory: "/project" as never,
+  worktree: "/project" as never,
+  project: { id: Project.ID.global, worktree: AbsolutePath.make("/project"), directory: AbsolutePath.make("/project"), config: {} } as never,
+}
+
+function setup() {
+  return Effect.gen(function* () {
+    const { db } = yield* Database.Service
+    yield* db.insert(ProjectTable).values({ id: Project.ID.global, worktree: AbsolutePath.make("/project"), sandboxes: [] }).run().pipe(Effect.orDie)
+    yield* db.insert(SessionTable).values({ id: sessionID, project_id: Project.ID.global, slug: "pub", directory: "/project", title: "pub", version: "test" }).run().pipe(Effect.orDie)
+  })
+}
+
+interface SummaryEmission {
+  sessionID: string
+  summaries: unknown[]
+}
+
+function startCollector(): { emissions: SummaryEmission[]; stop: () => void } {
+  const emissions: SummaryEmission[] = []
+  const handler = (e: { payload?: { type?: string; properties?: { sessionID?: string; summaries?: unknown[] } } }) => {
+    if (e.payload?.type === "dag.workflow.summary.updated") {
+      emissions.push({ sessionID: e.payload.properties!.sessionID!, summaries: e.payload.properties!.summaries! })
+    }
+  }
+  GlobalBus.on("event", handler)
+  return { emissions, stop: () => GlobalBus.off("event", handler) }
+}
+
+describe("DagSummaryPublisher behavior (integration)", () => {
+  it("a dag.node.completed event triggers a summary emission with aggregated counts", async () => {
+    const collector = startCollector()
+    try {
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          // Start the publisher subscriptions first (init drives InstanceState).
+          const publisher = yield* DagSummaryPublisher.Service
+          yield* publisher.init()
+          // init() forks the subscribe fibers; give the EventV2 PubSub subscriptions
+          // a tick to register before publishing, otherwise events published before
+          // the stream is drained are dropped (PubSub does not buffer history).
+          yield* Effect.sleep("20 millis")
+          yield* setup()
+          const events = yield* EventV2.Service
+          yield* events.publish(DagEvent.WorkflowCreated, { dagID, projectID: Project.ID.global as never, sessionID, title: "pub-test", config: "", status: "pending", timestamp: ts(0) })
+          yield* events.publish(DagEvent.NodeRegistered, { dagID, nodeID, name: "Build", workerType: "build", dependsOn: [], required: true, timestamp: ts(1) })
+          yield* events.publish(DagEvent.NodeStarted, { dagID, nodeID, childSessionID: "ses_child" as never, timestamp: ts(2) })
+          yield* events.publish(DagEvent.NodeCompleted, { dagID, nodeID, output: { ok: true }, durationMs: 5, timestamp: ts(3) })
+          // Give the burst-coalesced publish fiber a chance to run.
+          yield* Effect.sleep("150 millis")
+        }).pipe(
+          Effect.scoped,
+          Effect.provideService(InstanceRef, ctx),
+          Effect.provide(runtimeLayer),
+        ) as Effect.Effect<never>,
+      )
+
+      expect(collector.emissions.length).toBeGreaterThanOrEqual(1)
+      const last = collector.emissions.at(-1)!
+      expect(last.sessionID).toBe(sessionID)
+      expect(last.summaries).toHaveLength(1)
+      expect(last.summaries[0]).toMatchObject({
+        id: "dag_pub",
+        nodeCount: 1,
+        completedNodes: 1,
+        runningNodes: 0,
+        failedNodes: 0,
+      })
+    } finally {
+      collector.stop()
+    }
+  })
+
+  it("coalesces a burst of node events (fewer emissions than events, final state aggregated)", async () => {
+    const collector = startCollector()
+    try {
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const publisher = yield* DagSummaryPublisher.Service
+          yield* publisher.init()
+          yield* Effect.sleep("20 millis")
+          yield* setup()
+          const events = yield* EventV2.Service
+          yield* events.publish(DagEvent.WorkflowCreated, { dagID, projectID: Project.ID.global as never, sessionID, title: "burst", config: "", status: "pending", timestamp: ts(0) })
+          yield* events.publish(DagEvent.WorkflowStarted, { dagID, timestamp: ts(1) })
+          for (let i = 1; i <= 5; i++) {
+            yield* events.publish(DagEvent.NodeRegistered, { dagID, nodeID: `n-${i}` as never, name: `N${i}`, workerType: "build", dependsOn: [], required: false, timestamp: ts(2 + i) })
+          }
+          // Fire 5 completed events in a tight burst for the same session.
+          for (let i = 1; i <= 5; i++) {
+            yield* events.publish(DagEvent.NodeStarted, { dagID, nodeID: `n-${i}` as never, childSessionID: `ses_child_${i}` as never, timestamp: ts(10 + i) })
+            yield* events.publish(DagEvent.NodeCompleted, { dagID, nodeID: `n-${i}` as never, output: { ok: true }, durationMs: 1, timestamp: ts(20 + i) })
+          }
+          // Yield window for the burst-coalesced publish fibers to settle.
+          yield* Effect.sleep("200 millis")
+        }).pipe(
+          Effect.scoped,
+          Effect.provideService(InstanceRef, ctx),
+          Effect.provide(runtimeLayer),
+        ) as Effect.Effect<never>,
+      )
+
+      // Coalescing collapses a burst of 10 synchronous node events into far fewer
+      // emissions than the event count. The strict count is scheduler-dependent,
+      // so assert the invariant: the publisher never emitted one-per-event, and
+      // the final emission reflects the fully-aggregated state.
+      const emissions = collector.emissions
+      const triggeredNodeEvents = 10
+      expect(emissions.length).toBeLessThan(triggeredNodeEvents)
+      expect(emissions.length).toBeGreaterThanOrEqual(1)
+      const last = emissions.at(-1)!
+      expect(last.summaries[0]).toMatchObject({ nodeCount: 5, completedNodes: 5, runningNodes: 0 })
+    } finally {
+      collector.stop()
+    }
+  })
+})

--- a/packages/opencode/test/event-manifest.test.ts
+++ b/packages/opencode/test/event-manifest.test.ts
@@ -10,7 +10,7 @@ describe("public event manifest", () => {
     expect(EventManifest.Definitions).toBe(SchemaEventManifest.Definitions)
     expect(EventManifest.Latest).toBe(SchemaEventManifest.Latest)
     expect(EventManifest.Durable).toBe(SchemaEventManifest.Durable)
-    expect(EventManifest.Latest.size).toBe(91)
+    expect(EventManifest.Latest.size).toBe(92)
     expect(EventManifest.Latest.get("session.next.step.ended")).toBe(SessionEvent.Step.Ended)
     expect(EventManifest.Latest.get("todo.updated")).toBe(Todo.Event.Updated)
     expect(EventManifest.Latest.get("goal.updated")).toBe(SessionGoal.Event.Updated)

--- a/packages/tui/test/cli/cmd/tui/sync-dag.test.tsx
+++ b/packages/tui/test/cli/cmd/tui/sync-dag.test.tsx
@@ -1,0 +1,104 @@
+/** @jsxImportSource @opentui/solid */
+import { describe, expect, test } from "bun:test"
+import { tmpdir } from "../../../fixture/fixture"
+import { directory, mount, wait, json } from "./sync-fixture"
+import type { GlobalEvent } from "@opencode-ai/sdk/v2"
+import type { DagWorkflowSummary } from "@opencode-ai/sdk/v2"
+
+const sid = "ses_dag_1"
+
+function summaryEvent(summaries: DagWorkflowSummary[], sessionID = sid): GlobalEvent {
+  return {
+    directory,
+    project: "proj_test",
+    payload: {
+      id: `evt_dag_summary_${Date.now()}_${Math.random()}`,
+      type: "dag.workflow.summary.updated",
+      properties: { sessionID, summaries },
+    },
+  }
+}
+
+function summary(completed: number, total: number, running = 0, failed = 0): DagWorkflowSummary {
+  return {
+    id: "wf-1",
+    title: "Test workflow",
+    status: "running",
+    nodeCount: total,
+    completedNodes: completed,
+    runningNodes: running,
+    failedNodes: failed,
+  }
+}
+
+describe("tui sync dag slice", () => {
+  test("dag.workflow.summary.updated event writes into store.dag[sessionID]", async () => {
+    await using tmp = await tmpdir()
+    await Bun.write(`${tmp.path}/kv.json`, "{}")
+    const { app, emit, sync } = await mount(undefined, tmp.path)
+
+    try {
+      expect(sync.data.dag[sid] ?? []).toEqual([])
+
+      emit(summaryEvent([summary(2, 5, 1, 0)]))
+      await wait(() => (sync.data.dag[sid]?.length ?? 0) > 0)
+
+      const stored = sync.data.dag[sid]
+      expect(stored).toHaveLength(1)
+      expect(stored[0]).toMatchObject({ id: "wf-1", completedNodes: 2, nodeCount: 5, runningNodes: 1 })
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+
+  test("subsequent summary events replace the slice rather than accumulate", async () => {
+    await using tmp = await tmpdir()
+    await Bun.write(`${tmp.path}/kv.json`, "{}")
+    const { app, emit, sync } = await mount(undefined, tmp.path)
+
+    try {
+      emit(summaryEvent([summary(1, 3)]))
+      await wait(() => (sync.data.dag[sid]?.length ?? 0) === 1)
+      expect(sync.data.dag[sid][0].completedNodes).toBe(1)
+
+      emit(summaryEvent([summary(3, 3)]))
+      await wait(() => sync.data.dag[sid]?.[0]?.completedNodes === 3)
+
+      expect(sync.data.dag[sid]).toHaveLength(1)
+      expect(sync.data.dag[sid][0].completedNodes).toBe(3)
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+
+  test("bootstrap fetches GET /dag/session/:sid/summary as the baseline safety net", async () => {
+    await using tmp = await tmpdir()
+    await Bun.write(`${tmp.path}/kv.json`, "{}")
+    const fetched: string[] = []
+    const sessionRow = {
+      id: sid,
+      slug: "dag-test",
+      projectID: "proj_test",
+      directory,
+      version: "test",
+      time: { created: 0, updated: 0 },
+    }
+    const { app, sync } = await mount((url) => {
+      // Make the session visible so bootstrap treats it as eligible for the summary fetch.
+      if (url.pathname === "/session") return json([sessionRow])
+      if (url.pathname === `/dag/session/${sid}/summary`) {
+        fetched.push(url.pathname)
+        return json([summary(4, 6, 1, 1)])
+      }
+      return undefined
+    }, tmp.path)
+
+    try {
+      await wait(() => (sync.data.dag[sid]?.length ?? 0) > 0)
+      expect(fetched).toContain(`/dag/session/${sid}/summary`)
+      expect(sync.data.dag[sid][0]).toMatchObject({ completedNodes: 4, failedNodes: 1 })
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+})

--- a/packages/tui/test/feature-plugins/dag-inspector.test.tsx
+++ b/packages/tui/test/feature-plugins/dag-inspector.test.tsx
@@ -1,0 +1,265 @@
+/** @jsxImportSource @opentui/solid */
+import { describe, expect, test, mock } from "bun:test"
+import { createDefaultOpenTuiKeymap } from "@opentui/keymap/opentui"
+import { testRender, useRenderer } from "@opentui/solid"
+import type { TuiPluginApi, TuiRouteCurrent, TuiRouteDefinition } from "@opencode-ai/plugin/tui"
+import type { DagWorkflowSummary } from "@opencode-ai/sdk/v2"
+import { KVProvider } from "../../src/context/kv"
+import { ThemeProvider } from "../../src/context/theme"
+import { TuiConfigProvider } from "../../src/config"
+import { OpencodeKeymapProvider } from "../../src/keymap"
+import dagInspectorPlugin from "../../src/feature-plugins/system/dag-inspector"
+import { createTuiPluginApi } from "../fixture/tui-plugin"
+import { createTuiResolvedConfig } from "../fixture/tui-runtime"
+import { TestTuiContexts } from "../fixture/tui-environment"
+
+interface DagNodeRow {
+  id: string
+  name: string
+  status: string
+  worker_type: string
+  depends_on: string[]
+  child_session_id?: string | null
+  error_reason?: string | null
+}
+
+const wfSummary = (overrides: Partial<DagWorkflowSummary> = {}): DagWorkflowSummary => ({
+  id: "wf-1",
+  title: "Test workflow",
+  status: "running",
+  nodeCount: 2,
+  completedNodes: 0,
+  runningNodes: 0,
+  failedNodes: 0,
+  ...overrides,
+})
+
+type RenderOpts = {
+  workflows?: DagWorkflowSummary[]
+  nodes?: DagNodeRow[]
+  initialRoute?: TuiRouteCurrent
+}
+
+async function renderDagInspector(opts: RenderOpts = {}) {
+  const commands = new Map<
+    string,
+    NonNullable<Parameters<TuiPluginApi["keymap"]["registerLayer"]>[0]["commands"]>[number]
+  >()
+  let current: TuiRouteCurrent =
+    opts.initialRoute ?? { name: "dag", params: { sessionID: "ses_1" } }
+  let renderInspector: TuiRouteDefinition["render"] | undefined
+
+  // Trackable spies
+  const nodesCalls: string[] = []
+  const navigations: { name: string; params?: Record<string, unknown> }[] = []
+  const toasts: { variant?: string; message: string }[] = []
+  const eventHandlers = new Map<string, () => void>()
+
+  const config = createTuiResolvedConfig()
+
+  function Harness() {
+    const renderer = useRenderer()
+    const keymap = createDefaultOpenTuiKeymap(renderer)
+    const registerLayer = keymap.registerLayer.bind(keymap)
+    keymap.registerLayer = (layer) => {
+      layer.commands?.forEach((command) => commands.set(command.name, command))
+      return registerLayer(layer)
+    }
+    const base = createTuiPluginApi({
+      keymap,
+      client: {
+        dag: {
+          nodes: async (input: { dagID: string }) => {
+            nodesCalls.push(input.dagID)
+            return { data: opts.nodes ?? [] }
+          },
+        },
+      } as unknown as TuiPluginApi["client"],
+      state: {
+        session: {
+          dag: () => opts.workflows ?? [],
+        },
+      },
+      event: {
+        on: ((type: string, handler: () => void) => {
+          eventHandlers.set(type, handler)
+          return () => eventHandlers.delete(type)
+        }) as unknown as TuiPluginApi["event"]["on"],
+      } as TuiPluginApi["event"],
+    })
+    const api = {
+      ...base,
+      route: {
+        register(routes) {
+          renderInspector = routes.find((route) => route.name === "dag")?.render
+          return () => {}
+        },
+        navigate(name, params) {
+          navigations.push({ name, params })
+          current = params ? { name, params } : { name }
+        },
+        get current() {
+          return current
+        },
+      },
+      ui: {
+        ...base.ui,
+        toast: (t: { variant?: string; message: string }) => toasts.push(t),
+      },
+    } satisfies TuiPluginApi
+
+    void dagInspectorPlugin.tui(api, undefined, undefined as never)
+
+    return (
+      <TestTuiContexts>
+        <OpencodeKeymapProvider keymap={keymap}>
+          <TuiConfigProvider config={config}>
+            <KVProvider>
+              <ThemeProvider mode="dark">
+                {renderInspector?.({ params: "params" in current ? current.params : undefined })}
+              </ThemeProvider>
+            </KVProvider>
+          </TuiConfigProvider>
+        </OpencodeKeymapProvider>
+      </TestTuiContexts>
+    )
+  }
+
+  const app = await testRender(() => <Harness />, { width: 100, height: 30 })
+  // Wait for the inspector commands to be registered.
+  await waitForCommand(app, commands, "dag.close")
+
+  return {
+    app,
+    commands,
+    navigations: () => navigations,
+    toasts: () => toasts,
+    nodesCalls: () => nodesCalls,
+    emitSummaryUpdate: () => eventHandlers.get("dag.workflow.summary.updated")?.(),
+    current: () => current,
+  }
+}
+
+async function waitForCommand(
+  app: Awaited<ReturnType<typeof testRender>>,
+  commands: Map<string, unknown>,
+  name: string,
+  timeout = 2000,
+) {
+  const start = Date.now()
+  while (!commands.has(name)) {
+    if (Date.now() - start > timeout) throw new Error(`command "${name}" not registered`)
+    await app.renderOnce()
+    await Bun.sleep(5)
+  }
+}
+
+describe("DagInspector", () => {
+  test("mounting fetches nodes for the auto-selected workflow", async () => {
+    const viewer = await renderDagInspector({
+      workflows: [wfSummary({ id: "wf-1", nodeCount: 1 })],
+      nodes: [{ id: "n-1", name: "build", status: "pending", worker_type: "build", depends_on: [] }],
+    })
+    try {
+      await Bun.sleep(30)
+      expect(viewer.nodesCalls()).toContain("wf-1")
+    } finally {
+      viewer.app.renderer.destroy()
+    }
+  })
+
+  test("dag.workflow.summary.updated event triggers a node re-fetch", async () => {
+    const viewer = await renderDagInspector({
+      workflows: [wfSummary({ id: "wf-1" })],
+      nodes: [{ id: "n-1", name: "build", status: "running", worker_type: "build", depends_on: [] }],
+    })
+    try {
+      await Bun.sleep(20)
+      const before = viewer.nodesCalls().length
+      viewer.emitSummaryUpdate()
+      await Bun.sleep(20)
+      const after = viewer.nodesCalls().length
+      expect(after).toBeGreaterThan(before)
+    } finally {
+      viewer.app.renderer.destroy()
+    }
+  })
+
+  test("dag.enter navigates into the selected node's child session", async () => {
+    const viewer = await renderDagInspector({
+      workflows: [wfSummary({ id: "wf-1" })],
+      nodes: [
+        {
+          id: "n-1",
+          name: "build",
+          status: "running",
+          worker_type: "build",
+          depends_on: [],
+          child_session_id: "child_ses_1",
+        },
+      ],
+    })
+    try {
+      viewer.commands.get("dag.enter")!.run?.({} as never)
+      await Bun.sleep(10)
+      expect(viewer.navigations()).toContainEqual(
+        expect.objectContaining({ name: "session", params: expect.objectContaining({ sessionID: "child_ses_1" }) }),
+      )
+    } finally {
+      viewer.app.renderer.destroy()
+    }
+  })
+
+  test("dag.enter toasts when the node has no child session yet", async () => {
+    const viewer = await renderDagInspector({
+      workflows: [wfSummary({ id: "wf-1" })],
+      nodes: [{ id: "n-1", name: "build", status: "pending", worker_type: "build", depends_on: [], child_session_id: null }],
+    })
+    try {
+      viewer.commands.get("dag.enter")!.run?.({} as never)
+      await Bun.sleep(10)
+      expect(viewer.toasts().some((t) => /no session/i.test(t.message))).toBe(true)
+    } finally {
+      viewer.app.renderer.destroy()
+    }
+  })
+
+  test("dag.close navigates back to the return route", async () => {
+    const returnRoute = { name: "session", params: { sessionID: "ses_1" } }
+    const viewer = await renderDagInspector({
+      initialRoute: { name: "dag", params: { sessionID: "ses_1", returnRoute } },
+      workflows: [wfSummary({ id: "wf-1" })],
+    })
+    try {
+      viewer.commands.get("dag.close")!.run?.({} as never)
+      await Bun.sleep(10)
+      expect(viewer.navigations().at(-1)).toEqual(
+        expect.objectContaining({ name: "session", params: { sessionID: "ses_1" } }),
+      )
+    } finally {
+      viewer.app.renderer.destroy()
+    }
+  })
+
+  test("a failed node renders its error_reason in the inspector", async () => {
+    const viewer = await renderDagInspector({
+      workflows: [wfSummary({ id: "wf-1", failedNodes: 1, nodeCount: 1 })],
+      nodes: [
+        {
+          id: "n-1",
+          name: "build",
+          status: "failed",
+          worker_type: "build",
+          depends_on: [],
+          error_reason: "compile error in main.ts",
+        },
+      ],
+    })
+    try {
+      await viewer.app.waitForFrame((frame) => frame.includes("compile error in main.ts"))
+      // The error reason must reach the rendered frame. The guard above throws on timeout if absent.
+    } finally {
+      viewer.app.renderer.destroy()
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Follow-up to #102 (merged into `dev` as 18d9c143) carrying two commits that landed on `feat/dynamic-workflow` **after** #102 merged, so they are missing from `dev`.

- **`fix(test): update event manifest size`** — `dev` currently fails the full test suite: #102 registered `dag.workflow.summary.updated` in `EventManifest.Definitions` (a legitimate latest public wire type consumed via SSE), bumping `Latest.size` 91 → 92, but the pinned assertion in `test/event-manifest.test.ts` still expects 91. This is exactly the CI failure seen on run 29557398652. Fix: update the pinned count.
- **`test(tui): cover DAG summary sync reducer and inspector surface`** — closes the 8.6 manual-verification gap for the observability change with automated coverage (sync dag slice reducer + bootstrap fetch; inspector mount fetch / re-fetch on event / `dag.enter` navigation / `dag.close` / failed-node `error_reason` rendering).

Both cherry-picked clean onto `dev`; pre-commit `turbo typecheck` green.

## Verification

- `bun typecheck` green (tui + opencode).
- `packages/tui` full suite: 202 pass / 0 fail.
- `packages/opencode` event-manifest test: 2 pass.

🤂 Generated with [opencode](https://opencode.ai)