### PR TITLE
fix(dag): derive workflow project from session

### DIFF
--- a/packages/opencode/src/tool/workflow.ts
+++ b/packages/opencode/src/tool/workflow.ts
@@ -1,7 +1,9 @@
 import * as Tool from "./tool"
 import { SkillPlugin } from "@opencode-ai/core/plugin/skill"
-import { Effect, Option, Schema } from "effect"
+import { Effect, Schema } from "effect"
 import { Dag } from "@/dag/dag"
+import { Session } from "@/session/session"
+import { SessionID } from "@/session/schema"
 import type { NodeConfig, WorkflowConfig } from "@/dag/dag"
 
 const id = "workflow"
@@ -47,7 +49,7 @@ export const Parameters = Schema.Struct({
   action: Schema.Literals(["start", "extend", "control"]).annotate({ description: "start: create workflow; extend: add nodes; control: pause/resume/cancel/replan/step/complete" }),
   config: Schema.optional(WorkflowGraphSchema).annotate({ description: "(start) Workflow graph definition" }),
   session_id: Schema.optional(Schema.String).annotate({ description: "(start) Parent session ID" }),
-  project_id: Schema.optional(Schema.String).annotate({ description: "(start) Project ID" }),
+  project_id: Schema.optional(Schema.String).annotate({ description: "(start) Optional Project ID; must match the parent session project" }),
   title: Schema.optional(Schema.String).annotate({ description: "(start) Workflow title" }),
   workflow_id: Schema.optional(Schema.String).annotate({ description: "(extend/control) Target workflow ID" }),
   nodes: Schema.optional(Schema.Array(NodeSchema)).annotate({ description: "(extend) Nodes to add" }),
@@ -61,23 +63,28 @@ export const Parameters = Schema.Struct({
 
 type Metadata = { workflowId?: string; added?: string[]; cancel?: string[]; restart?: string[]; replace?: string[] }
 
-export const WorkflowTool = Tool.define<typeof Parameters, Metadata, Dag.Service>(
+export const WorkflowTool = Tool.define<typeof Parameters, Metadata, Dag.Service | Session.Service>(
   id,
   Effect.gen(function* () {
+    const dag = yield* Dag.Service
+    const sessions = yield* Session.Service
+
     return {
       description: SkillPlugin.WorkflowContent,
       parameters: Parameters,
       execute: (params: Schema.Schema.Type<typeof Parameters>, ctx: Tool.Context<Metadata>) =>
         Effect.gen(function* () {
-          const dagOpt = yield* Effect.serviceOption(Dag.Service)
-          if (Option.isNone(dagOpt)) return yield* Effect.die(new Error("DAG service not wired"))
-          const dag = dagOpt.value
           switch (params.action) {
             case "start": {
               if (!params.config) return yield* Effect.die(new Error("start requires 'config'"))
+              const sessionID = SessionID.make(params.session_id ?? ctx.sessionID)
+              const session = yield* sessions.get(sessionID).pipe(Effect.orDie)
+              if (params.project_id && params.project_id !== session.projectID) {
+                return yield* Effect.die(new Error("project_id must match the parent session project"))
+              }
               const dagID = yield* dag.create({
-                projectID: params.project_id ?? ctx.sessionID,
-                sessionID: params.session_id ?? ctx.sessionID,
+                projectID: session.projectID,
+                sessionID,
                 title: params.title ?? params.config.name,
                 config: params.config as WorkflowConfig,
               }).pipe(Effect.orDie)

--- a/packages/opencode/test/dag/workflow-tool.test.ts
+++ b/packages/opencode/test/dag/workflow-tool.test.ts
@@ -1,6 +1,48 @@
 import { describe, expect, it } from "bun:test"
-import { Schema } from "effect"
-import { Parameters } from "@/tool/workflow"
+import { Effect, Exit, Layer, Schema } from "effect"
+import { Dag } from "@/dag/dag"
+import { Agent } from "@/agent/agent"
+import { Session } from "@/session/session"
+import { MessageID, SessionID } from "@/session/schema"
+import type { Tool } from "@/tool/tool"
+import { Truncate } from "@/tool/truncate"
+import { Parameters, WorkflowTool } from "@/tool/workflow"
+import { testEffect } from "../lib/effect"
+
+const projectID = "project_test"
+const created: Parameters<Dag.Interface["create"]>[0][] = []
+const runtime = testEffect(
+  Layer.mergeAll(
+    Layer.succeed(
+      Agent.Service,
+      Agent.Service.of({
+        get: () => Effect.succeed({}),
+      } as unknown as Agent.Interface),
+    ),
+    Layer.succeed(
+      Truncate.Service,
+      Truncate.Service.of({
+        output: (content) => Effect.succeed({ content, truncated: false }),
+      } as Truncate.Interface),
+    ),
+    Layer.succeed(
+      Dag.Service,
+      Dag.Service.of({
+        create: (input: Parameters<Dag.Interface["create"]>[0]) =>
+          Effect.sync(() => {
+            created.push(input)
+            return Dag.ID.create()
+          }),
+      } as unknown as Dag.Interface),
+    ),
+    Layer.succeed(
+      Session.Service,
+      Session.Service.of({
+        get: (id: Parameters<Session.Interface["get"]>[0]) => Effect.succeed({ id, projectID } as Session.Info),
+      } as unknown as Session.Interface),
+    ),
+  ),
+)
 
 describe("workflow tool schema (negative tests)", () => {
   it("action field accepts start/extend/control", () => {
@@ -41,4 +83,73 @@ describe("workflow tool schema (negative tests)", () => {
     expect(() => decode({ action: "control", workflow_id: "wf-1", operation: "delete" })).toThrow()
     expect(() => decode({ action: "control", workflow_id: "wf-1", operation: "start" })).toThrow()
   })
+})
+
+describe("workflow tool execution", () => {
+  runtime.effect("start derives the project ID from the parent session", () =>
+    Effect.gen(function* () {
+      created.length = 0
+      const parentID = SessionID.make("ses_workflow_parent")
+      const info = yield* WorkflowTool
+      const workflow = yield* info.init()
+
+      const result = yield* workflow.execute(
+        {
+          action: "start",
+          config: {
+            name: "project-id-regression",
+            nodes: [],
+          },
+        },
+        {
+          sessionID: parentID,
+          messageID: MessageID.ascending(),
+          agent: "build",
+          abort: new AbortController().signal,
+          messages: [],
+          metadata: () => Effect.void,
+          ask: () => Effect.void,
+        } satisfies Tool.Context,
+      )
+
+      const workflowID = result.metadata.workflowId
+      expect(workflowID).toBeDefined()
+      expect(created).toHaveLength(1)
+      expect(created[0]?.projectID).toBe(projectID)
+      expect(created[0]?.sessionID).toBe(parentID)
+    }),
+  )
+
+  runtime.effect("start rejects a project ID outside the parent session project", () =>
+    Effect.gen(function* () {
+      created.length = 0
+      const parentID = SessionID.make("ses_workflow_parent")
+      const info = yield* WorkflowTool
+      const workflow = yield* info.init()
+      const exit = yield* workflow
+        .execute(
+          {
+            action: "start",
+            project_id: "project_other",
+            config: {
+              name: "project-id-mismatch",
+              nodes: [],
+            },
+          },
+          {
+            sessionID: parentID,
+            messageID: MessageID.ascending(),
+            agent: "build",
+            abort: new AbortController().signal,
+            messages: [],
+            metadata: () => Effect.void,
+            ask: () => Effect.void,
+          } satisfies Tool.Context,
+        )
+        .pipe(Effect.exit)
+
+      expect(Exit.isFailure(exit)).toBe(true)
+      expect(created).toHaveLength(0)
+    }),
+  )
 })


### PR DESCRIPTION
## 问题

DAG `workflow` 工具在启动动态工作流且未显式传入 `project_id` 时，会错误地把当前 `sessionID` 当成 `projectID`。由于 DAG 工作流记录的 `project_id` 受项目外键约束，创建过程会以 `SQLITE_CONSTRAINT_FOREIGNKEY` 失败，因此提示词看起来没有触发动态工作流。

`/dag` 命令本身只负责打开 DAG 检视器，不直接创建工作流。

## 修复

- 根据父会话读取真实的 `projectID`，用于创建 DAG 工作流
- 将可选的显式 `project_id` 作为一致性校验，拒绝跨项目启动
- 将 `Session.Service` 纳入 workflow 工具的显式依赖
- 增加回归测试，覆盖省略 `project_id` 和项目不匹配两条路径

## 影响

提示词调用 `workflow` 工具时，不再需要模型正确补出 `project_id`；工作流会稳定继承父会话所属项目。

## 验证

- `bun test test/dag/workflow-tool.test.ts`：8 passed
- `bun typecheck`（`packages/opencode`）：通过
- 提交/推送钩子全仓 Typecheck：29/29 通过
