### PR TITLE
feat(dag): add dag-flow command

### DIFF
--- a/packages/core/src/plugin/command.ts
+++ b/packages/core/src/plugin/command.ts
@@ -1,3 +1,5 @@
+/// <reference path="../markdown.d.ts" />
+
 export * as CommandPlugin from "./command"
 
 import { define } from "./internal"
@@ -5,6 +7,12 @@ import { Effect } from "effect"
 import { Location } from "../location"
 import PROMPT_INITIALIZE from "./command/initialize.txt"
 import PROMPT_REVIEW from "./command/review.txt"
+import DAG_FLOW_PROMPT from "./command/dag-flow.txt"
+import workflowContent from "./command/workflow.md" with { type: "text" }
+
+export const DagFlowDescription = "Start a dependency-graph multi-agent workflow for the supplied task"
+export const WorkflowContent = workflowContent
+export const DagFlowContent = `${DAG_FLOW_PROMPT}\n\n${WorkflowContent}`
 
 export const Plugin = define({
   id: "command",
@@ -19,6 +27,10 @@ export const Plugin = define({
         command.template = PROMPT_REVIEW.replace("${path}", location.project.directory)
         command.description = "review changes [commit|branch|pr], defaults to uncommitted"
         command.subtask = true
+      })
+      draft.update("dag-flow", (command) => {
+        command.template = DagFlowContent
+        command.description = DagFlowDescription
       })
     })
   }),

--- a/packages/core/src/plugin/command/dag-flow.txt
+++ b/packages/core/src/plugin/command/dag-flow.txt
@@ -1,0 +1,19 @@
+# Start a DAG Workflow
+
+The user invoked `/dag-flow` to start a new orchestration task.
+
+<dag-flow-task>
+$ARGUMENTS
+</dag-flow-task>
+
+If the content inside `<dag-flow-task>` is empty or contains only whitespace, ask the user what task should be orchestrated. Do not call the `workflow` tool until the user provides a task.
+
+For a non-empty task:
+
+1. Choose the smallest useful dependency graph for the task.
+2. Call the `workflow` tool with `action=start` in this response. Merely printing a plan, graph, JSON, or YAML does not mean a workflow was started.
+3. Do not claim the workflow is running unless the tool call succeeds.
+4. On success, report the exact Workflow ID and initial state returned by the tool, then tell the user to run `/dag` for live inspection.
+5. On failure, state that the workflow was not started and report the actual error. Never invent a Workflow ID.
+
+Use the orchestration guidance below to design and manage the workflow.

--- a/packages/core/src/plugin/command/workflow.md
+++ b/packages/core/src/plugin/command/workflow.md
@@ -1,7 +1,6 @@
 <!--
-  Built-in skill. Name and description are registered in code at
-  packages/core/src/plugin/skill.ts (WorkflowDescription).
-  The body below becomes the skill's content.
+  Shared workflow-tool guidance. The /dag-flow command prepends its launch
+  contract, while the workflow tool uses this neutral reference directly.
 -->
 
 # Workflow Orchestration

--- a/packages/core/src/plugin/skill.ts
+++ b/packages/core/src/plugin/skill.ts
@@ -8,20 +8,15 @@ import { AbsolutePath } from "../schema"
 import { SkillV2 } from "../skill"
 import customizeOpencodeContent from "./skill/customize-opencode.md" with { type: "text" }
 import configureHooksContent from "./skill/configure-hooks.md" with { type: "text" }
-import workflowContent from "./skill/workflow.md" with { type: "text" }
 
 export const CustomizeOpencodeContent = customizeOpencodeContent
 export const ConfigureHooksContent = configureHooksContent
-export const WorkflowContent = workflowContent
 
 export const CustomizeOpencodeDescription =
   "Use ONLY when the user is editing or creating opencode's own configuration: opencode.json, opencode.jsonc, files under .opencode/, or files under ~/.config/opencode/. Also use when creating or fixing opencode agents, subagents, commands, skills, plugins, MCP servers, or permission rules. Do not use for the user's own application code, or for any project that is not configuring opencode itself."
 
 export const ConfigureHooksDescription =
   "Use when the user wants to automatically run something on an opencode event — before/after a tool call, on session start/end, on compaction, etc. — or asks about opencode's hooks / hooks.json / event hooks. Covers hooks.json file locations and format, the 27 supported events, and the 5 hook types (command, mcp, http, prompt, agent). Also use to migrate hooks from Claude Code's .claude/settings.json via /import-claude-hooks."
-
-export const WorkflowDescription =
-  "Use when the user says \"动态工作流\", \"dynamic workflow\", \"dynamic flow\", \"workflow\", or describes a heavy task that needs multi-agent orchestration. Also use when a task is large enough to need staged pipelines with quality gates, parallel fan-out across independent units, adversarial multi-model review, or diverge-converge brainstorming. Covers the full orchestration lifecycle (explore → review → execute → merge → iterate), four collaboration patterns with YAML examples, adaptive replanning at runtime, and per-node model assignment strategy."
 
 export const Plugin = define({
   id: "skill",
@@ -46,17 +41,6 @@ export const Plugin = define({
             description: ConfigureHooksDescription,
             location: AbsolutePath.make("/builtin/configure-hooks.md"),
             content: ConfigureHooksContent,
-          }),
-        }),
-      )
-      draft.source(
-        SkillV2.EmbeddedSource.make({
-          type: "embedded",
-          skill: SkillV2.Info.make({
-            name: "workflow",
-            description: WorkflowDescription,
-            location: AbsolutePath.make("/builtin/workflow.md"),
-            content: WorkflowContent,
           }),
         }),
       )

--- a/packages/core/test/plugin/command.test.ts
+++ b/packages/core/test/plugin/command.test.ts
@@ -43,6 +43,15 @@ describe("CommandPlugin.Plugin", () => {
         description: "review changes [commit|branch|pr], defaults to uncommitted",
         subtask: true,
       })
+      expect(yield* command.get("dag-flow")).toMatchObject({
+        name: "dag-flow",
+        description: CommandPlugin.DagFlowDescription,
+        template: CommandPlugin.DagFlowContent,
+      })
+      expect(CommandPlugin.DagFlowContent).toContain("$ARGUMENTS")
+      expect(CommandPlugin.DagFlowContent).toContain("workflow` tool with `action=start")
+      expect(CommandPlugin.DagFlowContent).toContain("exact Workflow ID")
+      expect(CommandPlugin.DagFlowContent).toContain("run `/dag`")
     }),
   )
 })

--- a/packages/core/test/plugin/skill.test.ts
+++ b/packages/core/test/plugin/skill.test.ts
@@ -44,4 +44,13 @@ describe("SkillPlugin.Plugin", () => {
       )
     }),
   )
+
+  it.effect("does not register workflow as a built-in skill", () =>
+    Effect.gen(function* () {
+      const skill = yield* SkillV2.Service
+      yield* SkillPlugin.Plugin.effect(host({ skill: { ...skill, reload: skill.reload } }))
+
+      expect((yield* skill.list()).some((item) => item.name === "workflow")).toBe(false)
+    }),
+  )
 })

--- a/packages/opencode/src/command/index.ts
+++ b/packages/opencode/src/command/index.ts
@@ -11,6 +11,7 @@ import PROMPT_REVIEW from "./template/review.txt"
 import PROMPT_IMPORT_HOOKS from "./template/import-claude-hooks.txt"
 import PROMPT_CREATE_HOOK from "./template/create-hook.txt"
 import { LegacyEvent } from "@opencode-ai/schema/legacy-event"
+import { CommandPlugin } from "@opencode-ai/core/plugin/command"
 
 type State = {
   commands: Record<string, Info>
@@ -47,6 +48,7 @@ export function hints(template: string) {
 export const Default = {
   INIT: "init",
   REVIEW: "review",
+  DAG_FLOW: "dag-flow",
   IMPORT_HOOKS: "import-claude-hooks",
   CREATE_HOOK: "create-hook",
 } as const
@@ -88,6 +90,13 @@ export const layer = Layer.effect(
         },
         subtask: true,
         hints: hints(PROMPT_REVIEW),
+      }
+      commands[Default.DAG_FLOW] = {
+        name: Default.DAG_FLOW,
+        description: CommandPlugin.DagFlowDescription,
+        source: "command",
+        template: CommandPlugin.DagFlowContent,
+        hints: hints(CommandPlugin.DagFlowContent),
       }
       commands[Default.IMPORT_HOOKS] = {
         name: Default.IMPORT_HOOKS,

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1822,30 +1822,8 @@ export const layer = Layer.effect(
       }
       const agentName = cmd.agent ?? input.agent
 
-      const raw = input.arguments.match(argsRegex) ?? []
-      const args = raw.map((arg) => arg.replace(quoteTrimRegex, ""))
       const templateCommand = yield* Effect.promise(async () => cmd.template)
-
-      const placeholders = templateCommand.match(placeholderRegex) ?? []
-      let last = 0
-      for (const item of placeholders) {
-        const value = Number(item.slice(1))
-        if (value > last) last = value
-      }
-
-      const withArgs = templateCommand.replaceAll(placeholderRegex, (_, index) => {
-        const position = Number(index)
-        const argIndex = position - 1
-        if (argIndex >= args.length) return ""
-        if (position === last) return args.slice(argIndex).join(" ")
-        return args[argIndex]
-      })
-      const usesArgumentsPlaceholder = templateCommand.includes("$ARGUMENTS")
-      let template = withArgs.replaceAll("$ARGUMENTS", input.arguments)
-
-      if (placeholders.length === 0 && !usesArgumentsPlaceholder && input.arguments.trim()) {
-        template = template + "\n\n" + input.arguments
-      }
+      let template = expandCommandTemplate(templateCommand, input.arguments)
 
       const shellMatches = ConfigMarkdown.shell(template)
       if (shellMatches.length > 0) {
@@ -2082,6 +2060,25 @@ const bashRegex = /!`([^`]+)`/g
 const argsRegex = /(?:\[Image\s+\d+\]|"[^"]*"|'[^']*'|[^\s"']+)/gi
 const placeholderRegex = /\$(\d+)/g
 const quoteTrimRegex = /^["']|["']$/g
+
+/** @internal Exported for command-template regression tests. */
+export function expandCommandTemplate(template: string, input: string) {
+  const args = (input.match(argsRegex) ?? []).map((arg) => arg.replace(quoteTrimRegex, ""))
+  const placeholders = template.match(placeholderRegex) ?? []
+  const last = placeholders.reduce((max, item) => Math.max(max, Number(item.slice(1))), 0)
+  const expanded = template
+    .replaceAll(placeholderRegex, (_, index) => {
+      const position = Number(index)
+      const argIndex = position - 1
+      if (argIndex >= args.length) return ""
+      if (position === last) return args.slice(argIndex).join(" ")
+      return args[argIndex]
+    })
+    .replaceAll("$ARGUMENTS", input)
+
+  if (placeholders.length > 0 || template.includes("$ARGUMENTS") || !input.trim()) return expanded
+  return `${expanded}\n\n${input}`
+}
 
 export const node = LayerNode.make(layer, [
   SessionStatus.node,

--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -42,10 +42,6 @@ const CONFIGURE_HOOKS_SKILL_NAME = "configure-hooks"
 const CONFIGURE_HOOKS_SKILL_DESCRIPTION = SkillPlugin.ConfigureHooksDescription
 const CONFIGURE_HOOKS_SKILL_BODY = SkillPlugin.ConfigureHooksContent
 
-const WORKFLOW_SKILL_NAME = "workflow"
-const WORKFLOW_SKILL_DESCRIPTION = SkillPlugin.WorkflowDescription
-const WORKFLOW_SKILL_BODY = SkillPlugin.WorkflowContent
-
 export const Info = Schema.Struct({
   name: Schema.String,
   description: Schema.optional(Schema.String),
@@ -298,12 +294,6 @@ export const layer = Layer.effect(
           description: CONFIGURE_HOOKS_SKILL_DESCRIPTION,
           location: "<built-in>",
           content: CONFIGURE_HOOKS_SKILL_BODY,
-        }
-        s.skills[WORKFLOW_SKILL_NAME] = {
-          name: WORKFLOW_SKILL_NAME,
-          description: WORKFLOW_SKILL_DESCRIPTION,
-          location: "<built-in>",
-          content: WORKFLOW_SKILL_BODY,
         }
         yield* loadSkills(s, yield* InstanceState.get(discovered), events)
         return s

--- a/packages/opencode/src/tool/workflow.ts
+++ b/packages/opencode/src/tool/workflow.ts
@@ -1,5 +1,5 @@
 import * as Tool from "./tool"
-import { SkillPlugin } from "@opencode-ai/core/plugin/skill"
+import { CommandPlugin } from "@opencode-ai/core/plugin/command"
 import { Effect, Schema } from "effect"
 import { Dag } from "@/dag/dag"
 import { Session } from "@/session/session"
@@ -17,7 +17,10 @@ const NodeSchema = Schema.Struct({
   name: Schema.String.annotate({ description: "Human-readable node name" }),
   worker_type: Schema.String.annotate({ description: "Agent type (explore, build, general, plan, or custom)" }),
   depends_on: Schema.Array(Schema.String).annotate({ description: "Node IDs this node waits for ([] for root)" }),
-  required: Schema.optional(Schema.Boolean).annotate({ description: "If true and this node fails, the workflow is cancelled. Default: false" }),
+  required: Schema.Boolean.pipe(
+    Schema.optional,
+    Schema.withDecodingDefaultType(Effect.succeed(false)),
+  ).annotate({ description: "If true and this node fails, the workflow is cancelled. Default: false" }),
   prompt_template: Schema.Struct({
     id: Schema.optional(Schema.String),
     inline: Schema.optional(Schema.String),
@@ -70,7 +73,7 @@ export const WorkflowTool = Tool.define<typeof Parameters, Metadata, Dag.Service
     const sessions = yield* Session.Service
 
     return {
-      description: SkillPlugin.WorkflowContent,
+      description: CommandPlugin.WorkflowContent,
       parameters: Parameters,
       execute: (params: Schema.Schema.Type<typeof Parameters>, ctx: Tool.Context<Metadata>) =>
         Effect.gen(function* () {

--- a/packages/opencode/test/command/command.test.ts
+++ b/packages/opencode/test/command/command.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect } from "bun:test"
+import { CommandPlugin } from "@opencode-ai/core/plugin/command"
+import { Effect, Layer } from "effect"
+import { Command } from "@/command"
+import { Config } from "@/config/config"
+import { MCP } from "@/mcp"
+import { Skill } from "@/skill"
+import { SessionPrompt } from "@/session/prompt"
+import { testInstanceStoreLayer } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+
+function commandLayer(commands: Record<string, { template: string; description?: string }> = {}) {
+  return Layer.mergeAll(
+    Command.layer.pipe(
+      Layer.provide(
+        Layer.mock(Config.Service, {
+          get: () => Effect.succeed({ command: commands } as never),
+        }),
+      ),
+      Layer.provide(
+        Layer.mock(MCP.Service, {
+          prompts: () => Effect.succeed({}),
+        }),
+      ),
+      Layer.provide(
+        Layer.mock(Skill.Service, {
+          all: () => Effect.succeed([]),
+        }),
+      ),
+    ),
+    testInstanceStoreLayer,
+  )
+}
+
+const it = testEffect(commandLayer())
+const overridden = testEffect(
+  commandLayer({
+    "dag-flow": {
+      description: "Custom DAG flow",
+      template: "Custom task:\n$ARGUMENTS",
+    },
+  }),
+)
+
+describe("legacy command registry", () => {
+  it.instance("registers the canonical dag-flow command without a built-in workflow fallback", () =>
+    Effect.gen(function* () {
+      const commands = yield* Command.Service
+      const command = yield* commands.get("dag-flow")
+
+      expect(command).toMatchObject({
+        name: "dag-flow",
+        description: CommandPlugin.DagFlowDescription,
+        source: "command",
+        template: CommandPlugin.DagFlowContent,
+        hints: ["$ARGUMENTS"],
+      })
+      expect(yield* commands.get("workflow")).toBeUndefined()
+    }),
+  )
+
+  overridden.instance("allows configured dag-flow commands to override the built-in", () =>
+    Effect.gen(function* () {
+      const commands = yield* Command.Service
+      expect(yield* commands.get("dag-flow")).toMatchObject({
+        description: "Custom DAG flow",
+        template: "Custom task:\n$ARGUMENTS",
+      })
+    }),
+  )
+
+  it.effect("preserves complete multi-line command arguments", () =>
+    Effect.sync(() => {
+      const input = "Investigate auth\nThen run the focused tests"
+      const expanded = SessionPrompt.expandCommandTemplate(CommandPlugin.DagFlowContent, input)
+
+      expect(expanded).toContain(`<dag-flow-task>\n${input}\n</dag-flow-task>`)
+      expect(expanded).not.toContain("$ARGUMENTS")
+    }),
+  )
+
+  it.effect("keeps the blank-task guard when dag-flow has no arguments", () =>
+    Effect.sync(() => {
+      const expanded = SessionPrompt.expandCommandTemplate(CommandPlugin.DagFlowContent, "   ")
+
+      expect(expanded).toContain("<dag-flow-task>\n   \n</dag-flow-task>")
+      expect(expanded).toContain("empty or contains only whitespace")
+      expect(expanded).toContain("Do not call the `workflow` tool")
+    }),
+  )
+})

--- a/packages/opencode/test/dag/workflow-tool.test.ts
+++ b/packages/opencode/test/dag/workflow-tool.test.ts
@@ -130,9 +130,42 @@ describe("workflow tool schema (negative tests)", () => {
     expect(() => decode({ action: "control", workflow_id: "wf-1", operation: "delete" })).toThrow()
     expect(() => decode({ action: "control", workflow_id: "wf-1", operation: "start" })).toThrow()
   })
+
+  it("defaults an omitted node required flag to false", () => {
+    const decode = Schema.decodeUnknownSync(Parameters)
+    const input = decode({
+      action: "start",
+      config: {
+        name: "required-default",
+        nodes: [
+          {
+            id: "optional-node",
+            name: "Optional node",
+            worker_type: "build",
+            depends_on: [],
+            prompt_template: { inline: "work" },
+          },
+        ],
+      },
+    })
+
+    expect(input.config?.nodes[0]?.required).toBe(false)
+  })
 })
 
 describe("workflow tool execution", () => {
+  runtime.effect("description retains the workflow action reference after guidance migration", () =>
+    Effect.gen(function* () {
+      const info = yield* WorkflowTool
+      const workflow = yield* info.init()
+
+      for (const action of ["start", "extend", "status", "control"]) {
+        expect(workflow.description).toContain(`**${action}**`)
+      }
+      expect(workflow.description).not.toContain("$ARGUMENTS")
+    }),
+  )
+
   runtime.effect("status returns the durable workflow and node state", () =>
     Effect.gen(function* () {
       const info = yield* WorkflowTool
@@ -190,6 +223,43 @@ describe("workflow tool execution", () => {
       expect(created).toHaveLength(1)
       expect(created[0]?.projectID).toBe(projectID)
       expect(created[0]?.sessionID).toBe(parentID)
+    }),
+  )
+
+  runtime.effect("start passes the decoded required default to Dag.create", () =>
+    Effect.gen(function* () {
+      created.length = 0
+      const info = yield* WorkflowTool
+      const workflow = yield* info.init()
+
+      yield* workflow.execute(
+        {
+          action: "start",
+          config: {
+            name: "required-default",
+            nodes: [
+              {
+                id: "optional-node",
+                name: "Optional node",
+                worker_type: "build",
+                depends_on: [],
+                prompt_template: { inline: "work" },
+              },
+            ],
+          },
+        },
+        {
+          sessionID: SessionID.make("ses_workflow_parent"),
+          messageID: MessageID.ascending(),
+          agent: "build",
+          abort: new AbortController().signal,
+          messages: [],
+          metadata: () => Effect.void,
+          ask: () => Effect.void,
+        } satisfies Tool.Context,
+      )
+
+      expect(created[0]?.config.nodes[0]?.required).toBe(false)
     }),
   )
 

--- a/packages/opencode/test/skill/skill.test.ts
+++ b/packages/opencode/test/skill/skill.test.ts
@@ -77,6 +77,49 @@ const withHome = <A, E, R>(home: string, self: Effect.Effect<A, E, R>) =>
   )
 
 describe("skill", () => {
+  it.live("does not register workflow as a built-in skill", () =>
+    provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          const skill = yield* Skill.Service
+          expect(yield* skill.get("workflow")).toBeUndefined()
+          expect((yield* skill.all()).filter((item) => item.location === "<built-in>").map((item) => item.name)).toEqual([
+            "customize-opencode",
+            "configure-hooks",
+          ])
+        }),
+      { git: true },
+    ),
+  )
+
+  it.live("still discovers a user-defined workflow skill", () =>
+    provideTmpdirInstance(
+      (dir) =>
+        Effect.gen(function* () {
+          yield* Effect.promise(() =>
+            Bun.write(
+              path.join(dir, ".opencode", "skill", "workflow", "SKILL.md"),
+              `---
+name: workflow
+description: User-defined workflow guidance.
+---
+
+# User Workflow
+`,
+            ),
+          )
+
+          const skill = yield* Skill.Service
+          expect(yield* skill.get("workflow")).toMatchObject({
+            name: "workflow",
+            description: "User-defined workflow guidance.",
+          })
+          expect((yield* skill.get("workflow"))?.location).not.toBe("<built-in>")
+        }),
+      { git: true },
+    ),
+  )
+
   it.live("discovers skills from .opencode/skill/ directory", () =>
     provideTmpdirInstance(
       (dir) =>

--- a/packages/tui/src/feature-plugins/home/tips-view.tsx
+++ b/packages/tui/src/feature-plugins/home/tips-view.tsx
@@ -186,6 +186,7 @@ const TIPS: Tip[] = [
   (shortcuts) => press(shortcuts.messagesCopy(), "to copy the assistant's last message to clipboard"),
   (shortcuts) => press(shortcuts.commandList(), "to see all available actions and commands"),
   "Run {highlight}/connect{/highlight} to add API keys for 75+ supported LLM providers",
+  "Run {highlight}/dag-flow <task>{/highlight} to start a DAG workflow, then {highlight}/dag{/highlight} to inspect it",
   (shortcuts) => `The leader key is ${shortcutText(shortcuts.leader())}; combine with other keys for quick actions`,
   (shortcuts) => press(shortcuts.modelCycleRecent(), "to quickly switch between recently used models"),
   (shortcuts) => press(shortcuts.sessionSidebarToggle(), "in a session to show or hide the sidebar panel"),

--- a/packages/tui/test/feature-plugins/dag-inspector.test.tsx
+++ b/packages/tui/test/feature-plugins/dag-inspector.test.tsx
@@ -59,6 +59,7 @@ async function renderDagInspector(opts: RenderOpts = {}) {
 
   // Trackable spies
   const nodesCalls: string[] = []
+  const commandCalls: unknown[] = []
   const navigations: { name: string; params?: Record<string, unknown> }[] = []
   const toasts: { variant?: string; message: string }[] = []
   const eventHandlers = new Map<string, (event: never) => void>()
@@ -81,6 +82,12 @@ async function renderDagInspector(opts: RenderOpts = {}) {
           nodes: async (input: { dagID: string }) => {
             nodesCalls.push(input.dagID)
             return { data: opts.nodes ?? [] }
+          },
+        },
+        session: {
+          command: async (input: unknown) => {
+            commandCalls.push(input)
+            return { data: undefined }
           },
         },
       } as unknown as TuiPluginApi["client"],
@@ -140,7 +147,8 @@ async function renderDagInspector(opts: RenderOpts = {}) {
   }
 
   const app = await testRender(() => <Harness />, { width: 100, height: 30 })
-  await waitForCommand(app, commands, "dag.close")
+  await waitForCommand(app, commands, "dag.open")
+  if (current().name === "dag") await waitForCommand(app, commands, "dag.close")
   // Give the initial fetchNodes a chance to resolve.
   if (workflowsState.length > 0) await waitForCondition(() => nodesCalls.length > 0)
 
@@ -148,6 +156,7 @@ async function renderDagInspector(opts: RenderOpts = {}) {
     app,
     commands,
     navigations: () => navigations,
+    commandCalls: () => commandCalls,
     toasts: () => toasts,
     nodesCalls: () => nodesCalls,
     setWorkflows: (wfs: DagWorkflowSummary[]) => {
@@ -186,6 +195,24 @@ async function waitForCondition(fn: () => boolean, timeout = 2000) {
 }
 
 describe("DagInspector", () => {
+  test("/dag dispatches dag.open locally without submitting a model command", async () => {
+    const returnRoute = { name: "session", params: { sessionID: SESSION_ID } }
+    const viewer = await renderDagInspector({ initialRoute: returnRoute })
+    try {
+      expect(viewer.commands.get("dag.open")?.slashName).toBe("dag")
+      viewer.commands.get("dag.open")!.run?.({} as never)
+      await waitForCommand(viewer.app, viewer.commands, "dag.close")
+
+      expect(viewer.navigations().at(-1)).toEqual({
+        name: "dag",
+        params: { sessionID: SESSION_ID, returnRoute },
+      })
+      expect(viewer.commandCalls()).toEqual([])
+    } finally {
+      viewer.app.renderer.destroy()
+    }
+  })
+
   test("opening dag refreshes workflows from the server when sync state is empty", async () => {
     const viewer = await renderDagInspector({
       serverWorkflows: [wfSummary({ id: "wf-server", title: "Live server workflow", nodeCount: 1 })],


### PR DESCRIPTION
## Summary
- add /dag-flow as the model-driven DAG orchestration command while keeping /dag as the local inspector
- move the workflow orchestration guide from a discoverable skill into command-owned prompt content
- default omitted workflow node required flags to false and preserve multiline command arguments
- add regression coverage for command discovery, prompt expansion, workflow schema, and DAG inspector guidance

## Validation
- bun turbo typecheck (commit hook and pre-push hook)
- focused core/opencode/TUI tests
- opencode DAG suite: 157/157 passed
- local TUI smoke test: /dag opens inspector and /dag-flow starts a workflow