### PR TITLE
fix(test): stabilize opencode CI regressions

### DIFF
--- a/packages/opencode/test/fixture/plugin.ts
+++ b/packages/opencode/test/fixture/plugin.ts
@@ -2,7 +2,9 @@ import { mkdir } from "fs/promises"
 import path from "path"
 
 export async function markPluginDependenciesReady(dir: string) {
-  await mkdir(path.join(dir, "node_modules"), { recursive: true })
+  const plugin = path.join(dir, "node_modules", "@opencode-ai", "plugin")
+  await mkdir(plugin, { recursive: true })
+  await Bun.write(path.join(plugin, "package.json"), JSON.stringify({ name: "@opencode-ai/plugin", version: "0.0.0" }))
   await Bun.write(
     path.join(dir, "package-lock.json"),
     JSON.stringify({ packages: { "": { dependencies: { "@opencode-ai/plugin": "0.0.0" } } } }),

--- a/packages/opencode/test/lib/effect.ts
+++ b/packages/opencode/test/lib/effect.ts
@@ -160,7 +160,7 @@ export const awaitWithTimeout = <A, E, R>(
 
 export const pollWithTimeout = <A, E, R>(
   self: Effect.Effect<A | undefined, E, R>,
-  message: string,
+  message: string | (() => string),
   duration: Duration.Input = "5 seconds",
 ) =>
   Effect.gen(function* () {
@@ -172,6 +172,6 @@ export const pollWithTimeout = <A, E, R>(
   }).pipe(
     Effect.timeoutOrElse({
       duration,
-      orElse: () => Effect.fail(new Error(message)),
+      orElse: () => Effect.fail(new Error(typeof message === "function" ? message() : message)),
     }),
   )

--- a/packages/opencode/test/preload.ts
+++ b/packages/opencode/test/preload.ts
@@ -5,6 +5,7 @@ import path from "path"
 import fs from "fs/promises"
 import { setTimeout as sleep } from "node:timers/promises"
 import { afterAll } from "bun:test"
+import { markPluginDependenciesReady } from "./fixture/plugin"
 
 // Set XDG env vars FIRST, before any src/ imports
 const dir = path.join(os.tmpdir(), "opencode-test-data-" + process.pid)
@@ -48,6 +49,10 @@ process.env["OPENCODE_TEST_HOME"] = testHome
 // Set test managed config directory to isolate tests from system managed settings
 const testManagedConfigDir = path.join(dir, "managed")
 process.env["OPENCODE_TEST_MANAGED_CONFIG_DIR"] = testManagedConfigDir
+
+// Keep process-global AppRuntime construction in any test from starting a
+// registry install that can hold the shared config dependency lock.
+await markPluginDependenciesReady(path.join(dir, "config", "opencode"))
 
 // Write the cache version file to prevent global/index.ts from clearing the cache
 const cacheDir = path.join(dir, "cache", "opencode")

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -6,7 +6,13 @@ import { ModelsDev } from "@opencode-ai/core/models-dev"
 import { FSUtil } from "@opencode-ai/core/fs-util"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { Global } from "@opencode-ai/core/global"
-import { disposeAllInstances, provideInstanceEffect, tmpdirScoped, TestInstance } from "../fixture/fixture"
+import {
+  disposeAllInstancesEffect,
+  provideInstanceEffect,
+  testInstanceStoreLayer,
+  tmpdirScoped,
+  TestInstance,
+} from "../fixture/fixture"
 import { markPluginDependenciesReady } from "../fixture/plugin"
 import { Auth } from "@/auth"
 import { Config } from "@/config/config"
@@ -17,6 +23,7 @@ import { Provider } from "@/provider/provider"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { Filesystem } from "@/util/filesystem"
 import { InstanceLayer } from "@/project/instance-layer"
+import { InstanceState } from "@/effect/instance-state"
 import { testEffect } from "../lib/effect"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 import { ModelV2 } from "@opencode-ai/core/model"
@@ -47,13 +54,12 @@ const remove = (k: string) =>
     yield* Env.use.remove(k)
   })
 
-afterEach(async () => {
+afterEach(() => {
   for (const [key, value] of originalEnv) {
     if (value === undefined) delete process.env[key]
     else process.env[key] = value
   }
   originalEnv.clear()
-  await disposeAllInstances()
 })
 
 const providerLayer = (flags: Partial<RuntimeFlags.Info> = {}) =>
@@ -1649,7 +1655,7 @@ it.instance(
 // scoped tmpdir + provideInstance pattern via it.effect.
 
 const provideMultiInstance = <A, E, R>(eff: Effect.Effect<A, E, R>) =>
-  eff.pipe(Effect.provide(InstanceLayer.layer), Effect.provide(CrossSpawnSpawner.defaultLayer))
+  eff.pipe(Effect.provide(testInstanceStoreLayer), Effect.provide(CrossSpawnSpawner.defaultLayer))
 
 it.effect("plugin config providers persist after instance dispose", () =>
   Effect.gen(function* () {
@@ -1692,18 +1698,23 @@ it.effect("plugin config providers persist after instance dispose", () =>
       const plugin = yield* Plugin.Service
       const provider = yield* Provider.Service
       yield* plugin.init()
-      return yield* provider.list()
+      const providers = yield* provider.list()
+      return {
+        context: yield* InstanceState.context,
+        providers,
+      }
     }).pipe(provideInstanceEffect(dir))
 
     const first = yield* loadAndList
-    expect(first[ProviderV2.ID.make("demo")]).toBeDefined()
-    expect(first[ProviderV2.ID.make("demo")].models[ModelV2.ID.make("chat")]).toBeDefined()
+    expect(first.providers[ProviderV2.ID.make("demo")]).toBeDefined()
+    expect(first.providers[ProviderV2.ID.make("demo")].models[ModelV2.ID.make("chat")]).toBeDefined()
 
-    yield* Effect.promise(() => disposeAllInstances())
+    yield* disposeAllInstancesEffect
 
     const second = yield* loadAndList
-    expect(second[ProviderV2.ID.make("demo")]).toBeDefined()
-    expect(second[ProviderV2.ID.make("demo")].models[ModelV2.ID.make("chat")]).toBeDefined()
+    expect(second.context).not.toBe(first.context)
+    expect(second.providers[ProviderV2.ID.make("demo")]).toBeDefined()
+    expect(second.providers[ProviderV2.ID.make("demo")].models[ModelV2.ID.make("chat")]).toBeDefined()
   }).pipe(provideMultiInstance),
 )
 
@@ -1715,6 +1726,7 @@ it.instance(
     const root = path.join(configDir, "plugin")
     yield* Effect.promise(() => mkdir(root, { recursive: true }))
     yield* Effect.promise(() => markPluginDependenciesReady(configDir))
+    yield* Effect.promise(() => markPluginDependenciesReady(Global.Path.config))
     yield* Effect.promise(() =>
       Bun.write(
         path.join(root, "provider-filter.ts"),

--- a/packages/opencode/test/server/httpapi-reference.test.ts
+++ b/packages/opencode/test/server/httpapi-reference.test.ts
@@ -1,5 +1,8 @@
+import { $ } from "bun"
 import { afterEach, describe, expect, test } from "bun:test"
+import { mkdir } from "fs/promises"
 import path from "path"
+import { pathToFileURL } from "url"
 import { Server } from "../../src/server/server"
 import { Global } from "@opencode-ai/core/global"
 import { resetDatabase } from "../fixture/db"
@@ -14,58 +17,75 @@ afterEach(async () => {
 
 describe("reference HttpApi", () => {
   test("lists usable references resolved in the server workspace", async () => {
-    await using tmp = await tmpdir({
-      config: {
-        formatter: false,
-        lsp: false,
-        references: {
-          docs: "./docs",
-          effect: { repository: "Effect-TS/effect", branch: "main" },
-          bad: "not-a-repo",
-        },
-      },
-    })
+    await using source = await tmpdir({ git: true })
+    await $`git branch -M main`.cwd(source.path).quiet()
+    await using remote = await tmpdir()
+    await mkdir(path.join(remote.path, "Effect-TS"), { recursive: true })
+    await $`git clone --bare ${source.path} ${path.join(remote.path, "Effect-TS", "effect.git")}`.quiet()
 
-    const body = await Effect.runPromise(
-      pollWithTimeout(
-        Effect.promise(async () => {
-          const response = await Server.Default().app.request("/api/reference", {
-            headers: { "x-opencode-directory": tmp.path },
-          })
-          expect(response.status).toBe(200)
-          const body = await response.json()
-          return body.data.length === 0 ? undefined : body
-        }),
-        "references were not loaded",
-      ),
-    )
-    expect(body).toMatchObject({ location: { directory: tmp.path } })
-    expect(body.data).toEqual([
-      {
-        name: "docs",
-        path: path.join(tmp.path, "docs"),
-        description: null,
-        hidden: null,
-        source: {
-          type: "local",
+    const previous = process.env.OPENCODE_REPO_CLONE_GITHUB_BASE_URL
+    process.env.OPENCODE_REPO_CLONE_GITHUB_BASE_URL = pathToFileURL(remote.path).href
+    try {
+      await using tmp = await tmpdir({
+        config: {
+          formatter: false,
+          lsp: false,
+          references: {
+            docs: "./docs",
+            effect: { repository: "Effect-TS/effect", branch: "main" },
+            bad: "not-a-repo",
+          },
+        },
+      })
+
+      const expected = ["docs", "effect"]
+      let observed: string[] = []
+      const body = await Effect.runPromise(
+        pollWithTimeout(
+          Effect.promise(async () => {
+            const response = await Server.Default().app.request("/api/reference", {
+              headers: { "x-opencode-directory": tmp.path },
+            })
+            expect(response.status).toBe(200)
+            const body = await response.json()
+            observed = body.data.map((item: { name: string }) => item.name)
+            return expected.every((name) => observed.includes(name)) ? body : undefined
+          }),
+          () =>
+            `references were not loaded; observed=${observed.join(",") || "<none>"} missing=${expected.filter((name) => !observed.includes(name)).join(",") || "<none>"}`,
+        ),
+      )
+      expect(body).toMatchObject({ location: { directory: tmp.path } })
+      expect(body.data).toEqual([
+        {
+          name: "docs",
           path: path.join(tmp.path, "docs"),
           description: null,
           hidden: null,
+          source: {
+            type: "local",
+            path: path.join(tmp.path, "docs"),
+            description: null,
+            hidden: null,
+          },
         },
-      },
-      {
-        name: "effect",
-        path: path.join(Global.Path.repos, "github.com", "Effect-TS", "effect"),
-        description: null,
-        hidden: null,
-        source: {
-          type: "git",
-          repository: "Effect-TS/effect",
-          branch: "main",
+        {
+          name: "effect",
+          path: path.join(Global.Path.repos, "github.com", "Effect-TS", "effect"),
           description: null,
           hidden: null,
+          source: {
+            type: "git",
+            repository: "Effect-TS/effect",
+            branch: "main",
+            description: null,
+            hidden: null,
+          },
         },
-      },
-    ])
+      ])
+    } finally {
+      if (previous !== undefined) process.env.OPENCODE_REPO_CLONE_GITHUB_BASE_URL = previous
+      else delete process.env.OPENCODE_REPO_CLONE_GITHUB_BASE_URL
+    }
   })
 })

--- a/packages/opencode/test/server/httpapi-v2-pty.test.ts
+++ b/packages/opencode/test/server/httpapi-v2-pty.test.ts
@@ -81,7 +81,7 @@ describe("v2 pty HttpApi", () => {
     expect(body.data.title).toBe("v2")
 
     // The canonical surface keeps exited sessions observable with their exit code.
-    const deadline = Date.now() + 5_000
+    const deadline = Date.now() + 20_000
     let info: { status: string; exitCode?: number } | undefined
     while (Date.now() < deadline) {
       const found = await request(`/api/pty/${body.data.id}`, tmp.path)

--- a/packages/opencode/test/snapshot/snapshot.test.ts
+++ b/packages/opencode/test/snapshot/snapshot.test.ts
@@ -599,7 +599,8 @@ it.instance(
   withTrackedSnapshot(({ tmp, snapshot, before }) =>
     Effect.gen(function* () {
       const file = `${tmp.path}/.git/info/exclude`
-      yield* write(file, `${(yield* Effect.promise(() => Bun.file(file).text())).trimEnd()}\nignored.txt\n`)
+      const existing = yield* readText(file).pipe(Effect.orElseSucceed(() => ""))
+      yield* write(file, `${existing.trimEnd()}\nignored.txt\n`)
       yield* write(`${tmp.path}/ignored.txt`, "ignored content")
       yield* write(`${tmp.path}/normal.txt`, "normal content")
       const patch = yield* snapshot.patch(before)
@@ -629,7 +630,8 @@ it.instance(
         const before = yield* snapshot.track()
         expect(before).toBeTruthy()
         const file = `${tmp.path}/.git/info/exclude`
-        yield* write(file, `${(yield* Effect.promise(() => Bun.file(file).text())).trimEnd()}\ninfo.tmp\n`)
+        const existing = yield* readText(file).pipe(Effect.orElseSucceed(() => ""))
+        yield* write(file, `${existing.trimEnd()}\ninfo.tmp\n`)
         yield* write(`${tmp.path}/global.tmp`, "global content")
         yield* write(`${tmp.path}/info.tmp`, "info content")
         yield* write(`${tmp.path}/normal.txt`, "normal content")


### PR DESCRIPTION
## Summary

- keep provider lifecycle tests on their scoped InstanceStore and prepare plugin dependencies before any global runtime can acquire install locks
- replace the public reference repository with a deterministic local bare Git fixture and wait for the complete named reference set
- make snapshot exclude fixtures portable across Git template configurations and keep PTY exit polling reliable under package-suite load

## Verification

- `bun typecheck` from `packages/opencode`
- `bun test --timeout 30000 --only-failures` from `packages/opencode`: 3274 pass, 23 skip, 1 todo, 0 fail
- commit/push hook: all 29 typecheck tasks passed

Fixes the failures observed in Actions run 29978802440.