### PR TITLE
fix(dag): restore runtime visibility

### DIFF
--- a/packages/core/src/plugin/skill/workflow.md
+++ b/packages/core/src/plugin/skill/workflow.md
@@ -342,6 +342,8 @@ All nodes share the same workspace. Write conflicts are an orchestration concern
 
 **extend** — Add nodes to a running workflow. Existing nodes are unaffected; new nodes are immediately eligible for scheduling if their dependencies are met.
 
+**status** — Read the durable state of one workflow and all of its nodes. Pass `workflow_id`. Use it whenever the user asks whether a workflow is running, when progress is uncertain, or before deciding whether to replan/control a workflow.
+
 **control** — Control a running workflow:
 - `pause` — let running nodes finish, don't spawn new ones
 - `resume` — resume scheduling
@@ -372,5 +374,5 @@ All nodes share the same workspace. Write conflicts are an orchestration concern
 ### What NOT to expect
 
 - No `node_complete` action — completion is automatic
-- No `status` / `list` / `history` actions — those are TUI-only via HTTP routes
+- No `list` / `history` actions — inspect a known workflow with `status`; broader browsing remains TUI-only
 - No topology templates — templates are prompt fragments only; you design the graph

--- a/packages/opencode/src/project/bootstrap.ts
+++ b/packages/opencode/src/project/bootstrap.ts
@@ -54,8 +54,8 @@ export const layer = Layer.effect(
         (s) => s.init().pipe(Effect.catchCause((cause) => Effect.logWarning("init failed", { cause }))),
         { concurrency: "unbounded", discard: true },
       ).pipe(Effect.withSpan("InstanceBootstrap.init"))
-      // DagLoop is provided by AppLayer (provideMerge). Activate its event
-      // subscription only when available; skipped in test/standalone contexts.
+      // DAG services are present in the production/default graphs. Keep the
+      // optional lookup so narrow test layers may omit them intentionally.
       const dagLoop = yield* Effect.serviceOption(DagLoop.Service)
       if (dagLoop._tag === "Some") {
         yield* dagLoop.value
@@ -87,6 +87,8 @@ export const layer = Layer.effect(
 export const defaultLayer: Layer.Layer<Service> = layer.pipe(
   Layer.provide([
     Config.defaultLayer,
+    DagLoop.defaultLayer,
+    DagSummaryPublisher.defaultLayer,
     Format.defaultLayer,
     LSP.defaultLayer,
     Plugin.defaultLayer,
@@ -99,6 +101,8 @@ export const defaultLayer: Layer.Layer<Service> = layer.pipe(
 
 export const node = LayerNode.make(layer, [
   Config.node,
+  DagLoop.node,
+  DagSummaryPublisher.node,
   Format.node,
   LSP.node,
   Plugin.node,

--- a/packages/opencode/src/tool/workflow.ts
+++ b/packages/opencode/src/tool/workflow.ts
@@ -46,12 +46,12 @@ const WorkflowGraphSchema = Schema.Struct({
 })
 
 export const Parameters = Schema.Struct({
-  action: Schema.Literals(["start", "extend", "control"]).annotate({ description: "start: create workflow; extend: add nodes; control: pause/resume/cancel/replan/step/complete" }),
+  action: Schema.Literals(["start", "extend", "control", "status"]).annotate({ description: "start: create workflow; extend: add nodes; control: pause/resume/cancel/replan/step/complete; status: inspect durable workflow and node state" }),
   config: Schema.optional(WorkflowGraphSchema).annotate({ description: "(start) Workflow graph definition" }),
   session_id: Schema.optional(Schema.String).annotate({ description: "(start) Parent session ID" }),
   project_id: Schema.optional(Schema.String).annotate({ description: "(start) Optional Project ID; must match the parent session project" }),
   title: Schema.optional(Schema.String).annotate({ description: "(start) Workflow title" }),
-  workflow_id: Schema.optional(Schema.String).annotate({ description: "(extend/control) Target workflow ID" }),
+  workflow_id: Schema.optional(Schema.String).annotate({ description: "(extend/control/status) Target workflow ID" }),
   nodes: Schema.optional(Schema.Array(NodeSchema)).annotate({ description: "(extend) Nodes to add" }),
   operation: Schema.optional(Schema.Literals(["pause", "resume", "cancel", "replan", "step", "complete"])).annotate({ description: "(control) Operation to perform" }),
   fragment: Schema.optional(WorkflowGraphSchema).annotate({ description: "(control replan) Replan fragment with node definitions" }),
@@ -75,6 +75,35 @@ export const WorkflowTool = Tool.define<typeof Parameters, Metadata, Dag.Service
       execute: (params: Schema.Schema.Type<typeof Parameters>, ctx: Tool.Context<Metadata>) =>
         Effect.gen(function* () {
           switch (params.action) {
+            case "status": {
+              if (!params.workflow_id) return yield* Effect.die(new Error("status requires 'workflow_id'"))
+              const workflow = yield* dag.store.getWorkflow(params.workflow_id).pipe(Effect.orDie)
+              if (!workflow) return yield* Effect.die(new Error(`Workflow not found: ${params.workflow_id}`))
+              const nodes = yield* dag.store.getNodes(params.workflow_id).pipe(Effect.orDie)
+              return {
+                title: `Workflow status: ${workflow.title}`,
+                output: JSON.stringify(
+                  {
+                    id: workflow.id,
+                    title: workflow.title,
+                    status: workflow.status,
+                    session_id: workflow.sessionId,
+                    nodes: nodes.map((node) => ({
+                      id: node.id,
+                      name: node.name,
+                      status: node.status,
+                      required: node.required,
+                      depends_on: node.dependsOn,
+                      ...(node.childSessionId ? { child_session_id: node.childSessionId } : {}),
+                      ...(node.errorReason ? { error_reason: node.errorReason } : {}),
+                    })),
+                  },
+                  null,
+                  2,
+                ),
+                metadata: { workflowId: workflow.id } as Metadata,
+              }
+            }
             case "start": {
               if (!params.config) return yield* Effect.die(new Error("start requires 'config'"))
               const sessionID = SessionID.make(params.session_id ?? ctx.sessionID)

--- a/packages/opencode/test/dag/workflow-tool.test.ts
+++ b/packages/opencode/test/dag/workflow-tool.test.ts
@@ -33,6 +33,54 @@ const runtime = testEffect(
             created.push(input)
             return Dag.ID.create()
           }),
+        store: {
+          getWorkflow: (id: string) =>
+            Effect.succeed(
+              id === "dag_status"
+                ? {
+                    id,
+                    projectId: projectID,
+                    sessionId: "ses_workflow_parent",
+                    title: "Status workflow",
+                    status: "running",
+                    config: "{}",
+                    seq: 1,
+                    wakeReported: false,
+                    startedAt: 1,
+                    completedAt: null,
+                    timeCreated: 1,
+                    timeUpdated: 2,
+                  }
+                : undefined,
+            ),
+          getNodes: () =>
+            Effect.succeed([
+              {
+                id: "node_running",
+                workflowId: "dag_status",
+                name: "Running node",
+                workerType: "build",
+                status: "running",
+                required: true,
+                dependsOn: [],
+                modelId: null,
+                modelProviderId: null,
+                childSessionId: "ses_child",
+                output: null,
+                capturedOutput: null,
+                errorReason: null,
+                deadlineMs: null,
+                wakeEligible: true,
+                wakeReported: false,
+                replanAttempts: 0,
+                seq: 1,
+                startedAt: 1,
+                completedAt: null,
+                timeCreated: 1,
+                timeUpdated: 2,
+              },
+            ]),
+        },
       } as unknown as Dag.Interface),
     ),
     Layer.succeed(
@@ -45,17 +93,17 @@ const runtime = testEffect(
 )
 
 describe("workflow tool schema (negative tests)", () => {
-  it("action field accepts start/extend/control", () => {
+  it("action field accepts start/extend/control/status", () => {
     const decode = Schema.decodeUnknownSync(Parameters)
     expect(() => decode({ action: "start", config: { name: "test", nodes: [], max_concurrency: 3 } })).not.toThrow()
     expect(() => decode({ action: "extend", workflow_id: "wf-1", nodes: [] })).not.toThrow()
     expect(() => decode({ action: "control", workflow_id: "wf-1", operation: "pause" })).not.toThrow()
+    expect(() => decode({ action: "status", workflow_id: "wf-1" })).not.toThrow()
   })
 
   it("action field rejects unknown actions", () => {
     const decode = Schema.decodeUnknownSync(Parameters)
     expect(() => decode({ action: "delete" })).toThrow()
-    expect(() => decode({ action: "status" })).toThrow()
   })
 
   it("no node_complete action exists", () => {
@@ -63,9 +111,8 @@ describe("workflow tool schema (negative tests)", () => {
     expect(() => decode({ action: "node_complete" })).toThrow()
   })
 
-  it("no read-only actions exist (status/list/history/logs)", () => {
+  it("no unsupported read-only actions exist (list/history/logs)", () => {
     const decode = Schema.decodeUnknownSync(Parameters)
-    expect(() => decode({ action: "status" })).toThrow()
     expect(() => decode({ action: "list" })).toThrow()
     expect(() => decode({ action: "history" })).toThrow()
     expect(() => decode({ action: "logs" })).toThrow()
@@ -86,6 +133,32 @@ describe("workflow tool schema (negative tests)", () => {
 })
 
 describe("workflow tool execution", () => {
+  runtime.effect("status returns the durable workflow and node state", () =>
+    Effect.gen(function* () {
+      const info = yield* WorkflowTool
+      const workflow = yield* info.init()
+      const result = yield* workflow.execute(
+        {
+          action: "status",
+          workflow_id: "dag_status",
+        },
+        {
+          sessionID: SessionID.make("ses_workflow_parent"),
+          messageID: MessageID.ascending(),
+          agent: "build",
+          abort: new AbortController().signal,
+          messages: [],
+          metadata: () => Effect.void,
+          ask: () => Effect.void,
+        } satisfies Tool.Context,
+      )
+
+      expect(result.output).toContain('"status": "running"')
+      expect(result.output).toContain('"id": "node_running"')
+      expect(result.output).toContain('"child_session_id": "ses_child"')
+    }),
+  )
+
   runtime.effect("start derives the project ID from the parent session", () =>
     Effect.gen(function* () {
       created.length = 0

--- a/packages/opencode/test/project/bootstrap-dag-wiring.test.ts
+++ b/packages/opencode/test/project/bootstrap-dag-wiring.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test"
+import { DagLoop } from "@/dag/runtime/loop"
+import { DagSummaryPublisher } from "@/dag/runtime/summary-publisher"
+import { InstanceBootstrap } from "@/project/bootstrap"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+
+describe("instance bootstrap DAG wiring", () => {
+  test("production LayerNode graph provides the DAG runtime and summary publisher", () => {
+    expect(InstanceBootstrap.node.dependencies).toContain(DagLoop.node)
+    expect(InstanceBootstrap.node.dependencies).toContain(DagSummaryPublisher.node)
+    expect(() => LayerNode.buildLayer(InstanceBootstrap.node)).not.toThrow()
+  })
+})

--- a/packages/tui/src/feature-plugins/sidebar/dag.tsx
+++ b/packages/tui/src/feature-plugins/sidebar/dag.tsx
@@ -9,7 +9,7 @@ function DagIndicator(props: { api: TuiPluginApi; session_id: string }) {
   const [open, setOpen] = createSignal(true)
   const theme = () => props.api.theme.current
   const dags = createMemo(() => props.api.state.session.dag(props.session_id))
-  const active = createMemo(() => dags().filter((d) => d.status === "running" || d.status === "paused"))
+  const active = createMemo(() => dags().filter((d) => d.status === "running" || d.status === "paused" || d.status === "stepping"))
 
   const statusColor = (status: string) => {
     if (status === "completed") return theme().success
@@ -17,6 +17,7 @@ function DagIndicator(props: { api: TuiPluginApi; session_id: string }) {
     if (status === "cancelled") return theme().textMuted
     if (status === "running") return theme().textMuted
     if (status === "paused") return theme().warning
+    if (status === "stepping") return theme().warning
     return theme().textMuted
   }
 

--- a/packages/tui/src/feature-plugins/system/dag-inspector.tsx
+++ b/packages/tui/src/feature-plugins/system/dag-inspector.tsx
@@ -6,6 +6,7 @@ import { Spinner } from "../../component/spinner"
 import { TextAttributes } from "@opentui/core"
 import { useBindings, useCommandShortcut } from "../../keymap"
 import { computeWaves, type DagNode } from "./dag-inspector-utils"
+import type { DagWorkflowSummary } from "@opencode-ai/sdk/v2"
 
 const id = "internal:system-dag-inspector"
 const ROUTE = "dag"
@@ -20,11 +21,38 @@ function DagInspector(props: { api: TuiPluginApi }) {
   const [selectedWorkflow, setSelectedWorkflow] = createSignal<string | undefined>(undefined)
   const [selectedNode, setSelectedNode] = createSignal<string | undefined>(undefined)
   const [nodes, setNodes] = createSignal<DagNode[]>([])
+  const [fetchedWorkflows, setFetchedWorkflows] = createSignal<ReadonlyArray<DagWorkflowSummary> | undefined>()
+  const [workflowLoad, setWorkflowLoad] = createSignal<"loading" | "loaded" | "error">("loading")
 
   const workflows = createMemo(() => {
     const sid = params()?.sessionID
     if (!sid) return []
-    return props.api.state.session.dag(sid)
+    const synced = props.api.state.session.dag(sid)
+    return synced.length > 0 ? synced : (fetchedWorkflows() ?? [])
+  })
+
+  // Refresh authoritative state when the inspector opens. Summary events are
+  // ephemeral, so the shared sync slice can legitimately be empty after a
+  // missed event even though the workflow exists on the server.
+  createEffect(() => {
+    const sessionID = params()?.sessionID
+    if (!sessionID) {
+      setFetchedWorkflows([])
+      setWorkflowLoad("loaded")
+      return
+    }
+    setWorkflowLoad("loading")
+    void props.api.client.dag
+      .summary({ sessionID })
+      .then((response) => {
+        if (params()?.sessionID !== sessionID) return
+        setFetchedWorkflows(response.data ?? [])
+        setWorkflowLoad("loaded")
+      })
+      .catch(() => {
+        if (params()?.sessionID !== sessionID) return
+        setWorkflowLoad("error")
+      })
   })
 
   // Keep a valid workflow selected: adopt the first workflow when nothing is
@@ -251,6 +279,9 @@ function DagInspector(props: { api: TuiPluginApi }) {
             <text fg={theme().text} attributes={TextAttributes.BOLD}>
               Workflows
             </text>
+            <Show when={workflowLoad() !== "loading" && workflows().length === 0}>
+              <text fg={theme().textMuted}>No workflows</text>
+            </Show>
             <For each={workflows().slice(0, 10)}>
               {(wf) => (
                 <box
@@ -280,7 +311,15 @@ function DagInspector(props: { api: TuiPluginApi }) {
         <box flexGrow={1} padding={1}>
           <Show
             when={selectedWorkflow()}
-            fallback={<text fg={theme().textMuted}>Select a workflow from the left</text>}
+            fallback={
+              <text fg={theme().textMuted}>
+                {workflowLoad() === "loading"
+                  ? "Loading workflows..."
+                  : workflowLoad() === "error"
+                    ? "Unable to load workflows"
+                    : "No workflows for this session"}
+              </text>
+            }
           >
             <box flexDirection="column" gap={1}>
               <text fg={theme().text} attributes={TextAttributes.BOLD}>

--- a/packages/tui/test/feature-plugins/dag-inspector.test.tsx
+++ b/packages/tui/test/feature-plugins/dag-inspector.test.tsx
@@ -29,6 +29,7 @@ const wfSummary = (overrides: Partial<DagWorkflowSummary> = {}): DagWorkflowSumm
 
 type RenderOpts = {
   workflows?: DagWorkflowSummary[]
+  serverWorkflows?: DagWorkflowSummary[]
   nodes?: DagNode[]
   initialRoute?: TuiRouteCurrent
 }
@@ -76,6 +77,7 @@ async function renderDagInspector(opts: RenderOpts = {}) {
       keymap,
       client: {
         dag: {
+          summary: async () => ({ data: opts.serverWorkflows ?? workflowsState }),
           nodes: async (input: { dagID: string }) => {
             nodesCalls.push(input.dagID)
             return { data: opts.nodes ?? [] }
@@ -140,7 +142,7 @@ async function renderDagInspector(opts: RenderOpts = {}) {
   const app = await testRender(() => <Harness />, { width: 100, height: 30 })
   await waitForCommand(app, commands, "dag.close")
   // Give the initial fetchNodes a chance to resolve.
-  await waitForCondition(() => nodesCalls.length > 0)
+  if (workflowsState.length > 0) await waitForCondition(() => nodesCalls.length > 0)
 
   return {
     app,
@@ -184,6 +186,28 @@ async function waitForCondition(fn: () => boolean, timeout = 2000) {
 }
 
 describe("DagInspector", () => {
+  test("opening dag refreshes workflows from the server when sync state is empty", async () => {
+    const viewer = await renderDagInspector({
+      serverWorkflows: [wfSummary({ id: "wf-server", title: "Live server workflow", nodeCount: 1 })],
+      nodes: [dagNode({ id: "n-1", workflow_id: "wf-server", name: "build", status: "running" })],
+    })
+    try {
+      await viewer.app.waitForFrame((frame) => frame.includes("Live server workflow"))
+      expect(viewer.nodesCalls()).toContain("wf-server")
+    } finally {
+      viewer.app.renderer.destroy()
+    }
+  })
+
+  test("opening dag without visible workflows renders an explanatory empty state", async () => {
+    const viewer = await renderDagInspector()
+    try {
+      await viewer.app.waitForFrame((frame) => frame.includes("No workflows"))
+    } finally {
+      viewer.app.renderer.destroy()
+    }
+  })
+
   test("mounting fetches nodes for the auto-selected workflow", async () => {
     const viewer = await renderDagInspector({
       workflows: [wfSummary({ id: "wf-1", nodeCount: 1 })],


### PR DESCRIPTION
## What changed

- wire `DagLoop` and `DagSummaryPublisher` into both production LayerNode and default-layer bootstrap graphs
- add authoritative workflow refresh plus loading/empty/error states to the TUI DAG inspector
- add read-only `workflow status` support for models, including durable workflow and node state
- include `stepping` workflows in the TUI indicator
- add regression coverage for production wiring, server refresh, empty state, and status output

## Root cause

The server-driven production graph omitted the DAG scheduler and summary publisher from `InstanceBootstrap.node`. Workflow creation could persist a `running` workflow while no scheduler consumed it, and workflows created after TUI bootstrap emitted no summary update. The model also had no read-only status action, so it could only repeat the optimistic start result.

## User impact

Running DAGs are now actually scheduled in the production graph, appear in the session sidebar, load authoritatively in `/dag`, and can be queried by the model with `workflow status`.

## Validation

- `bun test test/dag` in `packages/opencode`: 154 passed
- DAG/TUI sync and inspector tests in `packages/tui`: 22 passed
- `bun typecheck` in `packages/opencode`
- `bun typecheck` in `packages/tui`
- pre-commit and pre-push full workspace Typecheck: 29 tasks passed
