### PR TITLE
fix(dag): terminalize lost executions on recovery

### DIFF
--- a/openspec/changes/dag-post-crash-continuation/.openspec.yaml
+++ b/openspec/changes/dag-post-crash-continuation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-23

--- a/openspec/changes/dag-post-crash-continuation/design.md
+++ b/openspec/changes/dag-post-crash-continuation/design.md
@@ -1,0 +1,111 @@
+## Context
+
+DAG 节点执行同时存在两类状态：
+
+1. SQLite/EventV2 中的持久状态，例如节点 `running`、`child_session_id` 和 `deadline_ms`。
+2. `DagLoop.WorkflowEntry.fibers` 中的进程本地执行所有权，真正驱动 `SessionPrompt.prompt()`、timeout 和最终 `NodeCompleted`/`NodeFailed`。
+
+进程崩溃会保留第一类状态并永久销毁第二类状态。当前 `reconcileWorkflow()` 在 child Session 看似 `active`/`unknown` 且 deadline 未过期时保留节点 `running`，但不会恢复 provider turn，也不会安装 completion watcher。由于 child Session 的终态不会自动变成 DAG 终态事件，这类节点可能永远悬挂。
+
+项目的 V2 Session 约束明确规定：本地 Session drain 没有 durable execution identity，崩溃后的 provider work 不得在没有独立设计的情况下自动重试。恢复方案因此必须优先保证“不重复执行工具/副作用”和“workflow 最终可达终态”，不能把数据库中的 `active` 当作可恢复执行所有权。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 为 recovered-running 节点建立明确、可测试的执行所有权规则。
+- 不自动重试 provider/tool work 的前提下消除永久 `running`。
+- 继续复用既有 `NodeFailed`、依赖级联、workflow 终态和 wake delivery 链路。
+- 保持已完成 child Session 的结构化输出恢复行为。
+- 用真实服务层级的集成测试覆盖启动恢复，而不只测试纯 `WorkflowRuntime`。
+
+**Non-Goals:**
+
+- 不实现 durable provider-turn checkpoint 或工具调用 exactly-once。
+- 不调用 `SessionExecution.wake()` 自动续跑崩溃前的 provider turn。
+- 不引入集群执行所有权、lease 或远程 worker adoption。
+- 不修改数据库 schema、HTTP API、SDK、TUI 或 replan 产品语义。
+- 不在本 change 中大规模拆分 `DagLoop` 或重构 `planReplan`。
+
+## Decisions
+
+### D1: 进程本地 fiber 是 DAG 节点执行所有权的唯一证明
+
+恢复后的 `WorkflowEntry.fibers` 初始为空。数据库中的 `status = running` 和 Session 的最后消息只能说明崩溃前的投影状态，不能证明当前进程仍有执行在推进。
+
+因此，启动恢复扫描发现的每个 `running` 节点都必须在 `reconcileWorkflow()` 内完成一次确定性分类，函数返回后不得留下无当前进程 fiber 所有权的 `running` 节点。
+
+**备选：**把 child Session 的 `active` 状态当作仍在执行。否决，因为当前 Session drain 是进程本地的，重启后没有执行所有权或终态桥接。
+
+### D2: 已结算结果投影；未结算执行确定性失败
+
+恢复分类顺序如下：
+
+1. 无 `childSessionId`：发布 `NodeFailed(exec_failed)`。
+2. child Session 已完成：沿用现有 output schema/captured output 判定，发布 `NodeCompleted` 或 `NodeFailed(verdict_fail)`。
+3. child Session 已失败：发布 `NodeFailed(exec_failed)`。
+4. child Session 为 `active` 或 `unknown`：
+   - deadline 已过：先 best-effort cancel child Session，再发布 `NodeFailed(timeout)`，原因保持 `deadline exceeded on recovery`。
+   - deadline 未过或未设置：先 best-effort cancel child Session，再发布 `NodeFailed(exec_failed)`，原因明确为 `execution ownership lost on recovery`。
+
+取消失败不得阻止 DAG 终态化；失败应记录结构化 warning。投影器的终态守卫负责拒绝之后可能到达的过期 `NodeStarted`/`NodeCompleted`。
+
+**备选：**等待 deadline。否决，因为无 deadline 节点仍会永久悬挂，且未来 deadline 也没有本地 timeout fiber 负责触发。
+
+### D3: 恢复不隐式创建新执行尝试
+
+恢复流程不得调用 `spawnNode`、`SessionExecution.wake` 或重新提交旧 prompt 来延续 recovered-running 节点。需要继续业务工作时，parent orchestrator 必须通过既有 workflow `replan`/restart 创建一个显式新尝试。
+
+这会把“可能重复执行副作用”的隐式恢复，转换为“旧尝试失败、后续尝试有明确控制事件”的可审计过程。
+
+**备选：**自动把节点重置为 pending 并重跑。否决，因为工具调用和外部副作用没有 durable attempt identity 或 exactly-once 保证。
+
+### D4: 恢复失败继续走标准 DAG 事件闭环
+
+不增加新的节点状态或旁路恢复表。恢复只调用公开的 `Dag.Service.nodeCompleted/nodeFailed`：
+
+- Projector 更新 read model；
+- DagLoop 的既有节点终态 handler 更新 `WorkflowRuntime`；
+- required failure 触发现有 workflow cancel；
+- optional failure 允许既有调度继续；
+- `report_to_parent` 和 workflow terminal 继续使用既有 durable wake eligibility。
+
+`reconcileWorkflow()` 的返回统计改为反映实际结果，例如 `reconciled` 和 `ownershipLost`；不再暴露暗示节点仍可推进的 `leftRunning`，或至少强制该值在恢复后为零。
+
+### D5: 增加真实 DagLoop 启动恢复集成夹具
+
+新增测试应构造包含 Database、EventV2Bridge、DagProjector、DagStore、Dag.Service 和 DagLoop 的服务层，并以可控的 Session/SessionPrompt 服务替代真实 provider。
+
+至少覆盖：
+
+- active child + future deadline → cancel + `NodeFailed(exec_failed)`；
+- active child + no deadline → cancel + `NodeFailed(exec_failed)`；
+- active child + expired deadline → cancel + `NodeFailed(timeout)`；
+- completed child + captured output → `NodeCompleted`；
+- 恢复完成后 read model 不存在无本地所有权的 `running` 节点；
+- 恢复产生的终态事件只投影一次，且不会触发 replacement spawn；
+- wake-eligible node failure 仍可被既有 unreported wake 查询发现。
+
+测试不得使用 `globalThis` mock；通过 Effect Layer 和现有 fixture 注入服务。
+
+## Risks / Trade-offs
+
+- **[恢复时可能放弃一个外部仍在运行的请求]** → 当前产品明确是进程本地执行；先调用 child Session cancel，并以终态投影守卫拒绝迟到事件。未来引入远程执行时必须先增加 durable ownership lease，再修改本契约。
+- **[节点在未过 deadline 时更早失败]** → 这是执行所有权丢失后的真实状态，不是超时；使用 `exec_failed` 和明确 reason，让 orchestrator 可选择 replan/restart。
+- **[required 节点恢复失败会取消 workflow]** → 复用既有 required failure 语义，避免新增仅用于恢复的状态机分支。
+- **[取消 child Session 失败后仍可能出现迟到输出]** → 记录 warning，依赖 Projector 终态守卫保持 DAG read model 不被复活。
+- **[集成夹具依赖较多、测试成本上升]** → 只覆盖启动恢复关键路径；纯调度排列组合继续留在快速单元测试中。
+
+## Migration Plan
+
+1. 先补恢复单元测试和服务层集成夹具，使当前行为以失败测试暴露。
+2. 修改 `reconcileWorkflow()` 分类与取消顺序。
+3. 调整 DagLoop rehydration 对恢复统计的处理与日志。
+4. 运行 DAG 全量测试、core/opencode typecheck 和 HTTP exercise（确认无路由缺失）。
+5. 部署无需数据迁移；已有悬挂 workflow 会在下一次实例启动/初始化时被确定性终态化。
+
+回滚只需恢复旧 reconciliation 分支；不会涉及 schema 回退，但会重新引入 recovered-running 永久悬挂风险。
+
+## Open Questions
+
+- 本 change 使用现有 `exec_failed` trigger 并把 `execution ownership lost on recovery` 放入 reason。若后续需要按恢复故障单独统计，可另行增加 `recovery_lost` trigger；本次不扩展事件 schema。

--- a/openspec/changes/dag-post-crash-continuation/proposal.md
+++ b/openspec/changes/dag-post-crash-continuation/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+DAG 节点执行由进程内 fiber 驱动；进程崩溃后，持久化读模型可能仍把节点记为 `running`，但原 fiber 已永久丢失。当前恢复逻辑会把 child Session 看似 `active` 且未过 deadline 的节点继续留在 `running`，同时不恢复执行、不安装 watcher，也没有任何 DAG 终态事件可触发 wake，导致 workflow 可能永久悬挂。
+
+## What Changes
+
+- 明确进程重启后的执行所有权语义：不存在当前进程执行 fiber 的 recovered-running 节点不得被当作仍在推进。
+- 恢复时先投影已经完成或失败的 child Session；对仍为 `active`/`unknown` 且已失去执行所有权的节点，停止旧 child Session 并确定性发布 `NodeFailed`，不隐式重试 provider/tool 执行。
+- 保留 deadline 优先语义：已过 deadline 的 recovered-running 节点继续以 `timeout` 失败；未过 deadline 或无 deadline 也不得无限保持 `running`。
+- 让节点失败、依赖级联、workflow 终态与 parent wake 继续通过既有 DAG 事件链路发生，显式 replan/restart 仍是恢复业务工作的唯一入口。
+- 新增真实 DagLoop 恢复集成测试，覆盖 EventV2、Projector、DagStore、DagLoop、child Session 状态判断和 wake eligibility，而不是只直接驱动 `WorkflowRuntime`。
+- 删除或修订“active child Session 会自行通过正常 wake 产生 DAG 终态”的失效假设与相关测试。
+
+## Capabilities
+
+### New Capabilities
+
+- 无。
+
+### Modified Capabilities
+
+- `dag-scheduler-recovery`: 将失去当前进程执行所有权的 recovered-running 节点从“继续等待”改为“不自动重试、确定性终态化”，消除无 deadline 节点的永久悬挂。
+- `dag-execution-engine`: 明确 node execution fiber 是进程本地执行所有权；恢复流程不得假定旧 provider turn 会继续，也不得在没有显式新执行尝试的情况下保留 `running`。
+
+## Impact
+
+- `packages/opencode/src/dag/runtime/recovery.ts`：恢复判定、旧 child Session 取消和终态发布。
+- `packages/opencode/src/dag/runtime/loop.ts`：rehydration 对 reconciliation 结果的处理与恢复可观测性。
+- `packages/opencode/test/dag/`：恢复单元测试和真实 DagLoop 层级集成测试。
+- `openspec/specs/dag-scheduler-recovery`、`openspec/specs/dag-execution-engine`：修订恢复契约。
+- 不修改数据库 schema、HTTP API、SDK 或 TUI 数据结构。
+- 行为变化：进程重启时仍显示 active/unknown、但没有当前进程执行所有权的节点将失败并进入既有级联/唤醒流程，而不是无限保持 `running`。

--- a/openspec/changes/dag-post-crash-continuation/specs/dag-execution-engine/spec.md
+++ b/openspec/changes/dag-post-crash-continuation/specs/dag-execution-engine/spec.md
@@ -1,0 +1,71 @@
+## ADDED Requirements
+
+### Requirement: DAG node execution ownership is process-local
+
+A node SHALL be considered actively executing only while the current process owns its tracked node execution fiber. Persisted node status, child Session identity, and a non-terminal child Session projection SHALL NOT by themselves constitute execution ownership after a process restart.
+
+#### Scenario: persisted running status does not restore execution ownership
+
+- **WHEN** a process restarts with a node persisted as `running`
+- **AND** the new DagLoop has no tracked fiber for that node
+- **THEN** the system SHALL treat the previous execution attempt as having lost ownership
+- **AND** SHALL reconcile it through `dag-scheduler-recovery`
+
+#### Scenario: current-process fiber proves active execution
+
+- **WHEN** `spawnReady` creates a node execution fiber in the current process
+- **AND** stores it in `WorkflowEntry.fibers`
+- **THEN** the node MAY be treated as actively making progress until that fiber terminates or is interrupted
+
+### Requirement: Crash recovery does not retry provider work implicitly
+
+The DAG runtime MUST NOT automatically retry or continue provider/tool execution merely because a recovered child Session is non-terminal. A new execution attempt SHALL require an explicit scheduling transition produced by normal workflow control, such as replan/restart, after the lost attempt has reached a DAG terminal state.
+
+#### Scenario: recovery does not invoke provider continuation
+
+- **WHEN** recovery finds a child Session classified as `active` or `unknown`
+- **THEN** it SHALL NOT call `SessionExecution.wake`, `SessionPrompt.prompt`, or `spawnNode` for that lost attempt
+- **AND** SHALL terminalize the attempt according to `dag-scheduler-recovery`
+
+#### Scenario: explicit replan can create a new attempt
+
+- **WHEN** the parent orchestrator observes a recovery failure
+- **AND** explicitly replans or restarts the node through the workflow control surface
+- **THEN** the normal `NodeRestarted` and scheduling path MAY create a new child Session and execution fiber
+
+## MODIFIED Requirements
+
+### Requirement: Crash-recovery re-attachment inherits the node's timeout
+
+A node's resolved timeout deadline (absolute `spawnedAt + timeout_ms`) SHALL be persisted as durable node state. Crash recovery SHALL use `reconcileWorkflow` as a one-time startup scan to classify every node left in `running`.
+
+If the child Session already completed or failed, recovery SHALL publish the corresponding DAG terminal event. If the child Session remains `active` or `unknown`, recovery SHALL recognize that the crashed process's timeout and prompt fibers no longer exist. It SHALL best-effort cancel the old child Session and terminalize the node: expired deadlines use `NodeFailed(timeout)`; future or unset deadlines use `NodeFailed(exec_failed)` with an execution-ownership-loss reason.
+
+Recovery SHALL NOT install a persistent polling watcher and SHALL NOT retry provider work implicitly.
+
+#### Scenario: recovered node with completed child session
+
+- **WHEN** a node is recovered in `running` after restart
+- **AND** its child Session has completed
+- **THEN** `reconcileWorkflow` SHALL publish `NodeCompleted`, or `NodeFailed(verdict_fail)` when its structured-output contract is unsatisfied
+
+#### Scenario: recovered node with failed child session
+
+- **WHEN** a node is recovered in `running` after restart
+- **AND** its child Session has failed
+- **THEN** `reconcileWorkflow` SHALL publish `NodeFailed(exec_failed)`
+
+#### Scenario: recovered node with active child session and expired deadline
+
+- **WHEN** a recovered node's child Session is `active` or `unknown`
+- **AND** its persisted deadline has expired
+- **THEN** recovery SHALL best-effort cancel the child Session
+- **AND** SHALL publish `NodeFailed(timeout)`
+
+#### Scenario: recovered node with active child session and future or absent deadline
+
+- **WHEN** a recovered node's child Session is `active` or `unknown`
+- **AND** its deadline is in the future or absent
+- **THEN** recovery SHALL best-effort cancel the child Session
+- **AND** SHALL publish `NodeFailed(exec_failed)` with an execution-ownership-loss reason
+- **AND** SHALL NOT leave the node in `running`

--- a/openspec/changes/dag-post-crash-continuation/specs/dag-scheduler-recovery/spec.md
+++ b/openspec/changes/dag-post-crash-continuation/specs/dag-scheduler-recovery/spec.md
@@ -1,0 +1,73 @@
+## MODIFIED Requirements
+
+### Requirement: No double-spawn for still-live child sessions
+
+The rehydrated DagLoop MUST NOT spawn replacement child sessions implicitly for nodes whose execution attempt belonged to the crashed process. A persisted child Session status of `active` or `unknown` SHALL NOT be treated as proof that the current process owns an execution fiber.
+
+For every recovered node in `running`, `reconcileWorkflow` SHALL inspect the child Session once. If the Session has already completed or failed, it SHALL publish the corresponding DAG terminal event. If the Session remains `active` or `unknown`, recovery SHALL best-effort cancel that child Session and publish `NodeFailed` for the lost execution attempt. Recovery SHALL NOT call `spawnNode`, reset the node to `pending`, invoke `SessionExecution.wake`, or otherwise retry provider/tool execution implicitly.
+
+A child session with zero messages MUST be classified as `unknown`. Both `active` and `unknown` mean that the durable Session projection is non-terminal; neither state restores process-local DAG execution ownership after restart.
+
+#### Scenario: active child session is terminalized without replacement spawn
+
+- **WHEN** a workflow is recovered with a `running` node whose child Session is classified `active`
+- **AND** no current-process fiber owns that node
+- **THEN** recovery SHALL best-effort cancel the child Session
+- **AND** SHALL publish `NodeFailed` with trigger `exec_failed` and a reason indicating execution ownership was lost on recovery
+- **AND** SHALL NOT spawn a replacement child Session
+
+#### Scenario: unknown child session is terminalized without replacement spawn
+
+- **WHEN** a workflow is recovered with a `running` node whose child Session is classified `unknown`
+- **THEN** recovery SHALL best-effort cancel the child Session
+- **AND** SHALL publish `NodeFailed` for the lost execution attempt
+- **AND** SHALL NOT leave the node in `running`
+
+#### Scenario: completed child session is projected instead of failed
+
+- **WHEN** `reconcileWorkflow` finds a `running` node whose child Session completed before the crash
+- **THEN** recovery SHALL publish `NodeCompleted` when its output contract is satisfied
+- **AND** SHALL publish `NodeFailed` with trigger `verdict_fail` when an output schema exists but no valid captured output exists
+
+#### Scenario: zero-message child session is not adopted
+
+- **WHEN** `reconcileWorkflow` checks a running node's child Session and the Session has zero messages
+- **THEN** the Session SHALL be classified as `unknown`
+- **AND** recovery SHALL fail the lost execution attempt rather than adopting or restarting it
+
+### Requirement: Recovered running nodes are bounded by deadline re-enforcement
+
+When `reconcileWorkflow()` encounters a node left in `running` after a crash, it MUST compare the current time with persisted `deadline_ms` before classifying execution ownership loss. An expired deadline SHALL produce `NodeFailed` with reason `"deadline exceeded on recovery"` and trigger `"timeout"`.
+
+A future or unset deadline SHALL NOT authorize recovery to leave the node `running`, because the timeout fiber died with the crashed process. If the child Session is still `active` or `unknown`, recovery SHALL best-effort cancel it and publish `NodeFailed` with trigger `"exec_failed"` and reason indicating execution ownership loss.
+
+#### Scenario: recovered node past its deadline fails as timeout
+
+- **WHEN** `reconcileWorkflow()` finds a `running` node whose `deadline_ms` is earlier than the recovery time
+- **AND** its child Session is `active` or `unknown`
+- **THEN** recovery SHALL best-effort cancel the child Session
+- **AND** SHALL publish `NodeFailed` with reason `"deadline exceeded on recovery"` and trigger `"timeout"`
+
+#### Scenario: recovered node before its deadline fails as ownership loss
+
+- **WHEN** `reconcileWorkflow()` finds a `running` node whose deadline is in the future
+- **AND** its child Session is `active` or `unknown`
+- **THEN** recovery SHALL NOT wait for the future deadline
+- **AND** SHALL best-effort cancel the child Session
+- **AND** SHALL publish `NodeFailed` with trigger `"exec_failed"` and a reason indicating execution ownership was lost
+
+#### Scenario: recovered node with no deadline cannot remain running
+
+- **WHEN** `reconcileWorkflow()` finds a `running` node with no persisted deadline
+- **AND** its child Session is `active` or `unknown`
+- **THEN** recovery SHALL best-effort cancel the child Session
+- **AND** SHALL publish `NodeFailed`
+- **AND** SHALL NOT leave the node indefinitely in `running`
+
+## REMOVED Requirements
+
+### Requirement: The orchestrator_unresponsive safety net remains reachable for recovered workflows
+
+**Reason**: Recovery no longer leaves nodes in `running` without a current-process execution fiber. The old requirement attempted to bound an invalid intermediate state through the parent wake safety net, but no node-result wake is guaranteed to exist for an execution that never reaches a DAG terminal event.
+
+**Migration**: Recovered-running nodes are now terminalized during reconciliation. Their normal `NodeFailed` projection, dependency cascade, workflow terminalization, and durable wake eligibility replace the orphan-specific `orchestrator_unresponsive` fallback.

--- a/openspec/changes/dag-post-crash-continuation/tasks.md
+++ b/openspec/changes/dag-post-crash-continuation/tasks.md
@@ -1,0 +1,42 @@
+## 1. 恢复契约回归测试
+
+- [x] 1.1 更新 `packages/opencode/test/dag/dag-recovery.test.ts`：active child + future deadline 预期 cancel 后 `NodeFailed(exec_failed)`，不再增加 `leftRunning`
+- [x] 1.2 增加 active child + 无 deadline 的 ownership-loss 失败测试，验证节点不会保持 `running`
+- [x] 1.3 更新 unknown/零消息 child Session 测试，验证 cancel、ownership-loss reason 和单一 `NodeFailed`
+- [x] 1.4 保留并强化 expired deadline 测试，验证先 best-effort cancel、再发布 `NodeFailed(timeout)`
+- [x] 1.5 保留 completed/failed child Session 与 structured output 恢复测试，确认已结算结果不会被误判为 ownership loss
+- [x] 1.6 增加 cancel 失败测试，验证记录失败不会阻止 DAG 节点终态化
+
+## 2. 确定性恢复实现
+
+- [x] 2.1 在 `packages/opencode/src/dag/runtime/recovery.ts` 中将 recovered-running 的 active/unknown 分支改为确定性 ownership-loss 终态化
+- [x] 2.2 对 active/unknown child Session 在发布 DAG 终态前调用注入的 cancel 操作，并将取消错误降级为结构化 warning
+- [x] 2.3 保持 expired deadline 优先映射到 `timeout`，future/unset deadline 映射到 `exec_failed`
+- [x] 2.4 使用稳定、可断言的 ownership-loss reason，并确保恢复流程不调用 `spawnNode`、`SessionPrompt.prompt` 或 `SessionExecution.wake`
+- [x] 2.5 调整 `reconcileWorkflow()` 返回统计，移除或废弃误导性的 `leftRunning`，增加 ownership-loss 可观测计数
+- [x] 2.6 更新 `packages/opencode/src/dag/runtime/loop.ts` 的恢复注释和日志，删除“旧执行会通过 normal wake 自行结算”的失效假设
+
+## 3. DagLoop 真实恢复集成测试
+
+- [x] 3.1 新建 DagLoop 恢复集成 fixture，组合 Database、EventV2Bridge、DagProjector、DagStore、Dag.Service、DagLoop，并通过 Effect Layer 注入可控 Session/SessionPrompt 服务
+- [x] 3.2 测试启动恢复 active child + future/unset deadline：旧 child 被取消、节点投影为 failed、无 replacement Session 被创建
+- [x] 3.3 测试启动恢复 expired deadline：节点投影为 failed、trigger/reason 保持 timeout 语义
+- [x] 3.4 测试启动恢复 completed child + captured output：节点投影为 completed 且 output 保持一致
+- [x] 3.5 测试 required recovered node 失败后的依赖级联和 workflow 终态，确认复用标准事件链路
+- [x] 3.6 测试 `report_to_parent` 节点的恢复失败仍出现在 unreported wake 查询中
+- [x] 3.7 测试恢复结束后 read model 中不存在无当前进程 fiber 所有权的 `running` 节点
+- [x] 3.8 测试迟到 `NodeStarted`/`NodeCompleted` 不会复活已因 ownership loss 终态化的节点
+
+## 4. 清理旧假设与文档
+
+- [x] 4.1 搜索并修订代码注释、测试名称和 fixture 中关于 recovered active child 会自行产生 DAG terminal/wake 的表述
+- [x] 4.2 确认没有重新引入 persistent polling watcher、detached fiber 或自动 provider retry
+- [x] 4.3 确认恢复行为不需要数据库迁移、HTTP API 变更或 SDK 重新生成
+
+## 5. 验证
+
+- [x] 5.1 在 `packages/opencode` 运行新增的 recovery 单元测试与 DagLoop 恢复集成测试
+- [x] 5.2 在 `packages/opencode` 运行 `bun test test/dag`
+- [x] 5.3 在 `packages/opencode` 运行 `bun typecheck`
+- [x] 5.4 在 `packages/core` 运行 `bun typecheck`，确认共享 DAG 类型与状态机契约未回归
+- [x] 5.5 运行 `openspec validate dag-post-crash-continuation --strict`

--- a/packages/opencode/src/dag/runtime/loop.ts
+++ b/packages/opencode/src/dag/runtime/loop.ts
@@ -541,9 +541,13 @@ export const layer = Layer.effect(
               // Persist wake_reported AFTER successful delivery only.
               // A failure stays durable for a later idle event or restart scan;
               // it must not spin synchronously on the same row.
+              // The part is marked synthetic: model-visible (the orchestrator
+              // receives the node result and can act) but NOT rendered as a user
+              // message in the TUI chat — DAG data surfaces via the sidebar panel
+              // and Inspector, keeping the chat conversation clean.
               const didDeliver = yield* promptSvc.prompt({
                 sessionID: SessionID.make(sessionID),
-                parts: [{ type: "text", text: summary }],
+                parts: [{ type: "text", text: summary, synthetic: true }],
               }).pipe(
                 Effect.tap(() =>
                   Effect.gen(function* () {

--- a/packages/opencode/src/dag/runtime/loop.ts
+++ b/packages/opencode/src/dag/runtime/loop.ts
@@ -17,7 +17,6 @@ import { SessionID } from "@/session/schema"
 import { resolveTemplate } from "../templates/resolve"
 import { sanitizeInput } from "../templates/sanitize"
 import { spawnNode } from "./spawn"
-import { registerCaptureSlot } from "./capture"
 import { evaluateCondition, resolveInputMapping } from "./eval"
 import { reconcileWorkflow, makeSessionStatusChecker } from "./recovery"
 
@@ -207,10 +206,21 @@ export const layer = Layer.effect(
         const recoverWorkflow = Effect.fn("DagLoop.recoverWorkflow")(function* (wf: DagStore.WorkflowRow) {
           const dagID = wf.id
           const config = parseWorkflowConfig(wf.config)
-          yield* reconcileWorkflow(dagID, checkSessionStatus, (sid) => promptSvc.cancel(sid as never), config).pipe(
+          const recovery = yield* reconcileWorkflow(
+            dagID,
+            checkSessionStatus,
+            (sid) => promptSvc.cancel(sid as never),
+            config,
+          ).pipe(
             Effect.provideService(Dag.Service, dag),
-            Effect.ignore,
           )
+          if (recovery.ownershipLost > 0) {
+            yield* Effect.logWarning("DagLoop terminalized recovered nodes after execution ownership loss", {
+              dagID,
+              reconciled: recovery.reconciled,
+              ownershipLost: recovery.ownershipLost,
+            })
+          }
           const nodes = yield* store.getNodes(dagID)
           const maxConcurrency = Math.max(1, config?.max_concurrency ?? 5)
           const runtime = new WorkflowRuntime(toSchedulingNodes(nodes), maxConcurrency)
@@ -221,19 +231,9 @@ export const layer = Layer.effect(
           if (isStepping) runtime.setStepMode(true)
           const entry: WorkflowEntry = { runtime, semaphore, evalLock: Semaphore.makeUnsafe(1), parentSessionID: wf.sessionId, config, fibers: new Map() }
           runtimes.set(dagID, entry)
-          // Re-register capture slots for running nodes whose child sessions
-          // may still call submit_result. No persistent watcher is forked
-          // (by design — see dag-module-cleanup design D1). reconcileWorkflow
-          // (above) already published terminal events for settled sessions.
-          // Still-active sessions whose fibers died with the crashed process
-          // remain running until a post-crash continuation mechanism is built.
-          for (const node of nodes) {
-            if (node.status !== "running" || !node.childSessionId) continue
-            const nodeConfig = entry.config?.nodes.find((n) => n.id === node.id)
-            if (nodeConfig?.output_schema && node.childSessionId) {
-              registerCaptureSlot(node.childSessionId, nodeConfig.output_schema as Record<string, unknown>)
-            }
-          }
+          // Reconciliation settles every persisted running attempt before the
+          // runtime is rebuilt. Recovery never adopts or restarts provider work;
+          // a new execution attempt must come from explicit workflow control.
           if (!isPaused && !isStepping) {
             yield* entry.evalLock.withPermits(1)(
               Effect.gen(function* () {
@@ -506,11 +506,8 @@ export const layer = Layer.effect(
                     const entry = runtimes.get(dagID)
                     if (!entry) continue
                     if (entry.runtime.isPaused()) continue
-                    // Suppress the net only if at least one running node has an
-                    // active in-process fiber (actively making progress). All-
-                    // orphaned running nodes (recovered after crash, no fiber)
-                    // should be exposed to the net so a recovered workflow
-                    // cannot hang indefinitely.
+                    // Suppress the net only when current-process execution
+                    // ownership proves that a running node is making progress.
                     if (entry.runtime.hasRunningMatching((id) => entry.fibers.has(id))) continue
                     if (entry.runtime.getReadyNodes().length > 0) continue
                     if (entry.runtime.isComplete()) continue

--- a/packages/opencode/src/dag/runtime/recovery.ts
+++ b/packages/opencode/src/dag/runtime/recovery.ts
@@ -1,10 +1,10 @@
 /**
  * DAG crash recovery — EventV2-driven, no separate recovery table/scan.
  *
- * With D3 (node = real child Session), crash recovery reduces to "what does the
- * child session's actual state say?" — which dev already tracks durably via
- * EventV2. On startup, any node left `running` by an unclean shutdown is
- * reconciled by querying its backing child session's state.
+ * A child Session's durable state can recover an already-settled result, but it
+ * cannot prove that the current process owns provider execution. On startup,
+ * every node left `running` by an unclean shutdown is therefore reconciled to a
+ * DAG terminal event before its WorkflowRuntime is rebuilt.
  *
  * This is NOT a startup-blocking scan (unlike the old recoverOrphanedWorkflows).
  * It runs lazily when a workflow is first accessed, and only touches workflows
@@ -20,14 +20,14 @@ import type { DagStore } from "@opencode-ai/core/dag/store"
 export function reconcileWorkflow(
   dagID: string,
   checkSessionStatus: (childSessionID: string) => Effect.Effect<"active" | "completed" | "failed" | "unknown", Error>,
-  cancelSession?: (sessionID: string) => Effect.Effect<void>,
+  cancelSession?: (sessionID: string) => Effect.Effect<void, Error>,
   workflowConfig?: { nodes: { id: string; output_schema?: Record<string, unknown> }[] } | undefined,
-): Effect.Effect<{ reconciled: number; leftRunning: number }, Error, Dag.Service> {
+): Effect.Effect<{ reconciled: number; ownershipLost: number }, Error, Dag.Service> {
   return Effect.gen(function* () {
     const dag = yield* Dag.Service
     const nodes = yield* dag.store.getNodes(dagID)
     let reconciled = 0
-    let leftRunning = 0
+    let ownershipLost = 0
 
     for (const node of nodes) {
       // Pending nodes have not been admitted to an execution attempt yet. This
@@ -69,9 +69,19 @@ export function reconcileWorkflow(
         yield* dag.nodeFailed(dagID, node.id, "child session failed (recovered)", "exec_failed")
         reconciled++
       } else {
-        // active or unknown: check whether the node overshot its persisted
-        // deadline during the crash. If so, fail it deterministically rather
-        // than leaving it to hang with no timeout protection.
+        ownershipLost++
+        if (cancelSession) {
+          yield* cancelSession(node.childSessionId).pipe(
+            Effect.catchCause((cause) =>
+              Effect.logWarning("DAG recovery failed to cancel child session", {
+                dagID,
+                nodeID: node.id,
+                childSessionID: node.childSessionId,
+                cause,
+              }),
+            ),
+          )
+        }
         if (node.deadlineMs !== null) {
           const now = yield* Clock.currentTimeMillis
           if (now >= node.deadlineMs) {
@@ -80,17 +90,17 @@ export function reconcileWorkflow(
             continue
           }
         }
-        // Deadline is in the future or unset. Leave running — the child
-        // session's in-process execution fiber died with the crashed process;
-        // its DB status may not yet reflect terminal. No persistent watcher is
-        // forked (by design — see dag-module-cleanup design D1). Post-crash
-        // continuation recovery requires a separate explicit mechanism not yet
-        // built. The orchestrator_unresponsive safety net + deadline bound it.
-        leftRunning++
+        yield* dag.nodeFailed(
+          dagID,
+          node.id,
+          "execution ownership lost on recovery",
+          "exec_failed",
+        )
+        reconciled++
       }
     }
 
-    return { reconciled, leftRunning }
+    return { reconciled, ownershipLost }
   })
 }
 

--- a/packages/opencode/test/dag/dag-loop-integration.test.ts
+++ b/packages/opencode/test/dag/dag-loop-integration.test.ts
@@ -157,7 +157,7 @@ describe("E2E: diamond dependency (A → {B,C} → D)", () => {
 })
 
 describe("hasRunningMatching (safety-net gate)", () => {
-  it("returns false when no running nodes have fibers (all orphaned)", () => {
+  it("returns false when no running node has current-process fiber ownership", () => {
     const nodes = makeNodes(["a"])
     const rt = new WorkflowRuntime(nodes, 4)
     rt.markRunning("a")

--- a/packages/opencode/test/dag/dag-loop-recovery-integration.test.ts
+++ b/packages/opencode/test/dag/dag-loop-recovery-integration.test.ts
@@ -1,0 +1,302 @@
+import { describe, expect, it } from "bun:test"
+import { DateTime, Effect, Layer } from "effect"
+import { Database } from "@opencode-ai/core/database/database"
+import { DagProjector } from "@opencode-ai/core/dag/projector"
+import { DagStore } from "@opencode-ai/core/dag/store"
+import { EventV2 } from "@opencode-ai/core/event"
+import { ProjectTable } from "@opencode-ai/core/project/sql"
+import { SessionTable } from "@opencode-ai/core/session/sql"
+import { DagEvent } from "@opencode-ai/schema/dag-event"
+import { Agent } from "@/agent/agent"
+import { Dag, type NodeConfig } from "@/dag/dag"
+import { DagLoop } from "@/dag/runtime/loop"
+import { InstanceRef } from "@/effect/instance-ref"
+import { EventV2Bridge } from "@/event-v2-bridge"
+import { SessionPrompt } from "@/session/prompt"
+import { Session } from "@/session/session"
+
+type ChildStatus = "active" | "completed" | "failed" | "unknown"
+
+function node(overrides: Partial<NodeConfig> = {}): NodeConfig {
+  return {
+    id: "n1",
+    name: "Node 1",
+    worker_type: "build",
+    depends_on: [],
+    required: true,
+    prompt_template: { inline: "work" },
+    ...overrides,
+  }
+}
+
+function recoveryLayer(input: {
+  childStatuses: Map<string, ChildStatus>
+  cancelled: string[]
+  created: string[]
+}) {
+  const database = Database.layerFromPath(":memory:")
+  const events = EventV2.layer.pipe(Layer.provide(database))
+  const bridge = EventV2Bridge.layer.pipe(Layer.provide(events))
+  const store = DagStore.layer.pipe(Layer.provide(database))
+  const projector = DagProjector.layer.pipe(
+    Layer.provide(events),
+    Layer.provide(database),
+  )
+  const dag = Dag.layer.pipe(
+    Layer.provide(bridge),
+    Layer.provide(store),
+  )
+  const base = Layer.mergeAll(database, events, bridge, store, projector, dag)
+  const session = Layer.mock(Session.Service, {
+    create: Effect.fn("test.Session.create")((_value?: unknown) =>
+      Effect.sync(() => {
+        input.created.push("generated")
+        return {} as never
+      }),
+    ),
+    get: Effect.fn("test.Session.get")(() => Effect.succeed({} as never)),
+    messages: Effect.fn("test.Session.messages")((value: { sessionID: string }) => {
+      const status = input.childStatuses.get(value.sessionID) ?? "unknown"
+      if (status === "unknown") return Effect.succeed([])
+      if (status === "active") {
+        return Effect.succeed([{ info: { role: "assistant", finish: undefined } }] as never)
+      }
+      if (status === "failed") {
+        return Effect.succeed([{ info: { role: "assistant", error: { name: "failed" } } }] as never)
+      }
+      return Effect.succeed([{ info: { role: "assistant", finish: "stop" } }] as never)
+    }),
+  })
+  const prompt = Layer.mock(SessionPrompt.Service, {
+    cancel: Effect.fn("test.SessionPrompt.cancel")((sessionID: string) =>
+      Effect.sync(() => input.cancelled.push(sessionID)),
+    ),
+    // Keep wake delivery pending so tests can inspect durable unreported rows.
+    prompt: () => Effect.never,
+  })
+  const loop = DagLoop.layer.pipe(
+    Layer.provide(base),
+    Layer.provide(session),
+    Layer.provide(prompt),
+    Layer.provide(Layer.mock(Agent.Service, {})),
+  )
+  return Layer.merge(base, loop)
+}
+
+function runRecovery<A>(
+  status: ChildStatus,
+  test: (services: {
+    dag: Dag.Interface
+    database: Database.Interface
+    loop: DagLoop.Interface
+    events: EventV2.Interface
+    store: DagStore.Interface
+    cancelled: string[]
+    created: string[]
+  }) => Effect.Effect<A, Error>,
+) {
+  const childStatuses = new Map([["ses_child1", status]])
+  const cancelled: string[] = []
+  const created: string[] = []
+  return Effect.gen(function* () {
+    const dag = yield* Dag.Service
+    const database = yield* Database.Service
+    const loop = yield* DagLoop.Service
+    const events = yield* EventV2.Service
+    const store = yield* DagStore.Service
+    return yield* test({ dag, database, loop, events, store, cancelled, created })
+  }).pipe(
+    Effect.provide(recoveryLayer({ childStatuses, cancelled, created })),
+    Effect.provideService(InstanceRef, {
+      directory: process.cwd(),
+      worktree: process.cwd(),
+      project: { id: "project-1" },
+    } as never),
+    Effect.scoped,
+  )
+}
+
+function createRunningNode(
+  dag: Dag.Interface,
+  database: Database.Interface,
+  config: NodeConfig[],
+  deadlineMs?: number,
+  wakeEligible?: boolean,
+) {
+  return Effect.gen(function* () {
+    yield* database.db.insert(ProjectTable).values({
+      id: "project-1" as never,
+      worktree: process.cwd() as never,
+      sandboxes: [],
+    }).run().pipe(Effect.orDie)
+    yield* database.db.insert(SessionTable).values({
+      id: "ses_parent1" as never,
+      project_id: "project-1" as never,
+      slug: "parent",
+      directory: process.cwd() as never,
+      title: "Parent",
+      version: "test",
+    }).run().pipe(Effect.orDie)
+    const dagID = yield* dag.create({
+      projectID: "project-1",
+      sessionID: "ses_parent1",
+      title: "Recovery",
+      config: { name: "recovery", nodes: config },
+    })
+    yield* dag.nodeStarted(dagID, "n1", "ses_child1", deadlineMs, wakeEligible)
+    return dagID
+  })
+}
+
+describe("DagLoop crash recovery integration", () => {
+  it("cancels active children with future or absent deadlines without spawning replacements", async () => {
+    for (const deadline of [Date.now() + 60_000, undefined]) {
+      await Effect.runPromise(
+        runRecovery("active", ({ dag, database, loop, store, cancelled, created }) =>
+          Effect.gen(function* () {
+            const dagID = yield* createRunningNode(dag, database, [node()], deadline)
+
+            yield* loop.init()
+
+            expect(cancelled).toEqual(["ses_child1"])
+            expect(created).toEqual([])
+            expect((yield* store.getNode(dagID, "n1"))?.status).toBe("failed")
+          }),
+        ),
+      )
+    }
+  })
+
+  it("preserves timeout trigger and reason for an expired recovered node", async () => {
+    await Effect.runPromise(
+      runRecovery("active", ({ dag, database, loop, events, store, cancelled }) =>
+        Effect.gen(function* () {
+          const failures: Array<{ reason: string; trigger: string }> = []
+          const unsubscribe = yield* events.listen((event) =>
+            event.type === DagEvent.NodeFailed.type
+              ? Effect.sync(() => failures.push(event.data as never))
+              : Effect.void,
+          )
+          const dagID = yield* createRunningNode(dag, database, [node()], Date.now() - 1)
+
+          yield* loop.init()
+          yield* unsubscribe
+
+          expect(cancelled).toEqual(["ses_child1"])
+          expect(failures).toContainEqual(expect.objectContaining({
+            reason: "deadline exceeded on recovery",
+            trigger: "timeout",
+          }))
+          expect((yield* store.getNode(dagID, "n1"))?.errorReason).toBe("deadline exceeded on recovery")
+        }),
+      ),
+    )
+  })
+
+  it("projects captured output from a completed child session", async () => {
+    await Effect.runPromise(
+      runRecovery("completed", ({ dag, database, loop, store, cancelled }) =>
+        Effect.gen(function* () {
+          const dagID = yield* createRunningNode(dag, database, [
+            node({ output_schema: { type: "object" } }),
+          ])
+          yield* store.setCapturedOutput("ses_child1", { summary: "done" })
+
+          yield* loop.init()
+
+          expect(cancelled).toEqual([])
+          expect((yield* store.getNode(dagID, "n1"))?.output).toEqual({ summary: "done" })
+          expect((yield* store.getWorkflow(dagID))?.status).toBe("completed")
+        }),
+      ),
+    )
+  })
+
+  it("cascades a required recovery failure through the standard workflow terminal path", async () => {
+    await Effect.runPromise(
+      runRecovery("active", ({ dag, database, loop, store }) =>
+        Effect.gen(function* () {
+          const dagID = yield* createRunningNode(dag, database, [
+            node(),
+            node({ id: "n2", name: "Node 2", depends_on: ["n1"] }),
+          ])
+
+          yield* loop.init()
+
+          expect((yield* store.getNode(dagID, "n1"))?.status).toBe("failed")
+          expect((yield* store.getNode(dagID, "n2"))?.status).toBe("skipped")
+          expect((yield* store.getWorkflow(dagID))?.status).toBe("cancelled")
+        }),
+      ),
+    )
+  })
+
+  it("keeps report-to-parent recovery failures in the durable unreported wake query", async () => {
+    await Effect.runPromise(
+      runRecovery("active", ({ dag, database, loop, store }) =>
+        Effect.gen(function* () {
+          const dagID = yield* createRunningNode(
+            dag,
+            database,
+            [node({ report_to_parent: true })],
+            undefined,
+            true,
+          )
+
+          yield* loop.init()
+
+          expect(yield* store.getUnreportedWakeNodes("ses_parent1")).toContainEqual(
+            expect.objectContaining({ workflowId: dagID, id: "n1", status: "failed" }),
+          )
+        }),
+      ),
+    )
+  })
+
+  it("leaves no recovered node running without current-process fiber ownership", async () => {
+    await Effect.runPromise(
+      runRecovery("unknown", ({ dag, database, loop, store }) =>
+        Effect.gen(function* () {
+          const dagID = yield* createRunningNode(dag, database, [node()])
+
+          yield* loop.init()
+
+          expect((yield* store.getNodes(dagID)).filter((item) => item.status === "running")).toEqual([])
+        }),
+      ),
+    )
+  })
+
+  it("rejects late start and completion projections after ownership-loss terminalization", async () => {
+    await Effect.runPromise(
+      runRecovery("active", ({ dag, database, loop, events, store }) =>
+        Effect.gen(function* () {
+          const dagID = yield* createRunningNode(dag, database, [node()])
+          yield* loop.init()
+
+          yield* events.publish(DagEvent.NodeStarted, {
+            dagID,
+            nodeID: "n1" as never,
+            childSessionID: "ses_latechild" as never,
+            timestamp: yield* DateTime.now,
+          })
+          yield* events.publish(DagEvent.NodeCompleted, {
+            dagID,
+            nodeID: "n1" as never,
+            output: { stale: true },
+            durationMs: 1 as never,
+            timestamp: yield* DateTime.now,
+          })
+
+          expect(yield* store.getNode(dagID, "n1")).toEqual(
+            expect.objectContaining({
+              status: "failed",
+              childSessionId: "ses_child1",
+              output: null,
+            }),
+          )
+        }),
+      ),
+    )
+  })
+})

--- a/packages/opencode/test/dag/dag-recovery.test.ts
+++ b/packages/opencode/test/dag/dag-recovery.test.ts
@@ -7,17 +7,32 @@ import { WorkflowRuntime } from "@opencode-ai/core/dag/core/scheduling"
 import { SUCCESS_TERMINAL, toSchedulingNodes } from "@/dag/runtime/loop"
 import { makeNodeRow } from "./fixtures"
 
-function makeDagLayer(nodes: DagStore.NodeRow[], trackedEvents: { type: string; nodeID: string }[]) {
+type TrackedEvent = {
+  type: string
+  nodeID: string
+  output?: unknown
+  reason?: string
+  trigger?: string
+}
+
+function makeDagLayer(nodes: DagStore.NodeRow[], trackedEvents: TrackedEvent[], actions?: string[]) {
   return Layer.mock(Dag.Service, {
     store: {
       getNodes: () => Effect.succeed(nodes),
       getNode: (id: string) => Effect.succeed(nodes.find((n) => n.id === id)),
     } as unknown as DagStore.Interface,
-    nodeCompleted: Effect.fn("stub.nodeCompleted")((dagID: string, nodeID: string) =>
-      Effect.sync(() => trackedEvents.push({ type: "nodeCompleted", nodeID })),
+    nodeCompleted: Effect.fn("stub.nodeCompleted")((dagID: string, nodeID: string, output: unknown) =>
+      Effect.sync(() => trackedEvents.push({
+        type: "nodeCompleted",
+        nodeID,
+        ...(output === undefined ? {} : { output }),
+      })),
     ),
-    nodeFailed: Effect.fn("stub.nodeFailed")((dagID: string, nodeID: string) =>
-      Effect.sync(() => trackedEvents.push({ type: "nodeFailed", nodeID })),
+    nodeFailed: Effect.fn("stub.nodeFailed")((dagID: string, nodeID: string, reason: string, trigger: string) =>
+      Effect.sync(() => {
+        actions?.push(`failed:${trigger}`)
+        trackedEvents.push({ type: "nodeFailed", nodeID, reason, trigger })
+      }),
     ),
     nodeStarted: Effect.fn("stub.nodeStarted")((dagID: string, nodeID: string) =>
       Effect.sync(() => trackedEvents.push({ type: "nodeStarted", nodeID })),
@@ -46,7 +61,7 @@ describe("reconcileWorkflow", () => {
 
     await Effect.runPromise(reconcileWorkflow("wf-1", checkStatus).pipe(Effect.provide(dagLayer)))
 
-    expect(events).toContainEqual({ type: "nodeFailed", nodeID: "n1" })
+    expect(events).toContainEqual(expect.objectContaining({ type: "nodeFailed", nodeID: "n1" }))
   })
 
   it("publishes NodeFailed for running node with no child session", async () => {
@@ -57,20 +72,29 @@ describe("reconcileWorkflow", () => {
 
     await Effect.runPromise(reconcileWorkflow("wf-1", checkStatus).pipe(Effect.provide(dagLayer)))
 
-    expect(events).toContainEqual({ type: "nodeFailed", nodeID: "n1" })
+    expect(events).toContainEqual(expect.objectContaining({ type: "nodeFailed", nodeID: "n1" }))
   })
 
-  it("leaves running node active when child session is still active", async () => {
-    const events: { type: string; nodeID: string }[] = []
+  it("cancels and fails an active child with no deadline after execution ownership is lost", async () => {
+    const events: TrackedEvent[] = []
+    const cancelled: string[] = []
     const nodes = [makeNodeRow({ id: "n1", status: "running", childSessionId: "ses_1" })]
     const dagLayer = makeDagLayer(nodes, events)
     const checkStatus = () => Effect.succeed("active" as const)
+    const cancelSession = (sessionID: string) => Effect.sync(() => cancelled.push(sessionID))
 
-    const result = await Effect.runPromise(reconcileWorkflow("wf-1", checkStatus).pipe(Effect.provide(dagLayer)))
+    const result = await Effect.runPromise(
+      reconcileWorkflow("wf-1", checkStatus, cancelSession).pipe(Effect.provide(dagLayer)),
+    )
 
-    expect(events).toEqual([])
-    expect(result.leftRunning).toBe(1)
-    expect(result.reconciled).toBe(0)
+    expect(cancelled).toEqual(["ses_1"])
+    expect(events).toContainEqual({
+      type: "nodeFailed",
+      nodeID: "n1",
+      reason: "execution ownership lost on recovery",
+      trigger: "exec_failed",
+    })
+    expect(result).toEqual({ reconciled: 1, ownershipLost: 1 })
   })
 
   it("leaves pending node with no child session for spawnReady", async () => {
@@ -98,7 +122,7 @@ describe("reconcileWorkflow", () => {
     // re-attach to the old session — leave them pending for spawnReady.
     expect(events).not.toContainEqual({ type: "nodeStarted", nodeID: "n1" })
     expect(result.reconciled).toBe(0)
-    expect(result.leftRunning).toBe(0)
+    expect(result.ownershipLost).toBe(0)
   })
 
   it("skips non-running, non-pending nodes", async () => {
@@ -116,53 +140,138 @@ describe("reconcileWorkflow", () => {
     expect(result.reconciled).toBe(0)
   })
 
-  it("leaves unknown session running (watcher handles it, does not falsely fail)", async () => {
-    const events: { type: string; nodeID: string }[] = []
+  it("cancels and fails a zero-message child classified as unknown exactly once", async () => {
+    const events: TrackedEvent[] = []
+    const cancelled: string[] = []
     const nodes = [makeNodeRow({ id: "n1", status: "running", childSessionId: "ses_1" })]
     const dagLayer = makeDagLayer(nodes, events)
     const checkStatus = () => Effect.succeed("unknown" as const)
+    const cancelSession = (sessionID: string) => Effect.sync(() => cancelled.push(sessionID))
 
-    const result = await Effect.runPromise(reconcileWorkflow("wf-1", checkStatus).pipe(Effect.provide(dagLayer)))
+    const result = await Effect.runPromise(
+      reconcileWorkflow("wf-1", checkStatus, cancelSession).pipe(Effect.provide(dagLayer)),
+    )
 
-    expect(events.find((e) => e.type === "nodeFailed")).toBeUndefined()
-    expect(result.leftRunning).toBe(1)
+    expect(cancelled).toEqual(["ses_1"])
+    expect(events.filter((event) => event.type === "nodeFailed")).toEqual([
+      {
+        type: "nodeFailed",
+        nodeID: "n1",
+        reason: "execution ownership lost on recovery",
+        trigger: "exec_failed",
+      },
+    ])
+    expect(result).toEqual({ reconciled: 1, ownershipLost: 1 })
   })
 
-  it("fails running node whose deadline expired during crash (deadline re-enforcement)", async () => {
-    const events: { type: string; nodeID: string }[] = []
+  it("cancels before failing a running node whose deadline expired during crash", async () => {
+    const events: TrackedEvent[] = []
+    const actions: string[] = []
     const nodes = [makeNodeRow({ id: "n1", status: "running", childSessionId: "ses_1", deadlineMs: Date.now() - 10000 })]
-    const dagLayer = makeDagLayer(nodes, events)
+    const dagLayer = makeDagLayer(nodes, events, actions)
     const checkStatus = () => Effect.succeed("active" as const)
+    const cancelSession = () => Effect.sync(() => actions.push("cancelled"))
 
-    const result = await Effect.runPromise(reconcileWorkflow("wf-1", checkStatus).pipe(Effect.provide(dagLayer)))
+    const result = await Effect.runPromise(
+      reconcileWorkflow("wf-1", checkStatus, cancelSession).pipe(Effect.provide(dagLayer)),
+    )
 
-    expect(events).toContainEqual({ type: "nodeFailed", nodeID: "n1" })
-    expect(result.reconciled).toBe(1)
-    expect(result.leftRunning).toBe(0)
+    expect(actions).toEqual(["cancelled", "failed:timeout"])
+    expect(events).toContainEqual({
+      type: "nodeFailed",
+      nodeID: "n1",
+      reason: "deadline exceeded on recovery",
+      trigger: "timeout",
+    })
+    expect(result).toEqual({ reconciled: 1, ownershipLost: 1 })
   })
 
-  it("leaves running node with future deadline running (deadline not yet expired)", async () => {
-    const events: { type: string; nodeID: string }[] = []
+  it("cancels and fails an active child with a future deadline after execution ownership is lost", async () => {
+    const events: TrackedEvent[] = []
+    const cancelled: string[] = []
     const nodes = [makeNodeRow({ id: "n1", status: "running", childSessionId: "ses_1", deadlineMs: Date.now() + 60000 })]
     const dagLayer = makeDagLayer(nodes, events)
     const checkStatus = () => Effect.succeed("active" as const)
+    const cancelSession = (sessionID: string) => Effect.sync(() => cancelled.push(sessionID))
 
-    const result = await Effect.runPromise(reconcileWorkflow("wf-1", checkStatus).pipe(Effect.provide(dagLayer)))
+    const result = await Effect.runPromise(
+      reconcileWorkflow("wf-1", checkStatus, cancelSession).pipe(Effect.provide(dagLayer)),
+    )
 
-    expect(events.find((e) => e.type === "nodeFailed")).toBeUndefined()
-    expect(result.leftRunning).toBe(1)
+    expect(cancelled).toEqual(["ses_1"])
+    expect(events).toContainEqual({
+      type: "nodeFailed",
+      nodeID: "n1",
+      reason: "execution ownership lost on recovery",
+      trigger: "exec_failed",
+    })
+    expect(result).toEqual({ reconciled: 1, ownershipLost: 1 })
   })
 
-  it("leaves running node with null deadline running (no deadline to enforce)", async () => {
-    const events: { type: string; nodeID: string }[] = []
+  it("terminalizes the node even when cancelling the lost child session fails", async () => {
+    const events: TrackedEvent[] = []
     const nodes = [makeNodeRow({ id: "n1", status: "running", childSessionId: "ses_1", deadlineMs: null })]
     const dagLayer = makeDagLayer(nodes, events)
     const checkStatus = () => Effect.succeed("unknown" as const)
+    const cancelSession = () => Effect.fail(new Error("cancel unavailable"))
 
-    const result = await Effect.runPromise(reconcileWorkflow("wf-1", checkStatus).pipe(Effect.provide(dagLayer)))
+    const result = await Effect.runPromise(
+      reconcileWorkflow("wf-1", checkStatus, cancelSession).pipe(Effect.provide(dagLayer)),
+    )
 
-    expect(events.find((e) => e.type === "nodeFailed")).toBeUndefined()
-    expect(result.leftRunning).toBe(1)
+    expect(events).toContainEqual({
+      type: "nodeFailed",
+      nodeID: "n1",
+      reason: "execution ownership lost on recovery",
+      trigger: "exec_failed",
+    })
+    expect(result).toEqual({ reconciled: 1, ownershipLost: 1 })
+  })
+
+  it("preserves captured structured output from an already completed child session", async () => {
+    const events: TrackedEvent[] = []
+    const output = { summary: "done" }
+    const nodes = [
+      makeNodeRow({
+        id: "n1",
+        status: "running",
+        childSessionId: "ses_1",
+        capturedOutput: output,
+      }),
+    ]
+    const dagLayer = makeDagLayer(nodes, events)
+    const checkStatus = () => Effect.succeed("completed" as const)
+    const workflowConfig = {
+      nodes: [{ id: "n1", output_schema: { type: "object" } }],
+    }
+
+    await Effect.runPromise(
+      reconcileWorkflow("wf-1", checkStatus, undefined, workflowConfig).pipe(Effect.provide(dagLayer)),
+    )
+
+    expect(events).toContainEqual({ type: "nodeCompleted", nodeID: "n1", output })
+    expect(events.find((event) => event.type === "nodeFailed")).toBeUndefined()
+  })
+
+  it("fails an already completed child whose required structured output was never captured", async () => {
+    const events: TrackedEvent[] = []
+    const nodes = [makeNodeRow({ id: "n1", status: "running", childSessionId: "ses_1" })]
+    const dagLayer = makeDagLayer(nodes, events)
+    const checkStatus = () => Effect.succeed("completed" as const)
+    const workflowConfig = {
+      nodes: [{ id: "n1", output_schema: { type: "object" } }],
+    }
+
+    await Effect.runPromise(
+      reconcileWorkflow("wf-1", checkStatus, undefined, workflowConfig).pipe(Effect.provide(dagLayer)),
+    )
+
+    expect(events).toContainEqual({
+      type: "nodeFailed",
+      nodeID: "n1",
+      reason: "output_schema declared but submit_result was never successfully called (recovered)",
+      trigger: "verdict_fail",
+    })
   })
 })
 

--- a/packages/tui/src/feature-plugins/builtins.ts
+++ b/packages/tui/src/feature-plugins/builtins.ts
@@ -8,6 +8,7 @@ import SidebarLsp from "./sidebar/lsp"
 import SidebarMcp from "./sidebar/mcp"
 import SidebarTodo from "./sidebar/todo"
 import SidebarDag from "./sidebar/dag"
+import SidebarDagPanel from "./sidebar/dag-panel"
 import DiffViewer from "./system/diff-viewer"
 import DagInspector from "./system/dag-inspector"
 import Notifications from "./system/notifications"
@@ -30,6 +31,7 @@ export function createBuiltinPlugins(options: { experimentalEventSystem: boolean
     SidebarTodo,
     SidebarFiles,
     SidebarDag,
+    SidebarDagPanel,
     SidebarFooter,
     Notifications,
     PluginManager,

--- a/packages/tui/src/feature-plugins/sidebar/dag-panel.tsx
+++ b/packages/tui/src/feature-plugins/sidebar/dag-panel.tsx
@@ -1,0 +1,207 @@
+/** @jsxImportSource @opentui/solid */
+import type { TuiPlugin, TuiPluginApi } from "@opencode-ai/plugin/tui"
+import type { DagNode, DagWorkflowSummary } from "@opencode-ai/sdk/v2"
+import type { BuiltinTuiPlugin } from "../builtins"
+import { createEffect, createMemo, createSignal, For, Show } from "solid-js"
+import { Spinner } from "../../component/spinner"
+
+const id = "internal:sidebar-dag-panel"
+
+const ACTIVE_STATUSES = new Set(["running", "paused", "stepping"])
+const TERMINAL_STATUSES = new Set(["completed", "failed", "cancelled"])
+
+function statusColor(theme: TuiPluginApi["theme"]["current"], status: string) {
+  if (status === "completed") return theme.success
+  if (status === "failed") return theme.error
+  if (status === "cancelled") return theme.textMuted
+  if (status === "running") return theme.textMuted
+  if (status === "paused") return theme.warning
+  if (status === "stepping") return theme.warning
+  return theme.textMuted
+}
+
+function WorkflowRow(props: {
+  api: TuiPluginApi
+  summary: DagWorkflowSummary
+  expanded: boolean
+  onToggle: () => void
+}) {
+  const theme = () => props.api.theme.current
+  const [nodes, setNodes] = createSignal<DagNode[]>([])
+
+  const total = () => Number(props.summary.nodeCount)
+  const completed = () => Number(props.summary.completedNodes)
+  const running = () => Number(props.summary.runningNodes)
+  const failed = () => Number(props.summary.failedNodes)
+
+  const signature = () => `${total()}:${completed()}:${running()}:${failed()}`
+
+  const fetchNodes = async (dagID: string, sig: string) => {
+    try {
+      const res = await props.api.client.dag.nodes({ dagID })
+      // Stale guard: discard if the summary signature changed (or the row was
+      // collapsed) between fetch-start and fetch-resolve.
+      if (!props.expanded || signature() !== sig) return
+      setNodes((res.data ?? []) as DagNode[])
+    } catch {
+      if (!props.expanded || signature() !== sig) return
+      setNodes([])
+    }
+  }
+
+  // Signature-triggered fetch: the signature memo only changes value when a
+  // node count actually changes, so this effect re-runs (and re-fetches) only
+  // on real state changes — never on a no-op summary event. No polling.
+  createEffect(() => {
+    const sig = signature()
+    if (!props.expanded) {
+      setNodes([])
+      return
+    }
+    void fetchNodes(props.summary.id, sig)
+  })
+
+  const bar = () => {
+    const width = 6
+    const t = total()
+    if (t <= 0) return ""
+    const filled = Math.round((completed() / t) * width)
+    return "▓".repeat(filled) + "░".repeat(width - filled)
+  }
+
+  return (
+    <box flexDirection="column">
+      <box flexDirection="row" gap={1} onMouseDown={props.onToggle}>
+        <text flexShrink={0} style={{ fg: statusColor(theme(), props.summary.status) }}>
+          {props.expanded ? "▼" : "▶"}
+        </text>
+        <text fg={theme().text} wrapMode="char">
+          {props.summary.title}
+        </text>
+        <text flexShrink={0} fg={theme().textMuted}>
+          {bar()} {completed()}/{total()}
+          {running() > 0 ? ` ▶${running()}` : ""}
+          {failed() > 0 ? ` ✗${failed()}` : ""}
+        </text>
+      </box>
+      <Show when={props.expanded}>
+        <box flexDirection="column" paddingLeft={2}>
+          <For each={nodes()}>
+            {(node) => (
+              <box flexDirection="row" gap={1}>
+                <Show
+                  when={node.status !== "running"}
+                  fallback={<Spinner color={theme().textMuted} />}
+                >
+                  <text flexShrink={0} style={{ fg: statusColor(theme(), node.status) }}>
+                    {node.status === "completed"
+                      ? "✓"
+                      : node.status === "failed"
+                        ? "✗"
+                        : node.status === "skipped" || node.status === "cancelled"
+                          ? "⊘"
+                          : "○"}
+                  </text>
+                </Show>
+                <text fg={theme().text} wrapMode="char">
+                  {node.name}
+                </text>
+              </box>
+            )}
+          </For>
+        </box>
+      </Show>
+    </box>
+  )
+}
+
+function DagPanel(props: { api: TuiPluginApi; session_id: string }) {
+  const theme = () => props.api.theme.current
+  const dags = createMemo(() => props.api.state.session.dag(props.session_id))
+  const active = createMemo(() => dags().filter((d) => ACTIVE_STATUSES.has(d.status)))
+  const terminal = createMemo(() => dags().filter((d) => TERMINAL_STATUSES.has(d.status)))
+
+  const [expandedIDs, setExpandedIDs] = createSignal<Set<string>>(new Set())
+  const [showTerminal, setShowTerminal] = createSignal(false)
+
+  // Default-expand the first active workflow so the user immediately sees
+  // node-level progress for the workflow that is currently doing work.
+  createEffect(() => {
+    const list = active()
+    if (list.length === 0) return
+    setExpandedIDs((prev) => {
+      if (prev.size > 0) return prev
+      return new Set([list[0]!.id])
+    })
+  })
+
+  const isExpanded = (wfID: string) => expandedIDs().has(wfID)
+  const toggle = (wfID: string) =>
+    setExpandedIDs((prev) => {
+      const next = new Set(prev)
+      if (next.has(wfID)) next.delete(wfID)
+      else next.add(wfID)
+      return next
+    })
+
+  return (
+    <Show when={dags().length > 0}>
+      <box flexDirection="column" gap={1}>
+        <text fg={theme().text}>
+          <b>DAG</b>
+        </text>
+        <For each={active()}>
+          {(summary) => (
+            <WorkflowRow
+              api={props.api}
+              summary={summary}
+              expanded={isExpanded(summary.id)}
+              onToggle={() => toggle(summary.id)}
+            />
+          )}
+        </For>
+        <Show when={terminal().length > 0}>
+          <box flexDirection="column">
+            <box flexDirection="row" gap={1} onMouseDown={() => setShowTerminal((x) => !x)}>
+              <text fg={theme().textMuted}>
+                {showTerminal() ? "▼" : "▶"} done ({terminal().length})
+              </text>
+            </box>
+            <Show when={showTerminal()}>
+              <box flexDirection="column" paddingLeft={1}>
+                <For each={terminal()}>
+                  {(summary) => (
+                    <WorkflowRow
+                      api={props.api}
+                      summary={summary}
+                      expanded={isExpanded(summary.id)}
+                      onToggle={() => toggle(summary.id)}
+                    />
+                  )}
+                </For>
+              </box>
+            </Show>
+          </box>
+        </Show>
+      </box>
+    </Show>
+  )
+}
+
+const tui: TuiPlugin = async (api) => {
+  api.slots.register({
+    order: 460,
+    slots: {
+      sidebar_content(_ctx, props) {
+        return <DagPanel api={api} session_id={props.session_id} />
+      },
+    },
+  })
+}
+
+const plugin: BuiltinTuiPlugin = {
+  id,
+  tui,
+}
+
+export default plugin


### PR DESCRIPTION
## Summary

- terminalize recovered running DAG nodes whose process-local execution ownership was lost
- best-effort cancel active or unknown child sessions without implicitly retrying provider/tool work
- preserve timeout precedence, settled child output projection, dependency cascade, workflow terminalization, and wake eligibility
- add a live DAG sidebar panel with expandable active and terminal workflow progress
- mark DAG parent wake prompts as synthetic so orchestration signals remain model-visible without polluting TUI chat history
- add OpenSpec artifacts plus real DagLoop recovery integration coverage across Database, EventV2, projector, store, and service layers

## Validation

- `bun test test/dag` in `packages/opencode` — 151 passed
- `bun test test/util/transcript.test.ts` in `packages/tui` — 18 passed
- `bun typecheck` in `packages/opencode`
- `bun typecheck` in `packages/core`
- `bun typecheck` in `packages/tui`
- commit/push hook full workspace typecheck — 29 packages passed
- `openspec validate dag-post-crash-continuation --strict`