### PR TITLE
fix(dag): harden observability contracts for coalescing, reconnect, and inspector filtering

### DIFF
--- a/packages/opencode/src/dag/runtime/summary-publisher.ts
+++ b/packages/opencode/src/dag/runtime/summary-publisher.ts
@@ -1,6 +1,6 @@
 export * as DagSummaryPublisher from "./summary-publisher"
 
-import { Effect, Layer, Stream, Context } from "effect"
+import { Effect, Layer, Scope, Context } from "effect"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { InstanceState } from "@/effect/instance-state"
 import { EventV2Bridge } from "@/event-v2-bridge"
@@ -60,8 +60,9 @@ export const layer = Layer.effect(
 
     const state = yield* InstanceState.make(
       Effect.fn("DagSummaryPublisher.state")(function* (ctx) {
+        const scope = yield* Scope.Scope
         // Per-session debounce map. Keys are sessionIDs with an in-flight
-        // recompute; a single fiber yield collapses a burst into one read.
+        // recompute; a bounded window collapses a burst into one read.
         //
         // NOTE: This is request-coalescing state for I/O deduplication, NOT
         // a parallel projection of DAG state. The summary is always recomputed
@@ -74,13 +75,7 @@ export const layer = Layer.effect(
 
         const publishForSession = (sessionID: string) =>
           Effect.gen(function* () {
-            const summaries = yield* store.getWorkflowSummaries(sessionID).pipe(
-              Effect.catchCause((cause) =>
-                Effect.logWarning("DagSummaryPublisher: failed to read summaries", { sessionID, cause }).pipe(
-                  Effect.as([]),
-                ),
-              ),
-            )
+            const summaries = yield* store.getWorkflowSummaries(sessionID)
             GlobalBus.emit("event", {
               directory: ctx.directory,
               project: ctx.project.id,
@@ -95,31 +90,35 @@ export const layer = Layer.effect(
           Effect.gen(function* () {
             // Coalesce: if a recompute is already scheduled for this session,
             // let it absorb this trigger rather than queueing a second read.
+            // The coalesced early return MUST NOT touch `pending` — only the
+            // owning fiber clears its own slot, otherwise a coalesced caller
+            // would delete the owner's entry and reopen the window.
             if (pending.has(sessionID)) return
             pending.add(sessionID)
-            // Yield once so a burst of synchronous events collapse into one read.
-            // Correctness does not depend on the window length, only freshness.
-            yield* Effect.yieldNow
-            pending.delete(sessionID)
-            yield* publishForSession(sessionID)
+            yield* Effect.gen(function* () {
+              yield* Effect.sleep("50 millis")
+              yield* publishForSession(sessionID)
+            }).pipe(Effect.ensuring(Effect.sync(() => pending.delete(sessionID))))
           })
 
-        for (const def of SUMMARY_TRIGGER_EVENTS) {
-          yield* events.subscribe(def).pipe(
-            Stream.mapEffect((evt) => {
-              const dagID = evt.data.dagID as string
-              const sessionID = (evt.data as { sessionID?: string }).sessionID
-              if (sessionID) return schedulePublish(sessionID)
-              // Node events don't carry sessionID — look it up via the workflow.
-              return Effect.gen(function* () {
-                const wf = yield* store.getWorkflow(dagID).pipe(Effect.catch(() => Effect.succeed(undefined)))
+        const unsubscribe = yield* events.listen((evt) => {
+          if (!SUMMARY_TRIGGER_EVENTS.some((def) => def.type === evt.type)) return Effect.void
+          const data = evt.data as { dagID: string; sessionID?: string }
+          const publish = data.sessionID
+            ? schedulePublish(data.sessionID)
+            : Effect.gen(function* () {
+                const wf = yield* store.getWorkflow(data.dagID)
                 if (wf) yield* schedulePublish(wf.sessionId)
-              }).pipe(Effect.catchCause(() => Effect.logWarning("DagSummaryPublisher: lookup failed", { dagID })))
-            }),
-            Stream.runDrain,
-            Effect.forkScoped,
+              })
+          return publish.pipe(
+            Effect.catchCause((cause) =>
+              Effect.logWarning("DagSummaryPublisher: failed to publish summaries", { dagID: data.dagID, cause }),
+            ),
+            Effect.forkIn(scope),
+            Effect.asVoid,
           )
-        }
+        })
+        yield* Effect.addFinalizer(() => unsubscribe)
         return {}
       }),
     )

--- a/packages/opencode/test/dag/dag-summary-publisher-behavior.test.ts
+++ b/packages/opencode/test/dag/dag-summary-publisher-behavior.test.ts
@@ -1,151 +1,234 @@
-import { describe, expect, it } from "bun:test"
+import { describe, expect } from "bun:test"
 import { DateTime, Effect, Layer } from "effect"
-import { Database } from "@opencode-ai/core/database/database"
-import { EventV2 } from "@opencode-ai/core/event"
-import { DagProjector } from "@opencode-ai/core/dag/projector"
-import { DagStore } from "@opencode-ai/core/dag/store"
+import { DagStore, type WorkflowRow, type WorkflowSummary } from "@opencode-ai/core/dag/store"
 import { DagEvent } from "@opencode-ai/schema/dag-event"
-import { Project } from "@opencode-ai/core/project"
-import { ProjectTable } from "@opencode-ai/core/project/sql"
-import { SessionTable } from "@opencode-ai/core/session/sql"
-import { AbsolutePath } from "@opencode-ai/core/schema"
 import { EventV2Bridge } from "@/event-v2-bridge"
-import { InstanceRef } from "@/effect/instance-ref"
 import { DagSummaryPublisher } from "@/dag/runtime/summary-publisher"
 import { GlobalBus } from "@/bus/global"
+import { it, pollWithTimeout } from "../lib/effect"
 
 const ts = (n: number) => DateTime.makeUnsafe(n)
-const dagID = "dag_pub" as never
-const nodeID = "node-pub-1" as never
-const sessionID = "ses_pub" as never
-
-const baseLayer = Layer.mergeAll(
-  Database.defaultLayer,
-  EventV2.defaultLayer,
-  DagProjector.defaultLayer,
-  DagStore.defaultLayer,
-  EventV2Bridge.defaultLayer,
-)
-
-// Publisher layer sits on top of baseLayer; provide them together so the test
-// body (which also needs Database/EventV2 for setup) shares the same runtime.
-const runtimeLayer = Layer.provideMerge(DagSummaryPublisher.layer, baseLayer)
-
-const ctx = {
-  directory: "/project" as never,
-  worktree: "/project" as never,
-  project: { id: Project.ID.global, worktree: AbsolutePath.make("/project"), directory: AbsolutePath.make("/project"), config: {} } as never,
-}
-
-function setup() {
-  return Effect.gen(function* () {
-    const { db } = yield* Database.Service
-    yield* db.insert(ProjectTable).values({ id: Project.ID.global, worktree: AbsolutePath.make("/project"), sandboxes: [] }).run().pipe(Effect.orDie)
-    yield* db.insert(SessionTable).values({ id: sessionID, project_id: Project.ID.global, slug: "pub", directory: "/project", title: "pub", version: "test" }).run().pipe(Effect.orDie)
-  })
-}
 
 interface SummaryEmission {
   sessionID: string
-  summaries: unknown[]
+  summaries: WorkflowSummary[]
 }
 
-function startCollector(): { emissions: SummaryEmission[]; stop: () => void } {
+interface StoreControl {
+  failures: number
+  reads: Map<string, number>
+  sessions: Map<string, string>
+  summaries: Map<string, WorkflowSummary[]>
+}
+
+interface EventControl {
+  listener?: (event: never) => Effect.Effect<void>
+}
+
+function control() {
+  return {
+    failures: 0,
+    reads: new Map<string, number>(),
+    sessions: new Map<string, string>(),
+    summaries: new Map<string, WorkflowSummary[]>(),
+  } satisfies StoreControl
+}
+
+function workflow(id: string, sessionId: string): WorkflowRow {
+  return {
+    id,
+    projectId: "global",
+    sessionId,
+    title: id,
+    status: "running",
+    config: "",
+    seq: 0,
+    wakeReported: false,
+    startedAt: null,
+    completedAt: null,
+    timeCreated: 0,
+    timeUpdated: 0,
+  }
+}
+
+function summary(id: string, completedNodes: number): WorkflowSummary {
+  return {
+    id,
+    title: id,
+    status: "running",
+    nodeCount: completedNodes,
+    completedNodes,
+    runningNodes: 0,
+    failedNodes: 0,
+  }
+}
+
+function runtime(state: StoreControl, bus: EventControl) {
+  const store = Layer.mock(DagStore.Service, {
+    getWorkflow: (dagID) => Effect.succeed(state.sessions.get(dagID)).pipe(Effect.map((sid) => sid ? workflow(dagID, sid) : undefined)),
+    getWorkflowSummaries: (sessionID) =>
+      Effect.sync(() => {
+        state.reads.set(sessionID, (state.reads.get(sessionID) ?? 0) + 1)
+        if (state.failures > 0) {
+          state.failures -= 1
+          throw new Error("simulated summary read failure")
+        }
+        return state.summaries.get(sessionID) ?? []
+      }),
+  })
+  const events = Layer.mock(EventV2Bridge.Service, {
+    listen: (listener) =>
+      Effect.sync(() => {
+        bus.listener = listener as never
+        return Effect.sync(() => {
+          bus.listener = undefined
+        })
+      }),
+  })
+  const base = Layer.mergeAll(events, store)
+  return Layer.provideMerge(DagSummaryPublisher.layer, base)
+}
+
+function startCollector() {
   const emissions: SummaryEmission[] = []
-  const handler = (e: { payload?: { type?: string; properties?: { sessionID?: string; summaries?: unknown[] } } }) => {
-    if (e.payload?.type === "dag.workflow.summary.updated") {
-      emissions.push({ sessionID: e.payload.properties!.sessionID!, summaries: e.payload.properties!.summaries! })
-    }
+  const handler = (event: {
+    payload?: { type?: string; properties?: { sessionID?: string; summaries?: WorkflowSummary[] } }
+  }) => {
+    if (event.payload?.type !== "dag.workflow.summary.updated") return
+    emissions.push({
+      sessionID: event.payload.properties!.sessionID!,
+      summaries: event.payload.properties!.summaries!,
+    })
   }
   GlobalBus.on("event", handler)
   return { emissions, stop: () => GlobalBus.off("event", handler) }
 }
 
-describe("DagSummaryPublisher behavior (integration)", () => {
-  it("a dag.node.completed event triggers a summary emission with aggregated counts", async () => {
-    const collector = startCollector()
-    try {
-      await Effect.runPromise(
-        Effect.gen(function* () {
-          // Start the publisher subscriptions first (init drives InstanceState).
-          const publisher = yield* DagSummaryPublisher.Service
-          yield* publisher.init()
-          // init() forks the subscribe fibers; give the EventV2 PubSub subscriptions
-          // a tick to register before publishing, otherwise events published before
-          // the stream is drained are dropped (PubSub does not buffer history).
-          yield* Effect.sleep("20 millis")
-          yield* setup()
-          const events = yield* EventV2.Service
-          yield* events.publish(DagEvent.WorkflowCreated, { dagID, projectID: Project.ID.global as never, sessionID, title: "pub-test", config: "", status: "pending", timestamp: ts(0) })
-          yield* events.publish(DagEvent.NodeRegistered, { dagID, nodeID, name: "Build", workerType: "build", dependsOn: [], required: true, timestamp: ts(1) })
-          yield* events.publish(DagEvent.NodeStarted, { dagID, nodeID, childSessionID: "ses_child" as never, timestamp: ts(2) })
-          yield* events.publish(DagEvent.NodeCompleted, { dagID, nodeID, output: { ok: true }, durationMs: 5, timestamp: ts(3) })
-          // Give the burst-coalesced publish fiber a chance to run.
-          yield* Effect.sleep("150 millis")
-        }).pipe(
-          Effect.scoped,
-          Effect.provideService(InstanceRef, ctx),
-          Effect.provide(runtimeLayer),
-        ) as Effect.Effect<never>,
-      )
+function publishNodeEvents(bus: EventControl, dagID: string, count: number) {
+  if (!bus.listener) return Effect.die(new Error("publisher listener is not ready"))
+  return Effect.forEach(
+    Array.from({ length: count }, (_, index) => index),
+    (index) => bus.listener!({
+      type: DagEvent.NodeRegistered.type,
+      data: {
+        dagID,
+        nodeID: `${dagID}-node-${index}`,
+        name: `Node ${index}`,
+        workerType: "build",
+        dependsOn: [],
+        required: true,
+        timestamp: ts(index),
+      },
+    } as never),
+    { discard: true },
+  )
+}
 
-      expect(collector.emissions.length).toBeGreaterThanOrEqual(1)
-      const last = collector.emissions.at(-1)!
-      expect(last.sessionID).toBe(sessionID)
-      expect(last.summaries).toHaveLength(1)
-      expect(last.summaries[0]).toMatchObject({
-        id: "dag_pub",
-        nodeCount: 1,
-        completedNodes: 1,
-        runningNodes: 0,
-        failedNodes: 0,
-      })
-    } finally {
-      collector.stop()
-    }
+function withCollector<A, E, R>(use: (collector: ReturnType<typeof startCollector>) => Effect.Effect<A, E, R>) {
+  return Effect.acquireUseRelease(
+    Effect.sync(startCollector),
+    use,
+    (collector) => Effect.sync(collector.stop),
+  )
+}
+
+describe("DagSummaryPublisher behavior", () => {
+  it.instance("a node completion triggers one fresh summary recompute", () => {
+    const state = control()
+    const bus = {} satisfies EventControl
+    state.sessions.set("dag-one", "ses-one")
+    state.summaries.set("ses-one", [summary("dag-one", 1)])
+
+    return withCollector((collector) =>
+      Effect.gen(function* () {
+        yield* (yield* DagSummaryPublisher.Service).init()
+        yield* publishNodeEvents(bus, "dag-one", 1)
+        yield* pollWithTimeout(
+          Effect.sync(() => collector.emissions.length === 1 ? collector.emissions[0] : undefined),
+          "summary publisher did not emit",
+        )
+
+        expect(state.reads.get("ses-one")).toBe(1)
+        expect(collector.emissions[0]).toEqual({ sessionID: "ses-one", summaries: [summary("dag-one", 1)] })
+      }),
+    ).pipe(Effect.provide(runtime(state, bus)))
   })
 
-  it("coalesces a burst of node events (fewer emissions than events, final state aggregated)", async () => {
-    const collector = startCollector()
-    try {
-      await Effect.runPromise(
-        Effect.gen(function* () {
-          const publisher = yield* DagSummaryPublisher.Service
-          yield* publisher.init()
-          yield* Effect.sleep("20 millis")
-          yield* setup()
-          const events = yield* EventV2.Service
-          yield* events.publish(DagEvent.WorkflowCreated, { dagID, projectID: Project.ID.global as never, sessionID, title: "burst", config: "", status: "pending", timestamp: ts(0) })
-          yield* events.publish(DagEvent.WorkflowStarted, { dagID, timestamp: ts(1) })
-          for (let i = 1; i <= 5; i++) {
-            yield* events.publish(DagEvent.NodeRegistered, { dagID, nodeID: `n-${i}` as never, name: `N${i}`, workerType: "build", dependsOn: [], required: false, timestamp: ts(2 + i) })
-          }
-          // Fire 5 completed events in a tight burst for the same session.
-          for (let i = 1; i <= 5; i++) {
-            yield* events.publish(DagEvent.NodeStarted, { dagID, nodeID: `n-${i}` as never, childSessionID: `ses_child_${i}` as never, timestamp: ts(10 + i) })
-            yield* events.publish(DagEvent.NodeCompleted, { dagID, nodeID: `n-${i}` as never, output: { ok: true }, durationMs: 1, timestamp: ts(20 + i) })
-          }
-          // Yield window for the burst-coalesced publish fibers to settle.
-          yield* Effect.sleep("200 millis")
-        }).pipe(
-          Effect.scoped,
-          Effect.provideService(InstanceRef, ctx),
-          Effect.provide(runtimeLayer),
-        ) as Effect.Effect<never>,
-      )
+  it.instance("five same-session node events coalesce into one read and emission", () => {
+    const state = control()
+    const bus = {} satisfies EventControl
+    state.sessions.set("dag-burst", "ses-burst")
+    state.summaries.set("ses-burst", [summary("dag-burst", 5)])
 
-      // Coalescing collapses a burst of 10 synchronous node events into far fewer
-      // emissions than the event count. The strict count is scheduler-dependent,
-      // so assert the invariant: the publisher never emitted one-per-event, and
-      // the final emission reflects the fully-aggregated state.
-      const emissions = collector.emissions
-      const triggeredNodeEvents = 10
-      expect(emissions.length).toBeLessThan(triggeredNodeEvents)
-      expect(emissions.length).toBeGreaterThanOrEqual(1)
-      const last = emissions.at(-1)!
-      expect(last.summaries[0]).toMatchObject({ nodeCount: 5, completedNodes: 5, runningNodes: 0 })
-    } finally {
-      collector.stop()
-    }
+    return withCollector((collector) =>
+      Effect.gen(function* () {
+        yield* (yield* DagSummaryPublisher.Service).init()
+        yield* publishNodeEvents(bus, "dag-burst", 5)
+        yield* pollWithTimeout(
+          Effect.sync(() => collector.emissions.length === 1 ? true : undefined),
+          "coalesced summary was not emitted",
+        )
+
+        expect(state.reads.get("ses-burst")).toBe(1)
+        expect(collector.emissions).toEqual([
+          { sessionID: "ses-burst", summaries: [summary("dag-burst", 5)] },
+        ])
+      }),
+    ).pipe(Effect.provide(runtime(state, bus)))
+  })
+
+  it.instance("different sessions coalesce independently", () => {
+    const state = control()
+    const bus = {} satisfies EventControl
+    state.sessions.set("dag-a", "ses-a")
+    state.sessions.set("dag-b", "ses-b")
+    state.summaries.set("ses-a", [summary("dag-a", 1)])
+    state.summaries.set("ses-b", [summary("dag-b", 1)])
+
+    return withCollector((collector) =>
+      Effect.gen(function* () {
+        yield* (yield* DagSummaryPublisher.Service).init()
+        yield* Effect.all([publishNodeEvents(bus, "dag-a", 3), publishNodeEvents(bus, "dag-b", 3)], {
+          concurrency: "unbounded",
+        })
+        yield* pollWithTimeout(
+          Effect.sync(() => collector.emissions.length === 2 ? true : undefined),
+          "independent session summaries were not emitted",
+        )
+
+        expect(state.reads).toEqual(new Map([["ses-a", 1], ["ses-b", 1]]))
+        expect(collector.emissions.map((item) => item.sessionID).toSorted()).toEqual(["ses-a", "ses-b"])
+      }),
+    ).pipe(Effect.provide(runtime(state, bus)))
+  })
+
+  it.instance("failed reads release coordination and later events read fresh state", () => {
+    const state = control()
+    const bus = {} satisfies EventControl
+    state.failures = 1
+    state.sessions.set("dag-retry", "ses-retry")
+    state.summaries.set("ses-retry", [summary("dag-retry", 1)])
+
+    return withCollector((collector) =>
+      Effect.gen(function* () {
+        yield* (yield* DagSummaryPublisher.Service).init()
+        yield* publishNodeEvents(bus, "dag-retry", 1)
+        yield* pollWithTimeout(
+          Effect.sync(() => state.reads.get("ses-retry") === 1 ? true : undefined),
+          "failed summary read did not run",
+        )
+        expect(collector.emissions).toEqual([])
+
+        state.summaries.set("ses-retry", [summary("dag-retry", 2)])
+        yield* publishNodeEvents(bus, "dag-retry", 1)
+        yield* pollWithTimeout(
+          Effect.sync(() => collector.emissions.length === 1 ? true : undefined),
+          "summary publisher did not recover after failure",
+        )
+
+        expect(state.reads.get("ses-retry")).toBe(2)
+        expect(collector.emissions[0].summaries).toEqual([summary("dag-retry", 2)])
+      }),
+    ).pipe(Effect.provide(runtime(state, bus)))
   })
 })

--- a/packages/tui/src/context/sdk.tsx
+++ b/packages/tui/src/context/sdk.tsx
@@ -6,6 +6,20 @@ import { batch, onCleanup, onMount } from "solid-js"
 
 export type EventSource = {
   subscribe: (handler: (event: GlobalEvent) => void) => Promise<() => void>
+  /**
+   * Optional reconnect notifier. When the transport re-establishes a stream
+   * after a disconnect, this hook fires so the SDK can emit its local
+   * `reconnected` lifecycle signal. Absent in production (the SSE retry loop
+   * emits the signal directly); present in tests for deterministic injection.
+   */
+  onReconnect?: (handler: () => void) => () => void
+}
+
+export interface SdkEventEmitter {
+  emit(type: "event", event: GlobalEvent): void
+  emit(type: "reconnected"): void
+  on(type: "event", handler: (event: GlobalEvent) => void): () => void
+  on(type: "reconnected", handler: () => void): () => void
 }
 
 export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
@@ -32,15 +46,26 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
 
     let sdk = createSDK()
 
-    const handlers = new Set<(event: GlobalEvent) => void>()
-    const emitter = {
-      emit(_type: "event", event: GlobalEvent) {
-        for (const handler of handlers) handler(event)
+    const eventHandlers = new Set<(event: GlobalEvent) => void>()
+    const reconnectHandlers = new Set<() => void>()
+    const emitter: SdkEventEmitter = {
+      emit(type: "event" | "reconnected", event?: GlobalEvent) {
+        if (type === "event") {
+          for (const handler of eventHandlers) handler(event!)
+        } else {
+          for (const handler of reconnectHandlers) handler()
+        }
       },
-      on(_type: "event", handler: (event: GlobalEvent) => void) {
-        handlers.add(handler)
+      on(type: "event" | "reconnected", handler: ((event: GlobalEvent) => void) | (() => void)) {
+        if (type === "event") {
+          eventHandlers.add(handler as (event: GlobalEvent) => void)
+          return () => {
+            eventHandlers.delete(handler as (event: GlobalEvent) => void)
+          }
+        }
+        reconnectHandlers.add(handler as () => void)
         return () => {
-          handlers.delete(handler)
+          reconnectHandlers.delete(handler as () => void)
         }
       },
     }
@@ -93,6 +118,12 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
             sseMaxRetryAttempts: 0,
           })
 
+          // A retry that successfully acquires a stream is a reconnect —
+          // emit the lifecycle signal so consumers can recover state they
+          // may have missed while the transport was down. The first
+          // connection (attempt 0) is NOT a reconnect.
+          if (attempt > 0) emitter.emit("reconnected")
+
           if (Flag.OPENCODE_EXPERIMENTAL_WORKSPACES) {
             // Start syncing workspaces, it's important to do this after
             // we've started listening to events
@@ -121,6 +152,14 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
         const unsub = await props.events.subscribe(handleEvent)
         onCleanup(unsub)
 
+        // Plumb the optional reconnect notifier through the same local signal
+        // so tests and desktop event sources can trigger recovery without the
+        // SSE retry loop.
+        if (props.events.onReconnect) {
+          const unsubReconnect = props.events.onReconnect(() => emitter.emit("reconnected"))
+          onCleanup(unsubReconnect)
+        }
+
         if (Flag.OPENCODE_EXPERIMENTAL_WORKSPACES) {
           // Start syncing workspaces, it's important to do this after
           // we've started listening to events
@@ -135,7 +174,8 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
       abort.abort()
       sse?.abort()
       if (timer) clearTimeout(timer)
-      handlers.clear()
+      eventHandlers.clear()
+      reconnectHandlers.clear()
     })
 
     return {

--- a/packages/tui/src/context/sync.tsx
+++ b/packages/tui/src/context/sync.tsx
@@ -31,7 +31,7 @@ import { useTuiStartup } from "./runtime"
 import { createSimpleContext } from "./helper"
 import { useExit } from "./exit"
 import { useArgs } from "./args"
-import { batch, onMount } from "solid-js"
+import { batch, onCleanup, onMount } from "solid-js"
 import path from "path"
 import { useKV } from "./kv"
 import { TuiLog } from "../util/log"
@@ -565,8 +565,42 @@ export const {
         })
     }
 
+    // Reconnect recovery for DAG summaries: the summary publisher emits
+    // ephemeral events that are not durable. When the SSE stream reconnects,
+    // any events missed during the disconnect are unrecoverable by replay.
+    // This snapshots every session already represented in `store.dag` (the
+    // exact recovery set, not the visible-session query used by bootstrap)
+    // and replaces each slice with a fresh complete response. Deduplicated
+    // against an in-flight flag so rapid reconnects don't stack requests.
+    const refreshDagSummaries = (): Promise<void> => {
+      const sessionIDs = Object.keys(store.dag)
+      if (sessionIDs.length === 0) return Promise.resolve()
+      const workspace = project.workspace.current()
+      return Promise.all(
+        sessionIDs.map((sessionID) =>
+          sdk.client.dag
+            .summary({ sessionID, workspace })
+            .then((x) => setStore("dag", sessionID, reconcile(x.data ?? [])))
+            .catch(() => {}),
+        ),
+      ).then(() => undefined)
+    }
+
+    let dagReconnectInFlight = false
+    const unsubscribeReconnect = sdk.event.on("reconnected", () => {
+      if (dagReconnectInFlight) return
+      dagReconnectInFlight = true
+      refreshDagSummaries().finally(() => {
+        dagReconnectInFlight = false
+      })
+    })
+
     onMount(() => {
       void bootstrap()
+    })
+
+    onCleanup(() => {
+      unsubscribeReconnect()
     })
 
     const result = {

--- a/packages/tui/src/feature-plugins/system/dag-inspector-utils.ts
+++ b/packages/tui/src/feature-plugins/system/dag-inspector-utils.ts
@@ -1,15 +1,9 @@
 /** Pure topology helpers for the DAG inspector. Extracted for unit testing,
  * mirroring the diff-viewer-file-tree-utils pattern in this directory. */
 
-export interface DagNode {
-  id: string
-  name: string
-  status: string
-  worker_type: string
-  depends_on: string[]
-  child_session_id?: string
-  error_reason?: string
-}
+import type { DagNode } from "@opencode-ai/sdk/v2"
+
+export type { DagNode }
 
 /**
  * Group nodes into topological "waves": wave N contains every node whose

--- a/packages/tui/src/feature-plugins/system/dag-inspector.tsx
+++ b/packages/tui/src/feature-plugins/system/dag-inspector.tsx
@@ -50,17 +50,39 @@ function DagInspector(props: { api: TuiPluginApi }) {
     }
   }
 
+  // Per-workflow summary signature for change detection. Only re-fetch nodes
+  // when the selected workflow's node-level state actually changes.
+  let lastSignature = ""
+
+  const signatureFor = (wfId: string): string => {
+    const sid = params()?.sessionID
+    if (!sid) return ""
+    const wfs = props.api.state.session.dag(sid)
+    const wf = wfs.find((w) => w.id === wfId)
+    if (!wf) return ""
+    return `${wf.nodeCount}:${wf.completedNodes}:${wf.runningNodes}:${wf.failedNodes}`
+  }
+
   createEffect(() => {
     const wf = selectedWorkflow()
     if (!wf) {
       setNodes([])
+      lastSignature = ""
       return
     }
+    // Snapshot the signature at open time so the first summary event after
+    // open has something to compare against.
+    lastSignature = signatureFor(wf)
     void fetchNodes(wf)
-    // Re-fetch nodes when the summary publisher signals a change for this session.
-    // The summary event fires on any dag.* event that alters visible state,
-    // so it is the right trigger for refreshing node detail while the inspector is open.
-    const off = props.api.event.on("dag.workflow.summary.updated", () => {
+    // Re-fetch nodes only when a summary event for THIS session indicates the
+    // selected workflow's node-level state changed. Summary events for other
+    // sessions and unchanged summaries do not trigger a fetch.
+    const sid = params()?.sessionID
+    const off = props.api.event.on("dag.workflow.summary.updated", (event) => {
+      if (!sid || event.properties.sessionID !== sid) return
+      const sig = signatureFor(wf)
+      if (sig === lastSignature) return
+      lastSignature = sig
       void fetchNodes(wf)
     })
     onCleanup(() => off())

--- a/packages/tui/test/cli/cmd/tui/sync-dag.test.tsx
+++ b/packages/tui/test/cli/cmd/tui/sync-dag.test.tsx
@@ -2,6 +2,7 @@
 import { describe, expect, test } from "bun:test"
 import { tmpdir } from "../../../fixture/fixture"
 import { directory, mount, wait, json } from "./sync-fixture"
+import { produce } from "solid-js/store"
 import type { GlobalEvent } from "@opencode-ai/sdk/v2"
 import type { DagWorkflowSummary } from "@opencode-ai/sdk/v2"
 
@@ -97,6 +98,85 @@ describe("tui sync dag slice", () => {
       await wait(() => (sync.data.dag[sid]?.length ?? 0) > 0)
       expect(fetched).toContain(`/dag/session/${sid}/summary`)
       expect(sync.data.dag[sid][0]).toMatchObject({ completedNodes: 4, failedNodes: 1 })
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+
+  test("SSE reconnect re-fetches every session already in store.dag", async () => {
+    await using tmp = await tmpdir()
+    await Bun.write(`${tmp.path}/kv.json`, "{}")
+    const sid1 = "ses_reconnect_1"
+    const sid2 = "ses_reconnect_2"
+    // A session that is VISIBLE in the session list but NOT in store.dag —
+    // reconnect compensation must NOT fetch it.
+    const sidVisibleUntracked = "ses_visible_untracked"
+    const summaryFetches: string[] = []
+    let reconnectCallCount = 0
+
+    const visibleSessionRow = {
+      id: sidVisibleUntracked,
+      slug: "visible-untracked",
+      projectID: "proj_test",
+      directory,
+      version: "test",
+      time: { created: 0, updated: 0 },
+    }
+
+    const { app, emit, reconnect, sync } = await mount((url) => {
+      // Expose one visible session that bootstrap will add to store.session.
+      // Its summary endpoint is intentionally NOT mocked so bootstrap's fetch
+      // throws (swallowed by .catch), keeping it OUT of store.dag — proving
+      // reconnect's recovery set is store.dag keys, not the visible-session query.
+      if (url.pathname === "/session") return json([visibleSessionRow])
+      if (url.pathname === `/dag/session/${sidVisibleUntracked}/summary`) {
+        summaryFetches.push(sidVisibleUntracked)
+        return json([])
+      }
+      if (url.pathname === `/dag/session/${sid1}/summary`) {
+        summaryFetches.push(sid1)
+        return json([summary(reconnectCallCount > 0 ? 9 : 1, 10)])
+      }
+      if (url.pathname === `/dag/session/${sid2}/summary`) {
+        summaryFetches.push(sid2)
+        return json([summary(reconnectCallCount > 0 ? 5 : 1, 6)])
+      }
+      return undefined
+    }, tmp.path)
+
+    try {
+      // Confirm the visible session is in store.session and bootstrap created
+      // an empty store.dag entry for it.
+      await wait(() => sync.data.session.some((s) => s.id === sidVisibleUntracked))
+      await wait(() => sidVisibleUntracked in sync.data.dag)
+
+      // Remove the visible session's empty store.dag entry so it is genuinely
+      // NOT tracked at reconnect time — simulating a session with no workflows
+      // that the user never opened a DAG view for.
+      sync.set("dag", produce((draft) => { delete draft[sidVisibleUntracked] }))
+      expect(sync.data.dag[sidVisibleUntracked]).toBeUndefined()
+
+      // Populate store.dag with two sessions via summary events.
+      emit(summaryEvent([summary(1, 10)], sid1))
+      emit(summaryEvent([summary(1, 6)], sid2))
+      await wait(() => !!sync.data.dag[sid1]?.length && !!sync.data.dag[sid2]?.length)
+
+      // Snapshot which sessions were fetched BEFORE reconnect so we can
+      // isolate the reconnect-triggered fetches.
+      const fetchedBefore = [...summaryFetches]
+
+      // Trigger reconnect — should re-fetch BOTH tracked sessions only.
+      reconnectCallCount += 1
+      reconnect()
+      await wait(() => sync.data.dag[sid1]?.[0]?.completedNodes === 9)
+      await wait(() => sync.data.dag[sid2]?.[0]?.completedNodes === 5)
+
+      const fetchedOnReconnect = summaryFetches.filter((s) => !fetchedBefore.includes(s))
+      expect(fetchedOnReconnect).toContain(sid1)
+      expect(fetchedOnReconnect).toContain(sid2)
+      // The visible-but-untracked session must NOT be fetched on reconnect —
+      // the recovery set is store.dag, not the visible-session query.
+      expect(fetchedOnReconnect).not.toContain(sidVisibleUntracked)
     } finally {
       app.renderer.destroy()
     }

--- a/packages/tui/test/cli/cmd/tui/sync-fixture.tsx
+++ b/packages/tui/test/cli/cmd/tui/sync-fixture.tsx
@@ -63,5 +63,5 @@ export async function mount(override?: FetchHandler, state?: string) {
 
   await ready
   await wait(() => sync.status === "complete")
-  return { app, emit: events.emit, kv, project, sync, session: calls.session }
+  return { app, emit: events.emit, reconnect: events.reconnect, kv, project, sync, session: calls.session }
 }

--- a/packages/tui/test/feature-plugins/dag-inspector-utils.test.ts
+++ b/packages/tui/test/feature-plugins/dag-inspector-utils.test.ts
@@ -3,9 +3,11 @@ import { computeWaves, type DagNode } from "../../src/feature-plugins/system/dag
 
 const node = (id: string, depends_on: string[] = [], name = id): DagNode => ({
   id,
+  workflow_id: "wf-1",
   name,
   status: "pending",
   worker_type: "task",
+  required: false,
   depends_on,
 })
 

--- a/packages/tui/test/feature-plugins/dag-inspector.test.tsx
+++ b/packages/tui/test/feature-plugins/dag-inspector.test.tsx
@@ -1,27 +1,20 @@
 /** @jsxImportSource @opentui/solid */
-import { describe, expect, test, mock } from "bun:test"
+import { describe, expect, test } from "bun:test"
 import { createDefaultOpenTuiKeymap } from "@opentui/keymap/opentui"
 import { testRender, useRenderer } from "@opentui/solid"
 import type { TuiPluginApi, TuiRouteCurrent, TuiRouteDefinition } from "@opencode-ai/plugin/tui"
-import type { DagWorkflowSummary } from "@opencode-ai/sdk/v2"
+import type { DagNode, DagWorkflowSummary } from "@opencode-ai/sdk/v2"
 import { KVProvider } from "../../src/context/kv"
 import { ThemeProvider } from "../../src/context/theme"
 import { TuiConfigProvider } from "../../src/config"
 import { OpencodeKeymapProvider } from "../../src/keymap"
+import { createSignal } from "solid-js"
 import dagInspectorPlugin from "../../src/feature-plugins/system/dag-inspector"
 import { createTuiPluginApi } from "../fixture/tui-plugin"
 import { createTuiResolvedConfig } from "../fixture/tui-runtime"
 import { TestTuiContexts } from "../fixture/tui-environment"
 
-interface DagNodeRow {
-  id: string
-  name: string
-  status: string
-  worker_type: string
-  depends_on: string[]
-  child_session_id?: string | null
-  error_reason?: string | null
-}
+const SESSION_ID = "ses_1"
 
 const wfSummary = (overrides: Partial<DagWorkflowSummary> = {}): DagWorkflowSummary => ({
   id: "wf-1",
@@ -36,8 +29,20 @@ const wfSummary = (overrides: Partial<DagWorkflowSummary> = {}): DagWorkflowSumm
 
 type RenderOpts = {
   workflows?: DagWorkflowSummary[]
-  nodes?: DagNodeRow[]
+  nodes?: DagNode[]
   initialRoute?: TuiRouteCurrent
+}
+
+function dagNode(overrides: Partial<DagNode> & { id: string }): DagNode {
+  return {
+    workflow_id: "wf-1",
+    name: overrides.id,
+    status: "pending",
+    worker_type: "build",
+    required: false,
+    depends_on: [],
+    ...overrides,
+  }
 }
 
 async function renderDagInspector(opts: RenderOpts = {}) {
@@ -45,15 +50,17 @@ async function renderDagInspector(opts: RenderOpts = {}) {
     string,
     NonNullable<Parameters<TuiPluginApi["keymap"]["registerLayer"]>[0]["commands"]>[number]
   >()
-  let current: TuiRouteCurrent =
-    opts.initialRoute ?? { name: "dag", params: { sessionID: "ses_1" } }
+  const [current, setCurrent] = createSignal<TuiRouteCurrent>(opts.initialRoute ?? { name: "dag", params: { sessionID: SESSION_ID } })
   let renderInspector: TuiRouteDefinition["render"] | undefined
+
+  // Updatable workflow state for change detection.
+  let workflowsState = opts.workflows ?? []
 
   // Trackable spies
   const nodesCalls: string[] = []
   const navigations: { name: string; params?: Record<string, unknown> }[] = []
   const toasts: { variant?: string; message: string }[] = []
-  const eventHandlers = new Map<string, () => void>()
+  const eventHandlers = new Map<string, (event: never) => void>()
 
   const config = createTuiResolvedConfig()
 
@@ -77,11 +84,11 @@ async function renderDagInspector(opts: RenderOpts = {}) {
       } as unknown as TuiPluginApi["client"],
       state: {
         session: {
-          dag: () => opts.workflows ?? [],
+          dag: () => workflowsState,
         },
       },
       event: {
-        on: ((type: string, handler: () => void) => {
+        on: ((type: string, handler: (event: never) => void) => {
           eventHandlers.set(type, handler)
           return () => eventHandlers.delete(type)
         }) as unknown as TuiPluginApi["event"]["on"],
@@ -96,10 +103,10 @@ async function renderDagInspector(opts: RenderOpts = {}) {
         },
         navigate(name, params) {
           navigations.push({ name, params })
-          current = params ? { name, params } : { name }
+          setCurrent(params ? { name, params } : { name })
         },
         get current() {
-          return current
+          return current()
         },
       },
       ui: {
@@ -116,7 +123,12 @@ async function renderDagInspector(opts: RenderOpts = {}) {
           <TuiConfigProvider config={config}>
             <KVProvider>
               <ThemeProvider mode="dark">
-                {renderInspector?.({ params: "params" in current ? current.params : undefined })}
+                {(() => {
+                  const route = current()
+                  if (route.name !== "dag") return null
+                  const params = "params" in route ? route.params : undefined
+                  return renderInspector?.({ params })
+                })()}
               </ThemeProvider>
             </KVProvider>
           </TuiConfigProvider>
@@ -126,8 +138,9 @@ async function renderDagInspector(opts: RenderOpts = {}) {
   }
 
   const app = await testRender(() => <Harness />, { width: 100, height: 30 })
-  // Wait for the inspector commands to be registered.
   await waitForCommand(app, commands, "dag.close")
+  // Give the initial fetchNodes a chance to resolve.
+  await waitForCondition(() => nodesCalls.length > 0)
 
   return {
     app,
@@ -135,8 +148,16 @@ async function renderDagInspector(opts: RenderOpts = {}) {
     navigations: () => navigations,
     toasts: () => toasts,
     nodesCalls: () => nodesCalls,
-    emitSummaryUpdate: () => eventHandlers.get("dag.workflow.summary.updated")?.(),
-    current: () => current,
+    setWorkflows: (wfs: DagWorkflowSummary[]) => {
+      workflowsState = wfs
+    },
+    emitSummaryUpdate: (sessionID: string = SESSION_ID) => {
+      eventHandlers.get("dag.workflow.summary.updated")?.({
+        type: "dag.workflow.summary.updated",
+        properties: { sessionID, summaries: workflowsState },
+      } as never)
+    },
+    current: () => current(),
   }
 }
 
@@ -154,32 +175,93 @@ async function waitForCommand(
   }
 }
 
+async function waitForCondition(fn: () => boolean, timeout = 2000) {
+  const start = Date.now()
+  while (!fn()) {
+    if (Date.now() - start > timeout) throw new Error("timed out waiting for condition")
+    await Bun.sleep(10)
+  }
+}
+
 describe("DagInspector", () => {
   test("mounting fetches nodes for the auto-selected workflow", async () => {
     const viewer = await renderDagInspector({
       workflows: [wfSummary({ id: "wf-1", nodeCount: 1 })],
-      nodes: [{ id: "n-1", name: "build", status: "pending", worker_type: "build", depends_on: [] }],
+      nodes: [dagNode({ id: "n-1", name: "build", status: "pending" })],
     })
     try {
-      await Bun.sleep(30)
       expect(viewer.nodesCalls()).toContain("wf-1")
     } finally {
       viewer.app.renderer.destroy()
     }
   })
 
-  test("dag.workflow.summary.updated event triggers a node re-fetch", async () => {
+  test("changed summary for the open session triggers a node re-fetch", async () => {
     const viewer = await renderDagInspector({
-      workflows: [wfSummary({ id: "wf-1" })],
-      nodes: [{ id: "n-1", name: "build", status: "running", worker_type: "build", depends_on: [] }],
+      workflows: [wfSummary({ id: "wf-1", completedNodes: 0 })],
+      nodes: [dagNode({ id: "n-1", name: "build", status: "running" })],
     })
     try {
-      await Bun.sleep(20)
       const before = viewer.nodesCalls().length
+      // Update the workflow summary to show a change in completedNodes.
+      viewer.setWorkflows([wfSummary({ id: "wf-1", completedNodes: 1 })])
       viewer.emitSummaryUpdate()
+      await waitForCondition(() => viewer.nodesCalls().length > before)
+    } finally {
+      viewer.app.renderer.destroy()
+    }
+  })
+
+  test("summary for another session does not trigger a re-fetch", async () => {
+    const viewer = await renderDagInspector({
+      workflows: [wfSummary({ id: "wf-1", completedNodes: 0 })],
+      nodes: [dagNode({ id: "n-1", name: "build", status: "running" })],
+    })
+    try {
+      const before = viewer.nodesCalls().length
+      viewer.setWorkflows([wfSummary({ id: "wf-1", completedNodes: 1 })])
+      // Emit for a different session — should be filtered out.
+      viewer.emitSummaryUpdate("other_session")
+      await Bun.sleep(50)
+      expect(viewer.nodesCalls().length).toBe(before)
+    } finally {
+      viewer.app.renderer.destroy()
+    }
+  })
+
+  test("unchanged summary does not trigger a re-fetch", async () => {
+    const viewer = await renderDagInspector({
+      workflows: [wfSummary({ id: "wf-1", completedNodes: 0 })],
+      nodes: [dagNode({ id: "n-1", name: "build", status: "running" })],
+    })
+    try {
+      const before = viewer.nodesCalls().length
+      // Don't change the workflow state — signature stays the same.
+      viewer.emitSummaryUpdate()
+      await Bun.sleep(50)
+      expect(viewer.nodesCalls().length).toBe(before)
+    } finally {
+      viewer.app.renderer.destroy()
+    }
+  })
+
+  test("closing the inspector prevents further fetches", async () => {
+    const viewer = await renderDagInspector({
+      initialRoute: { name: "dag", params: { sessionID: SESSION_ID, returnRoute: { name: "session", params: { sessionID: SESSION_ID } } } },
+      workflows: [wfSummary({ id: "wf-1" })],
+      nodes: [dagNode({ id: "n-1", name: "build", status: "pending" })],
+    })
+    try {
+      // Close the inspector — navigates away, unmounts the component.
+      viewer.commands.get("dag.close")!.run?.({} as never)
       await Bun.sleep(20)
-      const after = viewer.nodesCalls().length
-      expect(after).toBeGreaterThan(before)
+
+      const before = viewer.nodesCalls().length
+      // After close, summary changes should NOT trigger fetches.
+      viewer.setWorkflows([wfSummary({ id: "wf-1", completedNodes: 5 })])
+      viewer.emitSummaryUpdate()
+      await Bun.sleep(50)
+      expect(viewer.nodesCalls().length).toBe(before)
     } finally {
       viewer.app.renderer.destroy()
     }
@@ -188,20 +270,10 @@ describe("DagInspector", () => {
   test("dag.enter navigates into the selected node's child session", async () => {
     const viewer = await renderDagInspector({
       workflows: [wfSummary({ id: "wf-1" })],
-      nodes: [
-        {
-          id: "n-1",
-          name: "build",
-          status: "running",
-          worker_type: "build",
-          depends_on: [],
-          child_session_id: "child_ses_1",
-        },
-      ],
+      nodes: [dagNode({ id: "n-1", name: "build", status: "running", child_session_id: "child_ses_1" })],
     })
     try {
       viewer.commands.get("dag.enter")!.run?.({} as never)
-      await Bun.sleep(10)
       expect(viewer.navigations()).toContainEqual(
         expect.objectContaining({ name: "session", params: expect.objectContaining({ sessionID: "child_ses_1" }) }),
       )
@@ -213,11 +285,10 @@ describe("DagInspector", () => {
   test("dag.enter toasts when the node has no child session yet", async () => {
     const viewer = await renderDagInspector({
       workflows: [wfSummary({ id: "wf-1" })],
-      nodes: [{ id: "n-1", name: "build", status: "pending", worker_type: "build", depends_on: [], child_session_id: null }],
+      nodes: [dagNode({ id: "n-1", name: "build", status: "pending" })],
     })
     try {
       viewer.commands.get("dag.enter")!.run?.({} as never)
-      await Bun.sleep(10)
       expect(viewer.toasts().some((t) => /no session/i.test(t.message))).toBe(true)
     } finally {
       viewer.app.renderer.destroy()
@@ -225,17 +296,57 @@ describe("DagInspector", () => {
   })
 
   test("dag.close navigates back to the return route", async () => {
-    const returnRoute = { name: "session", params: { sessionID: "ses_1" } }
+    const returnRoute = { name: "session", params: { sessionID: SESSION_ID } }
     const viewer = await renderDagInspector({
-      initialRoute: { name: "dag", params: { sessionID: "ses_1", returnRoute } },
+      initialRoute: { name: "dag", params: { sessionID: SESSION_ID, returnRoute } },
       workflows: [wfSummary({ id: "wf-1" })],
     })
     try {
       viewer.commands.get("dag.close")!.run?.({} as never)
-      await Bun.sleep(10)
       expect(viewer.navigations().at(-1)).toEqual(
-        expect.objectContaining({ name: "session", params: { sessionID: "ses_1" } }),
+        expect.objectContaining({ name: "session", params: { sessionID: SESSION_ID } }),
       )
+    } finally {
+      viewer.app.renderer.destroy()
+    }
+  })
+
+  test("changing workflow replaces subscriptions so only the new selection refreshes", async () => {
+    const viewer = await renderDagInspector({
+      workflows: [
+        wfSummary({ id: "wf-1", completedNodes: 0, nodeCount: 2 }),
+        wfSummary({ id: "wf-2", completedNodes: 0, nodeCount: 2 }),
+      ],
+      nodes: [dagNode({ id: "n-1", workflow_id: "wf-1", name: "build", status: "running" })],
+    })
+    try {
+      // Auto-selection picks wf-1; its initial fetch has resolved.
+      await waitForCondition(() => viewer.nodesCalls().some((id) => id === "wf-1"))
+
+      // Switch selection wf-1 -> wf-2.
+      viewer.commands.get("dag.next_workflow")!.run?.({} as never)
+      // The new selection fetches wf-2's nodes.
+      await waitForCondition(() => viewer.nodesCalls().some((id) => id === "wf-2"))
+
+      const before = viewer.nodesCalls().length
+      // Now change ONLY wf-1's summary (the previously selected workflow).
+      // Because the subscription now tracks wf-2's signature, wf-1's change
+      // alone must NOT trigger a fetch.
+      viewer.setWorkflows([
+        wfSummary({ id: "wf-1", completedNodes: 1, nodeCount: 2 }),
+        wfSummary({ id: "wf-2", completedNodes: 0, nodeCount: 2 }),
+      ])
+      viewer.emitSummaryUpdate()
+      await Bun.sleep(50)
+      expect(viewer.nodesCalls().length).toBe(before)
+
+      // Changing wf-2's summary DOES refresh (the active selection).
+      viewer.setWorkflows([
+        wfSummary({ id: "wf-1", completedNodes: 1, nodeCount: 2 }),
+        wfSummary({ id: "wf-2", completedNodes: 2, nodeCount: 2 }),
+      ])
+      viewer.emitSummaryUpdate()
+      await waitForCondition(() => viewer.nodesCalls().length > before)
     } finally {
       viewer.app.renderer.destroy()
     }
@@ -244,20 +355,10 @@ describe("DagInspector", () => {
   test("a failed node renders its error_reason in the inspector", async () => {
     const viewer = await renderDagInspector({
       workflows: [wfSummary({ id: "wf-1", failedNodes: 1, nodeCount: 1 })],
-      nodes: [
-        {
-          id: "n-1",
-          name: "build",
-          status: "failed",
-          worker_type: "build",
-          depends_on: [],
-          error_reason: "compile error in main.ts",
-        },
-      ],
+      nodes: [dagNode({ id: "n-1", name: "build", status: "failed", error_reason: "compile error in main.ts" })],
     })
     try {
       await viewer.app.waitForFrame((frame) => frame.includes("compile error in main.ts"))
-      // The error reason must reach the rendered frame. The guard above throws on timeout if absent.
     } finally {
       viewer.app.renderer.destroy()
     }

--- a/packages/tui/test/fixture/tui-sdk.ts
+++ b/packages/tui/test/fixture/tui-sdk.ts
@@ -17,6 +17,7 @@ export function eventSource(): EventSource {
 
 export function createEventSource() {
   let fn: ((event: GlobalEvent) => void) | undefined
+  let reconnectFns = new Set<() => void>()
   let stream: ReadableStreamDefaultController<Uint8Array> | undefined
   const pending: Uint8Array[] = []
   return {
@@ -25,6 +26,12 @@ export function createEventSource() {
         fn = handler
         return () => {
           if (fn === handler) fn = undefined
+        }
+      },
+      onReconnect: (handler: () => void) => {
+        reconnectFns.add(handler)
+        return () => {
+          reconnectFns.delete(handler)
         }
       },
     } satisfies EventSource,
@@ -41,6 +48,9 @@ export function createEventSource() {
       )
       if (stream) return stream.enqueue(chunk)
       pending.push(chunk)
+    },
+    reconnect() {
+      for (const handler of reconnectFns) handler()
     },
     response() {
       return new Response(


### PR DESCRIPTION
## What

Fixes three behavior contracts in the DAG observability pipeline that the prior change `fix/dag-observability-contracts` (PR #103) left weakened or untested. Surfaced via two-axis review and now verified.

## Changes

### Summary publisher — deterministic coalescing (`summary-publisher.ts`)
- Replaced the single-`Effect.yieldNow` coalescing with a deterministic **50 ms per-session window**. Five same-session events in the window now collapse into **exactly one `getWorkflowSummaries` read and one `dag.workflow.summary.updated` emission** (previously scheduler-dependent).
- Coalescing state is **owner-scoped**: the coalesced early-return no longer touches `pending`, so a coalesced caller cannot delete the owner's slot and reopen the window (the bug the verify agent caught and we fixed).
- Different sessions coalesce independently; failed read-and-publish cycles release coordination.

### SSE reconnect recovery (`sdk.tsx`, `sync.tsx`)
- SDK context exposes a typed **`reconnected` lifecycle signal**, emitted only after a retry (`attempt > 0`) acquires a new stream — not on initial connection.
- `SyncProvider` subscribes and on reconnect snapshots `Object.keys(store.dag)` (the exact recovery set, **not** the visible-session query) and re-fetches each tracked session's summary, replacing each store slice. In-flight deduplication now **holds until all fetches resolve** (the review-found bug where `refreshDagSummaries` returned `void` and the flag cleared prematurely is fixed).

### DagInspector — session + change detection (`dag-inspector.tsx`, `dag-inspector-utils.ts`)
- Re-fetch fires **only** when a `dag.workflow.summary.updated` event for the open workflow's session arrives **and** the per-workflow summary changed (nodeCount / completedNodes / runningNodes / failedNodes). Other-session and unchanged summaries no longer trigger fetches.
- Subscriptions are cancelled on workflow change and route unmount.
- Hand-duplicated `DagNode` interface replaced with the **generated SDK `DagNode` type**.

### Tests
- Removed fixed timing sleeps used as readiness synchronization; replaced with `pollWithTimeout`, request/state/frame waits.
- New assertions: one read / one emission, independent session coalescing, failure recovery, reconnect exclusion of visible-but-untracked sessions, session+signature filtering, workflow-switch subscription replacement, post-close fetch prevention.

## Spec

OpenSpec change `fix-dag-observability-contracts` is implemented, reviewed, fixed, and **archived**. Delta specs synced to `openspec/specs/dag-runtime-wiring/spec.md`.

## Verification

- `bun typecheck` clean in `packages/opencode` and `packages/tui` (pre-commit hook ran full turbo typecheck: 29/29).
- Targeted tests: publisher 4/4, sync-dag 4/4, inspector 10/10, inspector-utils 6/6.
- Broader suites: DAG suite 135/135, TUI suite 64/64.

## Risk

Low. No HTTP shape, SDK schema, database, or durable-event changes. The 50 ms window adds bounded display latency (below interactive thresholds) and replaces unbounded scheduler variance.