### PR TITLE
fix(dag): stabilize workflow wake delivery

### DIFF
--- a/packages/core/src/dag/store.ts
+++ b/packages/core/src/dag/store.ts
@@ -1,6 +1,6 @@
 export * as DagStore from "./store"
 
-import { and, desc, eq, gte, lte, inArray } from "drizzle-orm"
+import { and, asc, desc, eq, gte, lte, inArray } from "drizzle-orm"
 import { Context, Effect, Layer } from "effect"
 import { Database } from "../database/database"
 import { LayerNode } from "../effect/layer-node"
@@ -46,6 +46,16 @@ export interface NodeRow {
   seq: number
   startedAt: number | null
   completedAt: number | null
+}
+
+export interface WakeBatch {
+  readonly nodes: readonly NodeRow[]
+  readonly workflows: readonly WorkflowRow[]
+}
+
+export interface WakeSnapshot {
+  readonly nodes: readonly NodeRow[]
+  readonly workflows: readonly WorkflowRow[]
 }
 
 export interface ViolationRow {
@@ -150,6 +160,8 @@ export interface Interface {
 
   readonly markNodeWakeReported: (workflowId: string, nodeID: string) => Effect.Effect<void>
   readonly markWorkflowWakeReported: (dagID: string) => Effect.Effect<void>
+  readonly markWakeBatchReported: (batch: WakeBatch) => Effect.Effect<void>
+  readonly getWakeSnapshot: (sessionID: string) => Effect.Effect<WakeSnapshot>
   readonly getUnreportedWakeNodes: (sessionID: string) => Effect.Effect<NodeRow[]>
   readonly getUnreportedWakeWorkflows: (sessionID: string) => Effect.Effect<WorkflowRow[]>
   readonly getSessionsWithUnreportedWakes: () => Effect.Effect<string[]>
@@ -302,6 +314,80 @@ export const layer = Layer.effect(
           .pipe(Effect.orDie)
       }),
 
+      markWakeBatchReported: Effect.fn("DagStore.markWakeBatchReported")(function* (batch) {
+        yield* db
+          .transaction((tx) =>
+            Effect.gen(function* () {
+              yield* Effect.forEach(
+                batch.nodes,
+                (node) =>
+                  tx
+                    .update(WorkflowNodeTable)
+                    .set({ wake_reported: true })
+                    .where(and(
+                      eq(WorkflowNodeTable.workflow_id, node.workflowId),
+                      eq(WorkflowNodeTable.id, node.id),
+                      eq(WorkflowNodeTable.seq, node.seq),
+                      eq(WorkflowNodeTable.wake_reported, false),
+                    ))
+                    .run(),
+                { discard: true },
+              )
+              yield* Effect.forEach(
+                batch.workflows,
+                (workflow) =>
+                  tx
+                    .update(WorkflowTable)
+                    .set({ wake_reported: true })
+                    .where(and(
+                      eq(WorkflowTable.id, workflow.id),
+                      eq(WorkflowTable.seq, workflow.seq),
+                      eq(WorkflowTable.wake_reported, false),
+                    ))
+                    .run(),
+                { discard: true },
+              )
+            }),
+          )
+          .pipe(Effect.orDie)
+      }),
+
+      getWakeSnapshot: Effect.fn("DagStore.getWakeSnapshot")(function* (sessionID) {
+        return yield* db
+          .transaction((tx) =>
+            Effect.gen(function* () {
+              const nodes = yield* tx
+                .select()
+                .from(WorkflowNodeTable)
+                .innerJoin(WorkflowTable, eq(WorkflowNodeTable.workflow_id, WorkflowTable.id))
+                .where(and(
+                  eq(WorkflowTable.session_id, sessionID),
+                  eq(WorkflowNodeTable.wake_eligible, true),
+                  eq(WorkflowNodeTable.wake_reported, false),
+                  inArray(WorkflowNodeTable.status, ["completed", "failed"]),
+                ))
+                .orderBy(
+                  asc(WorkflowTable.seq),
+                  asc(WorkflowTable.id),
+                  asc(WorkflowNodeTable.seq),
+                  asc(WorkflowNodeTable.id),
+                )
+                .all()
+              const workflows = yield* tx
+                .select()
+                .from(WorkflowTable)
+                .where(eq(WorkflowTable.session_id, sessionID))
+                .orderBy(asc(WorkflowTable.seq), asc(WorkflowTable.id))
+                .all()
+              return {
+                nodes: nodes.map((row) => mapNode(row.workflow_node)),
+                workflows: workflows.map(mapWorkflow),
+              }
+            }),
+          )
+          .pipe(Effect.orDie)
+      }),
+
       getUnreportedWakeNodes: Effect.fn("DagStore.getUnreportedWakeNodes")(function* (sessionID) {
         const rows = yield* db
           .select()
@@ -313,6 +399,12 @@ export const layer = Layer.effect(
             eq(WorkflowNodeTable.wake_reported, false),
             inArray(WorkflowNodeTable.status, ["completed", "failed"]),
           ))
+          .orderBy(
+            asc(WorkflowTable.seq),
+            asc(WorkflowTable.id),
+            asc(WorkflowNodeTable.seq),
+            asc(WorkflowNodeTable.id),
+          )
           .all()
           .pipe(Effect.orDie)
         return rows.map((r) => mapNode(r.workflow_node))
@@ -326,6 +418,7 @@ export const layer = Layer.effect(
             eq(WorkflowTable.session_id, sessionID),
             eq(WorkflowTable.wake_reported, false),
           ))
+          .orderBy(asc(WorkflowTable.seq), asc(WorkflowTable.id))
           .all()
           .pipe(Effect.orDie)
         return rows

--- a/packages/core/src/plugin/command/dag-flow.txt
+++ b/packages/core/src/plugin/command/dag-flow.txt
@@ -14,6 +14,7 @@ For a non-empty task:
 2. Call the `workflow` tool with `action=start` in this response. Merely printing a plan, graph, JSON, or YAML does not mean a workflow was started.
 3. Do not claim the workflow is running unless the tool call succeeds.
 4. On success, report the exact Workflow ID and initial state returned by the tool, then tell the user to run `/dag` for live inspection.
-5. On failure, state that the workflow was not started and report the actual error. Never invent a Workflow ID.
+5. The workflow runs asynchronously and wakes this parent session when attention or a terminal result is ready. Do not poll it with `action=status`, sleep, retry, or loop merely to wait. End the current response after the brief success report.
+6. On failure, state that the workflow was not started and report the actual error. Never invent a Workflow ID.
 
 Use the orchestration guidance below to design and manage the workflow.

--- a/packages/core/src/plugin/command/workflow.md
+++ b/packages/core/src/plugin/command/workflow.md
@@ -341,7 +341,7 @@ All nodes share the same workspace. Write conflicts are an orchestration concern
 
 **extend** — Add nodes to a running workflow. Existing nodes are unaffected; new nodes are immediately eligible for scheduling if their dependencies are met.
 
-**status** — Read the durable state of one workflow and all of its nodes. Pass `workflow_id`. Use it whenever the user asks whether a workflow is running, when progress is uncertain, or before deciding whether to replan/control a workflow.
+**status** — Read the durable state of one workflow and all of its nodes. Pass `workflow_id`. Use it when the user explicitly asks for current state or once before a decision that requires fresh state, such as replan/control. Do not poll a running workflow merely to wait: node reports and terminal outcomes wake the parent session automatically.
 
 **control** — Control a running workflow:
 - `pause` — let running nodes finish, don't spawn new ones

--- a/packages/core/test/dag-store-wake.test.ts
+++ b/packages/core/test/dag-store-wake.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, test } from "bun:test"
+import path from "path"
+import { sql } from "drizzle-orm"
+import { Effect, Exit, Layer } from "effect"
+import { Database } from "@opencode-ai/core/database/database"
+import { WorkflowNodeTable, WorkflowTable } from "@opencode-ai/core/dag/sql"
+import { DagStore } from "@opencode-ai/core/dag/store"
+import { ProjectTable } from "@opencode-ai/core/project/sql"
+import { SessionTable } from "@opencode-ai/core/session/sql"
+import { tmpdir } from "./fixture/tmpdir"
+
+function storeLayer(filename: string) {
+  const database = Database.layerFromPath(filename)
+  const store = DagStore.layer.pipe(Layer.provide(database))
+  return Layer.merge(database, store)
+}
+
+function seedBatch() {
+  return Effect.gen(function* () {
+    const database = yield* Database.Service
+    yield* database.db.insert(ProjectTable).values({
+      id: "project-1" as never,
+      worktree: process.cwd() as never,
+      sandboxes: [],
+    }).run().pipe(Effect.orDie)
+    yield* database.db.insert(SessionTable).values({
+      id: "ses_parent" as never,
+      project_id: "project-1" as never,
+      slug: "parent",
+      directory: process.cwd() as never,
+      title: "Parent",
+      version: "test",
+    }).run().pipe(Effect.orDie)
+    yield* database.db.insert(WorkflowTable).values({
+      id: "wf-1",
+      project_id: "project-1" as never,
+      session_id: "ses_parent" as never,
+      title: "Batch",
+      status: "completed",
+      config: "{}",
+      seq: 4,
+      wake_reported: false,
+    }).run().pipe(Effect.orDie)
+    yield* database.db.insert(WorkflowNodeTable).values([
+      {
+        id: "a",
+        workflow_id: "wf-1",
+        name: "A",
+        worker_type: "build",
+        status: "completed",
+        required: true,
+        depends_on: [],
+        output: "A",
+        wake_eligible: true,
+        wake_reported: false,
+        seq: 2,
+      },
+      {
+        id: "b",
+        workflow_id: "wf-1",
+        name: "B",
+        worker_type: "build",
+        status: "completed",
+        required: true,
+        depends_on: [],
+        output: "B",
+        wake_eligible: true,
+        wake_reported: false,
+        seq: 3,
+      },
+    ]).run().pipe(Effect.orDie)
+  })
+}
+
+function acknowledgeBatch(store: DagStore.Interface) {
+  return Effect.gen(function* () {
+    const nodes = yield* store.getUnreportedWakeNodes("ses_parent")
+    const workflows = yield* store.getUnreportedWakeWorkflows("ses_parent")
+    yield* store.markWakeBatchReported({ nodes, workflows })
+  })
+}
+
+describe("DagStore wake batch", () => {
+  test("atomically marks every included node and workflow reported", async () => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const store = yield* DagStore.Service
+        yield* seedBatch()
+
+        yield* acknowledgeBatch(store)
+
+        expect(yield* store.getUnreportedWakeNodes("ses_parent")).toEqual([])
+        expect(yield* store.getUnreportedWakeWorkflows("ses_parent")).toEqual([])
+      }).pipe(
+        Effect.provide(storeLayer(":memory:")),
+        Effect.scoped,
+      ),
+    )
+  })
+
+  test("rolls back the whole batch when one acknowledgement update fails", async () => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const database = yield* Database.Service
+        const store = yield* DagStore.Service
+        yield* seedBatch()
+        yield* database.db.run(sql`
+          CREATE TRIGGER reject_workflow_wake
+          BEFORE UPDATE OF wake_reported ON workflow
+          WHEN NEW.id = 'wf-1' AND NEW.wake_reported = 1
+          BEGIN
+            SELECT RAISE(ABORT, 'forced acknowledgement failure');
+          END
+        `).pipe(Effect.orDie)
+
+        expect(Exit.isFailure(yield* Effect.exit(acknowledgeBatch(store)))).toBe(true)
+        expect(yield* store.getUnreportedWakeNodes("ses_parent")).toHaveLength(2)
+        expect(yield* store.getUnreportedWakeWorkflows("ses_parent")).toHaveLength(1)
+      }).pipe(
+        Effect.provide(storeLayer(":memory:")),
+        Effect.scoped,
+      ),
+    )
+  })
+
+  test("does not acknowledge a newer attempt that reused the same node ID", async () => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const database = yield* Database.Service
+        const store = yield* DagStore.Service
+        yield* seedBatch()
+        const batch = yield* store.getWakeSnapshot("ses_parent")
+        const original = batch.nodes.find((node) => node.id === "a")!
+        yield* database.db
+          .update(WorkflowNodeTable)
+          .set({ seq: original.seq + 10, output: "new attempt", wake_reported: false })
+          .where(sql`${WorkflowNodeTable.workflow_id} = 'wf-1' AND ${WorkflowNodeTable.id} = 'a'`)
+          .run()
+          .pipe(Effect.orDie)
+
+        yield* store.markWakeBatchReported({
+          nodes: batch.nodes,
+          workflows: batch.workflows.filter((workflow) => !workflow.wakeReported),
+        })
+
+        expect((yield* store.getUnreportedWakeNodes("ses_parent")).map((node) => node.output)).toEqual([
+          "new attempt",
+        ])
+      }).pipe(
+        Effect.provide(storeLayer(":memory:")),
+        Effect.scoped,
+      ),
+    )
+  })
+
+  test("discovers the full unacknowledged batch after reopening the database", async () => {
+    await using tmp = await tmpdir()
+    const filename = path.join(tmp.path, "dag-wake.sqlite")
+    await Effect.runPromise(
+      seedBatch().pipe(
+        Effect.provide(storeLayer(filename)),
+        Effect.scoped,
+      ),
+    )
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const store = yield* DagStore.Service
+        expect(yield* store.getUnreportedWakeNodes("ses_parent")).toHaveLength(2)
+        expect(yield* store.getUnreportedWakeWorkflows("ses_parent")).toHaveLength(1)
+        expect(yield* store.getSessionsWithUnreportedWakes()).toEqual(["ses_parent"])
+      }).pipe(
+        Effect.provide(storeLayer(filename)),
+        Effect.scoped,
+      ),
+    )
+  })
+})

--- a/packages/opencode/src/dag/runtime/loop.ts
+++ b/packages/opencode/src/dag/runtime/loop.ts
@@ -1,6 +1,6 @@
 export * as DagLoop from "./loop"
 
-import { Effect, Layer, Context, Stream, Semaphore, Fiber } from "effect"
+import { Effect, Layer, Context, Stream, Semaphore, Fiber, Option } from "effect"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { InstanceState } from "@/effect/instance-state"
 import { EventV2Bridge } from "@/event-v2-bridge"
@@ -14,6 +14,7 @@ import { Agent } from "@/agent/agent"
 import { Session } from "@/session/session"
 import { SessionPrompt } from "@/session/prompt"
 import { SessionID } from "@/session/schema"
+import { SessionStatus } from "@/session/status"
 import { resolveTemplate } from "../templates/resolve"
 import { sanitizeInput } from "../templates/sanitize"
 import { spawnNode } from "./spawn"
@@ -61,6 +62,7 @@ export const layer = Layer.effect(
     const agentSvc = yield* Agent.Service
     const sessionSvc = yield* Session.Service
     const promptSvc = yield* SessionPrompt.Service
+    const statusSvc = yield* SessionStatus.Service
 
     const state = yield* InstanceState.make(
       Effect.fn("DagLoop.state")(function* (ctx) {
@@ -266,7 +268,7 @@ export const layer = Layer.effect(
               )
             }).pipe(Effect.ignore),
           ),
-          Effect.forkScoped,
+          Effect.forkScoped({ startImmediately: true }),
         )
 
         for (const def of [DagEvent.NodeCompleted, DagEvent.NodeSkipped]) {
@@ -280,6 +282,9 @@ export const layer = Layer.effect(
                 yield* entry.evalLock.withPermits(1)(
                   Effect.gen(function* () {
                     entry.fibers.delete(evt.data.nodeID as string)
+                    const workflow = yield* store.getWorkflow(dagID)
+                    entry.runtime.setPaused(workflow?.status === "paused")
+                    entry.runtime.setStepMode(workflow?.status === "stepping")
                     // Guard against stale events: a node already cancelled
                     // (markUnsatisfied) or already satisfied must not be flipped
                     // back. Mirrors the NodeFailed handler's isActive guard.
@@ -296,10 +301,10 @@ export const layer = Layer.effect(
                 // P1-2: trigger wake check directly on node terminal —
                 // the parent session may already be idle (no new idle event
                 // will fire), so we can't rely on the idle subscription alone.
-                yield* tryDeliverWake(entry.parentSessionID).pipe(Effect.ignore)
+                yield* tryDeliverWake(entry.parentSessionID).pipe(Effect.ignore, Effect.forkScoped)
               }).pipe(Effect.ignore),
             ),
-            Effect.forkScoped,
+            Effect.forkScoped({ startImmediately: true }),
           )
         }
 
@@ -326,7 +331,7 @@ export const layer = Layer.effect(
               )
             }).pipe(Effect.ignore),
           ),
-          Effect.forkScoped,
+          Effect.forkScoped({ startImmediately: true }),
         )
 
         yield* events.subscribe(DagEvent.NodeFailed).pipe(
@@ -357,10 +362,10 @@ export const layer = Layer.effect(
                     yield* checkCompletion(dagID)
                   }),
                 )
-                yield* tryDeliverWake(entry.parentSessionID).pipe(Effect.ignore)
+                yield* tryDeliverWake(entry.parentSessionID).pipe(Effect.ignore, Effect.forkScoped)
               }).pipe(Effect.ignore),
           ),
-          Effect.forkScoped,
+          Effect.forkScoped({ startImmediately: true }),
         )
 
         yield* events.subscribe(DagEvent.WorkflowPaused).pipe(
@@ -372,7 +377,7 @@ export const layer = Layer.effect(
               yield* entry.evalLock.withPermits(1)(Effect.sync(() => entry.runtime.setPaused(true)))
             }).pipe(Effect.ignore),
           ),
-          Effect.forkScoped,
+          Effect.forkScoped({ startImmediately: true }),
         )
 
         yield* events.subscribe(DagEvent.WorkflowStepped).pipe(
@@ -390,7 +395,7 @@ export const layer = Layer.effect(
               )
             }).pipe(Effect.ignore),
           ),
-          Effect.forkScoped,
+          Effect.forkScoped({ startImmediately: true }),
         )
 
         yield* events.subscribe(DagEvent.WorkflowResumed).pipe(
@@ -409,7 +414,7 @@ export const layer = Layer.effect(
               )
             }).pipe(Effect.ignore),
           ),
-          Effect.forkScoped,
+          Effect.forkScoped({ startImmediately: true }),
         )
 
         yield* events.subscribe(DagEvent.WorkflowReplanned).pipe(
@@ -431,7 +436,7 @@ export const layer = Layer.effect(
               )
             }).pipe(Effect.ignore),
           ),
-          Effect.forkScoped,
+          Effect.forkScoped({ startImmediately: true }),
         )
 
         for (const def of [DagEvent.WorkflowCompleted, DagEvent.WorkflowFailed, DagEvent.WorkflowCancelled]) {
@@ -458,11 +463,11 @@ export const layer = Layer.effect(
                 // P1-6: trigger wake on workflow terminal so the parent
                 // learns the final outcome even if no idle event fires.
                 if (parentSessionID) {
-                  yield* tryDeliverWake(parentSessionID).pipe(Effect.ignore)
+                  yield* tryDeliverWake(parentSessionID).pipe(Effect.ignore, Effect.forkScoped)
                 }
               }).pipe(Effect.ignore),
             ),
-            Effect.forkScoped,
+            Effect.forkScoped({ startImmediately: true }),
           )
         }
 
@@ -471,6 +476,56 @@ export const layer = Layer.effect(
         // event handlers, so a wake fires even when the parent session is
         // already idle (P1-2 fix).
 
+        const readWakeBatch = Effect.fn("DagLoop.readWakeBatch")(function* (sessionID: string) {
+          const snapshot = yield* store.getWakeSnapshot(sessionID).pipe(
+            Effect.catch(() =>
+              Effect.succeed({ nodes: [], workflows: [] } satisfies DagStore.WakeSnapshot),
+            ),
+          )
+          const terminalWorkflows = snapshot.workflows.filter(
+            (workflow) => !workflow.wakeReported && isWorkflowTerminalStatus(workflow.status as never),
+          )
+          const workflowIDs = [...new Set([
+            ...snapshot.nodes.map((node) => node.workflowId),
+            ...terminalWorkflows.map((workflow) => workflow.id),
+          ])]
+          const workflowsByID = new Map(snapshot.workflows.map((workflow) => [workflow.id, workflow]))
+          const workflows = workflowIDs.map((workflowID) => workflowsByID.get(workflowID))
+          const boundaryWorkflows = workflows.filter((workflow): workflow is DagStore.WorkflowRow => {
+            if (!workflow) return false
+            if (isWorkflowTerminalStatus(workflow.status as never)) return true
+            const entry = runtimes.get(workflow.id)
+            if (workflow.status === "paused" || workflow.status === "stepping") return true
+            if (entry?.runtime.isPaused() || entry?.runtime.isStepMode()) return true
+            if (workflow.status !== "running" || !entry) return false
+            if (entry.runtime.hasRunningMatching((id) => entry.fibers.has(id))) return false
+            return entry.runtime.getReadyNodes().length === 0
+          })
+          const atBoundary = new Set(boundaryWorkflows.map((workflow) => workflow.id))
+          const batch = {
+            nodes: snapshot.nodes.filter((node) => atBoundary.has(node.workflowId)),
+            workflows: terminalWorkflows.filter((workflow) => atBoundary.has(workflow.id)),
+          } satisfies DagStore.WakeBatch
+          return {
+            batch,
+            actionableDagIDs: new Set(
+              boundaryWorkflows
+                .filter((workflow) => !isWorkflowTerminalStatus(workflow.status as never))
+                .map((workflow) => workflow.id),
+            ),
+            unresponsiveDagIDs: new Set(
+              boundaryWorkflows
+                .filter((workflow) => {
+                  const entry = runtimes.get(workflow.id)
+                  return workflow.status === "running"
+                    && !entry?.runtime.isPaused()
+                    && !entry?.runtime.isStepMode()
+                })
+                .map((workflow) => workflow.id),
+            ),
+          }
+        })
+
         let tryDeliverWake: (sessionID: string) => Effect.Effect<void> = () => Effect.void
         tryDeliverWake = Effect.fn("DagLoop.tryDeliverWake")(function* (sessionID: string) {
           if (wakeInFlight.has(sessionID)) {
@@ -478,19 +533,14 @@ export const layer = Layer.effect(
             return
           }
           wakeInFlight.add(sessionID)
-          // #4: drain loop — deliver ALL pending unreported rows, not just one.
-          // Each iteration delivers at most one to keep messages coherent,
-          // then re-checks for additional rows.
+          // Re-read after each stable batch so rows committed during delivery
+          // remain a separate batch.
           try {
-            const deliveredDagIDs = new Set<string>()
+            const deliveredUnresponsiveDagIDs = new Set<string>()
             for (;;) {
-              const unreportedNodes = yield* store.getUnreportedWakeNodes(sessionID).pipe(
-                Effect.catch(() => Effect.succeed([] as DagStore.NodeRow[])),
-              )
-              const unreportedWorkflows = yield* store.getUnreportedWakeWorkflows(sessionID).pipe(
-                Effect.catch(() => Effect.succeed([] as DagStore.WorkflowRow[])),
-              )
-              const hasUnreported = unreportedNodes.length > 0 || unreportedWorkflows.length > 0
+              const plan = yield* readWakeBatch(sessionID)
+              const batch = plan.batch
+              const hasUnreported = batch.nodes.length > 0 || batch.workflows.length > 0
 
               if (!hasUnreported) {
                 // A terminal event can commit between either query. Coalesce
@@ -500,12 +550,13 @@ export const layer = Layer.effect(
                 // unreported rows remain, check for orchestrator-unresponsive.
                 // #5: scoped per-workflow — only fail the workflow whose node
                 // was reported, not any other workflow under the same session.
-                // Skip paused workflows (they intentionally have no ready nodes).
-                if (deliveredDagIDs.size > 0) {
-                  for (const dagID of deliveredDagIDs) {
+                // Skip paused and stepping workflows; both can intentionally
+                // have no ready nodes.
+                if (deliveredUnresponsiveDagIDs.size > 0) {
+                  for (const dagID of deliveredUnresponsiveDagIDs) {
                     const entry = runtimes.get(dagID)
                     if (!entry) continue
-                    if (entry.runtime.isPaused()) continue
+                    if (entry.runtime.isPaused() || entry.runtime.isStepMode()) continue
                     // Suppress the net only when current-process execution
                     // ownership proves that a running node is making progress.
                     if (entry.runtime.hasRunningMatching((id) => entry.fibers.has(id))) continue
@@ -516,6 +567,8 @@ export const layer = Layer.effect(
                 }
                 return
               }
+
+              if ((yield* statusSvc.get(SessionID.make(sessionID))).type !== "idle") return
 
               // Preemption guard (task 3.3): abort if fresher user message exists
               const msgs = yield* sessionSvc.messages({ sessionID: SessionID.make(sessionID), limit: 20 }).pipe(Effect.catch(() => Effect.succeed([])))
@@ -529,14 +582,24 @@ export const layer = Layer.effect(
               }
               if (lastUserAt > lastAsstAt) return
 
-              // D6: prioritize node-level wake, then workflow-terminal wake
-              const targetNode = unreportedNodes[0]
-              const targetWorkflow = targetNode ? undefined : unreportedWorkflows[0]
-              if (!targetNode && !targetWorkflow) return
-
-              const summary = targetNode
-                ? `[DAG Node Result] Node "${targetNode.name}" ${targetNode.status}: ${typeof targetNode.output === "string" ? targetNode.output.slice(0, 500) : targetNode.errorReason ?? "(no output)"}\n\nYou MUST act on this workflow in this turn (workflow tool: extend / control replan / complete / cancel). If this turn ends with the workflow stalled and no action taken, it will be failed with reason "orchestrator_unresponsive".`
-                : `[DAG Workflow ${targetWorkflow!.status}] Workflow "${targetWorkflow!.title}" has reached terminal status.`
+              const summaries = [
+                ...batch.nodes.map((node) => {
+                  const output = typeof node.output === "string"
+                    ? node.output.slice(0, 500)
+                    : node.errorReason ?? (node.output == null ? "(no output)" : JSON.stringify(node.output).slice(0, 500))
+                  return `[DAG Node Result] Node "${node.name}" ${node.status}: ${output}`
+                }),
+                ...batch.workflows.map(
+                  (workflow) =>
+                    `[DAG Workflow ${workflow.status}] Workflow "${workflow.title}" has reached terminal status.`,
+                ),
+              ]
+              const summary = [
+                ...summaries,
+                ...(plan.actionableDagIDs.size > 0
+                  ? ['You MUST act on these workflows in this turn (workflow tool: extend / control replan / complete / cancel). If this turn ends with a workflow stalled and no action taken, it will be failed with reason "orchestrator_unresponsive".']
+                  : []),
+              ].join("\n\n")
 
               // Persist wake_reported AFTER successful delivery only.
               // A failure stays durable for a later idle event or restart scan;
@@ -545,29 +608,29 @@ export const layer = Layer.effect(
               // receives the node result and can act) but NOT rendered as a user
               // message in the TUI chat — DAG data surfaces via the sidebar panel
               // and Inspector, keeping the chat conversation clean.
-              const didDeliver = yield* promptSvc.prompt({
+              const didDeliver = yield* promptSvc.promptIfIdle({
                 sessionID: SessionID.make(sessionID),
                 parts: [{ type: "text", text: summary, synthetic: true }],
               }).pipe(
-                Effect.tap(() =>
-                  Effect.gen(function* () {
-                    if (targetNode) {
-                      yield* store.markNodeWakeReported(targetNode.workflowId, targetNode.id)
-                      deliveredDagIDs.add(targetNode.workflowId)
-                    }
-                    if (targetWorkflow) {
-                      yield* store.markWorkflowWakeReported(targetWorkflow.id)
-                      deliveredDagIDs.add(targetWorkflow.id)
-                    }
-                  }),
-                ),
-                Effect.as(true),
+                Effect.flatMap(Option.match({
+                  onNone: () => Effect.succeed(false),
+                  onSome: () =>
+                    store.markWakeBatchReported(batch).pipe(
+                      Effect.tap(() =>
+                        Effect.sync(() => {
+                          plan.unresponsiveDagIDs.forEach((workflowID) =>
+                            deliveredUnresponsiveDagIDs.add(workflowID),
+                          )
+                        }),
+                      ),
+                      Effect.as(true),
+                    ),
+                })),
                 Effect.catchCause(() =>
                   Effect.logWarning("DAG wake delivery failed", { sessionID }).pipe(Effect.as(false)),
                 ),
               )
               if (!didDeliver) return
-              // Loop continues to drain remaining unreported rows
             }
           } finally {
             const retry = wakePending.delete(sessionID)
@@ -580,9 +643,9 @@ export const layer = Layer.effect(
         yield* events.subscribe(SessionStatusEvent.Status).pipe(
           Stream.filter((evt) => evt.data.status.type === "idle"),
           Stream.runForEach((evt) =>
-            tryDeliverWake(evt.data.sessionID as string).pipe(Effect.ignore),
+            tryDeliverWake(evt.data.sessionID as string).pipe(Effect.ignore, Effect.forkScoped),
           ),
-          Effect.forkScoped,
+          Effect.forkScoped({ startImmediately: true }),
         )
 
         // Install all live event handlers before spawning recovery watchers so
@@ -627,6 +690,7 @@ export const defaultLayer = layer.pipe(
   Layer.provide(Agent.defaultLayer),
   Layer.provide(Session.defaultLayer),
   Layer.provide(SessionPrompt.defaultLayer),
+  Layer.provide(SessionStatus.defaultLayer),
 )
 
 export const node = LayerNode.make(layer, [
@@ -636,4 +700,5 @@ export const node = LayerNode.make(layer, [
   Agent.node,
   Session.node,
   SessionPrompt.node,
+  SessionStatus.node,
 ])

--- a/packages/opencode/src/effect/runner.ts
+++ b/packages/opencode/src/effect/runner.ts
@@ -1,9 +1,11 @@
-import { Cause, Deferred, Effect, Exit, Fiber, Latch, Schema, Scope, SynchronizedRef } from "effect"
+import { Cause, Deferred, Effect, Exit, Fiber, Latch, Option, Schema, Scope, SynchronizedRef } from "effect"
 
 export interface Runner<A, E = never> {
   readonly state: State<A, E>
   readonly busy: boolean
   readonly ensureRunning: (work: Effect.Effect<A, E>) => Effect.Effect<A, E>
+  readonly ensureRunningHandle: (work: Effect.Effect<A, E>) => Effect.Effect<Effect.Effect<A, E>>
+  readonly startIfIdle: (work: Effect.Effect<A, E>) => Effect.Effect<Option.Option<Effect.Effect<A, E>>>
   readonly startShell: (work: Effect.Effect<A, E>, ready?: Latch.Latch) => Effect.Effect<A, E | Busy>
   readonly cancel: Effect.Effect<void>
 }
@@ -112,7 +114,7 @@ export const make = <A, E = never>(
       yield* Fiber.interrupt(shell.fiber)
     })
 
-  const ensureRunning = (work: Effect.Effect<A, E>) =>
+  const ensureRunningHandle = (work: Effect.Effect<A, E>) =>
     SynchronizedRef.modifyEffect(
       ref,
       Effect.fnUntraced(function* (st) {
@@ -129,13 +131,28 @@ export const make = <A, E = never>(
             return [awaitDone(run.done), { _tag: "ShellThenRun", shell: st.shell, run }] as const
           }
           case "Idle": {
+            yield* onBusy
             const done = yield* Deferred.make<A, E | Cancelled>()
             const run = yield* startRun(work, done)
             return [awaitDone(done), { _tag: "Running", run }] as const
           }
         }
       }),
-    ).pipe(Effect.flatten)
+    )
+
+  const ensureRunning = (work: Effect.Effect<A, E>) => ensureRunningHandle(work).pipe(Effect.flatten)
+
+  const startIfIdle = (work: Effect.Effect<A, E>) =>
+    SynchronizedRef.modifyEffect(
+      ref,
+      Effect.fnUntraced(function* (st) {
+        if (st._tag !== "Idle") return [Option.none<Effect.Effect<A, E>>(), st] as const
+        yield* onBusy
+        const done = yield* Deferred.make<A, E | Cancelled>()
+        const run = yield* startRun(work, done)
+        return [Option.some(awaitDone(done)), { _tag: "Running", run }] as const
+      }),
+    )
 
   const startShell = (work: Effect.Effect<A, E>, ready?: Latch.Latch): Effect.Effect<A, E | Busy> =>
     SynchronizedRef.modifyEffect(
@@ -209,6 +226,8 @@ export const make = <A, E = never>(
       return state()._tag !== "Idle"
     },
     ensureRunning,
+    ensureRunningHandle,
+    startIfIdle,
     startShell,
     cancel,
   }

--- a/packages/opencode/src/project/bootstrap.ts
+++ b/packages/opencode/src/project/bootstrap.ts
@@ -24,6 +24,8 @@ export const layer = Layer.effect(
     // InstanceStore imports only the lightweight tag from bootstrap-service.ts,
     // so it can depend on bootstrap without importing this implementation graph.
     const config = yield* Config.Service
+    const dagLoop = yield* DagLoop.Service
+    const dagPublisher = yield* DagSummaryPublisher.Service
     const format = yield* Format.Service
     const lsp = yield* LSP.Service
     const plugin = yield* Plugin.Service
@@ -54,22 +56,12 @@ export const layer = Layer.effect(
         (s) => s.init().pipe(Effect.catchCause((cause) => Effect.logWarning("init failed", { cause }))),
         { concurrency: "unbounded", discard: true },
       ).pipe(Effect.withSpan("InstanceBootstrap.init"))
-      // DAG services are present in the production/default graphs. Keep the
-      // optional lookup so narrow test layers may omit them intentionally.
-      const dagLoop = yield* Effect.serviceOption(DagLoop.Service)
-      if (dagLoop._tag === "Some") {
-        yield* dagLoop.value
-          .init()
-          .pipe(Effect.catchCause((cause) => Effect.logWarning("dag loop init failed", { cause })))
-      }
+      yield* dagLoop.init().pipe(Effect.catchCause((cause) => Effect.logWarning("dag loop init failed", { cause })))
       // DagSummaryPublisher: same lifecycle pattern. Stateless derived-view
       // publisher that pushes per-session workflow summaries to the TUI.
-      const dagPublisher = yield* Effect.serviceOption(DagSummaryPublisher.Service)
-      if (dagPublisher._tag === "Some") {
-        yield* dagPublisher.value
-          .init()
-          .pipe(Effect.catchCause((cause) => Effect.logWarning("dag summary publisher init failed", { cause })))
-      }
+      yield* dagPublisher
+        .init()
+        .pipe(Effect.catchCause((cause) => Effect.logWarning("dag summary publisher init failed", { cause })))
       // SettingsHook: Setup fires once per instance bootstrap. Resolved lazily
       // so bootstrap layers stay self-contained.
       const settingsHook = yield* Effect.serviceOption(SettingsHook.Service)

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -42,7 +42,7 @@ import { Truncate } from "@/tool/truncate"
 import { Image } from "@/image/image"
 import { decodeDataUrl } from "@/util/data-url"
 import { Process } from "@/util/process"
-import { Cause, Effect, Exit, Latch, Layer, Option, Scope, Context, Schema, Types } from "effect"
+import { Cause, Deferred, Effect, Exit, Latch, Layer, Option, Scope, Context, Schema, Types } from "effect"
 import { InstanceState } from "@/effect/instance-state"
 import { TaskTool, type TaskPromptOps } from "@/tool/task"
 import { SessionRunState } from "./run-state"
@@ -64,6 +64,7 @@ import { SettingsHook, HOOK_REWAKE_SENTINEL, type TriggerResult } from "@/hook/s
 import { applyPreHookDecision } from "@/hook/pre-hook-decision"
 import { dispatchTrust } from "@/hook/workspace-trust"
 import { HookStartContext } from "@/hook/start-context"
+import { KeyedMutex } from "@opencode-ai/core/effect/keyed-mutex"
 
 // @ts-ignore
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -110,6 +111,7 @@ function isOrphanedInterruptedTool(part: SessionV1.ToolPart) {
 export interface Interface {
   readonly cancel: (sessionID: SessionID) => Effect.Effect<void>
   readonly prompt: (input: PromptInput) => Effect.Effect<SessionV1.WithParts, Image.Error>
+  readonly promptIfIdle: (input: PromptInput) => Effect.Effect<Option.Option<SessionV1.WithParts>, Image.Error>
   readonly loop: (input: LoopInput) => Effect.Effect<SessionV1.WithParts>
   readonly shell: (input: ShellInput) => Effect.Effect<SessionV1.WithParts, Session.BusyError>
   readonly command: (input: CommandInput) => Effect.Effect<SessionV1.WithParts, Image.Error>
@@ -151,6 +153,7 @@ export const layer = Layer.effect(
     const { db } = database
     const settingsHook = Option.getOrUndefined(yield* Effect.serviceOption(SettingsHook.Service))
     const startContext = Option.getOrUndefined(yield* Effect.serviceOption(HookStartContext.Service))
+    const promptLocks = KeyedMutex.makeUnsafe<SessionID>()
     const ops = Effect.fn("SessionPrompt.ops")(function* () {
       return {
         cancel: (sessionID: SessionID) => cancel(sessionID),
@@ -1295,9 +1298,7 @@ export const layer = Layer.effect(
       return { info, parts }
     }, Effect.scoped)
 
-    const prompt: (input: PromptInput) => Effect.Effect<SessionV1.WithParts, Image.Error> = Effect.fn(
-      "SessionPrompt.prompt",
-    )(function* (input: PromptInput) {
+    const admitPrompt = Effect.fn("SessionPrompt.admitPrompt")(function* (input: PromptInput) {
       const session = yield* sessions.get(input.sessionID).pipe(Effect.orDie)
       yield* revert.cleanup(session)
       const message = yield* createUserMessage(input)
@@ -1333,7 +1334,7 @@ export const layer = Layer.effect(
                   synthetic: true,
                 } satisfies SessionV1.TextPart),
         })
-        if (hookResult.blocked) return message
+        if (hookResult.blocked) return { message, run: false as const }
       }
 
       // SettingsHook: drain HookStartContext queued by SessionStart hooks (only if not blocked)
@@ -1362,9 +1363,57 @@ export const layer = Layer.effect(
         yield* sessions.setPermission({ sessionID: session.id, permission: permissions })
       }
 
-      if (input.noReply === true) return message
-      return yield* loop({ sessionID: input.sessionID })
+      return { message, run: input.noReply !== true }
     })
+
+    const prompt: (input: PromptInput) => Effect.Effect<SessionV1.WithParts, Image.Error> = Effect.fn(
+      "SessionPrompt.prompt",
+    )(function* (input: PromptInput) {
+      const wait = yield* promptLocks.withLock(input.sessionID)(
+        Effect.gen(function* () {
+          const admitted = yield* admitPrompt(input)
+          if (!admitted.run) return Effect.succeed(admitted.message)
+          return yield* state.ensureRunningHandle(
+            input.sessionID,
+            lastAssistant(input.sessionID),
+            runLoop(input.sessionID),
+          )
+        }),
+      )
+      return yield* wait
+    })
+
+    const promptIfIdle: Interface["promptIfIdle"] = Effect.fn("SessionPrompt.promptIfIdle")(
+      function* (input: PromptInput) {
+        const wait = yield* promptLocks.withLock(input.sessionID)(
+          Effect.uninterruptibleMask((restore) =>
+            Effect.gen(function* () {
+              const admission = yield* Deferred.make<
+                Exit.Exit<{ readonly message: SessionV1.WithParts; readonly run: boolean }, Image.Error>
+              >()
+              const wait = yield* state.startIfIdle(
+                input.sessionID,
+                lastAssistant(input.sessionID),
+                Effect.gen(function* () {
+                  const admitted = yield* Deferred.await(admission)
+                  if (Exit.isFailure(admitted)) return yield* Effect.failCause(admitted.cause)
+                  if (!admitted.value.run) return admitted.value.message
+                  return yield* runLoop(input.sessionID)
+                }).pipe(Effect.orDie),
+              )
+              if (Option.isNone(wait)) return wait
+
+              const admitted = yield* restore(admitPrompt(input)).pipe(Effect.exit)
+              yield* Deferred.succeed(admission, admitted)
+              if (Exit.isFailure(admitted)) return yield* Effect.failCause(admitted.cause)
+              return wait
+            }),
+          ),
+        )
+        if (Option.isNone(wait)) return Option.none()
+        return Option.some(yield* wait.value)
+      },
+    )
 
     const lastAssistant = Effect.fnUntraced(function* (sessionID: SessionID) {
       const match = yield* sessions.findMessage(sessionID, (m) => m.info.role !== "user").pipe(Effect.orDie)
@@ -1879,7 +1928,14 @@ export const layer = Layer.effect(
               prompt: templateParts.find((y) => y.type === "text")?.text ?? "",
             },
           ]
-        : [...uniqueTemplateParts, ...(input.parts ?? [])]
+        : [
+            {
+              type: "text" as const,
+              text: `/${input.command}${input.arguments ? ` ${input.arguments}` : ""}`,
+            },
+            ...uniqueTemplateParts.map((part) => (part.type === "text" ? { ...part, synthetic: true } : part)),
+            ...(input.parts ?? []),
+          ]
 
       const userAgent = isSubtask ? (input.agent ?? (yield* agents.defaultInfo()).name) : agent.name
       const userModel = isSubtask
@@ -1914,6 +1970,7 @@ export const layer = Layer.effect(
     return Service.of({
       cancel,
       prompt,
+      promptIfIdle,
       loop,
       shell,
       command,

--- a/packages/opencode/src/session/run-state.ts
+++ b/packages/opencode/src/session/run-state.ts
@@ -3,7 +3,7 @@ import { InstanceState } from "@/effect/instance-state"
 import { SessionV1 } from "@opencode-ai/core/v1/session"
 import { Runner } from "@/effect/runner"
 import { BackgroundJob } from "@/background/job"
-import { Effect, Latch, Layer, Scope, Context } from "effect"
+import { Effect, Latch, Layer, Option, Scope, Context } from "effect"
 import { Session } from "./session"
 import { SessionID } from "./schema"
 import { SessionStatus } from "./status"
@@ -16,6 +16,16 @@ export interface Interface {
     onInterrupt: Effect.Effect<SessionV1.WithParts>,
     work: Effect.Effect<SessionV1.WithParts>,
   ) => Effect.Effect<SessionV1.WithParts>
+  readonly ensureRunningHandle: (
+    sessionID: SessionID,
+    onInterrupt: Effect.Effect<SessionV1.WithParts>,
+    work: Effect.Effect<SessionV1.WithParts>,
+  ) => Effect.Effect<Effect.Effect<SessionV1.WithParts>>
+  readonly startIfIdle: (
+    sessionID: SessionID,
+    onInterrupt: Effect.Effect<SessionV1.WithParts>,
+    work: Effect.Effect<SessionV1.WithParts>,
+  ) => Effect.Effect<Option.Option<Effect.Effect<SessionV1.WithParts>>>
   readonly startShell: (
     sessionID: SessionID,
     onInterrupt: Effect.Effect<SessionV1.WithParts>,
@@ -93,6 +103,22 @@ export const layer = Layer.effect(
       return yield* (yield* runner(sessionID, onInterrupt)).ensureRunning(work)
     })
 
+    const ensureRunningHandle = Effect.fn("SessionRunState.ensureRunningHandle")(function* (
+      sessionID: SessionID,
+      onInterrupt: Effect.Effect<SessionV1.WithParts>,
+      work: Effect.Effect<SessionV1.WithParts>,
+    ) {
+      return yield* (yield* runner(sessionID, onInterrupt)).ensureRunningHandle(work)
+    })
+
+    const startIfIdle = Effect.fn("SessionRunState.startIfIdle")(function* (
+      sessionID: SessionID,
+      onInterrupt: Effect.Effect<SessionV1.WithParts>,
+      work: Effect.Effect<SessionV1.WithParts>,
+    ) {
+      return yield* (yield* runner(sessionID, onInterrupt)).startIfIdle(work)
+    })
+
     const startShell = Effect.fn("SessionRunState.startShell")(function* (
       sessionID: SessionID,
       onInterrupt: Effect.Effect<SessionV1.WithParts>,
@@ -104,7 +130,7 @@ export const layer = Layer.effect(
         .pipe(Effect.catchTag("RunnerBusy", () => Effect.fail(busyError(sessionID))))
     })
 
-    return Service.of({ assertNotBusy, cancel, ensureRunning, startShell })
+    return Service.of({ assertNotBusy, cancel, ensureRunning, ensureRunningHandle, startIfIdle, startShell })
   }),
 )
 

--- a/packages/opencode/src/tool/workflow.ts
+++ b/packages/opencode/src/tool/workflow.ts
@@ -122,7 +122,7 @@ export const WorkflowTool = Tool.define<typeof Parameters, Metadata, Dag.Service
               }).pipe(Effect.orDie)
               return {
                 title: `Workflow started: ${params.config.name}`,
-                output: `<workflow id="${dagID}" state="running">\n${params.config.nodes.length} nodes registered.\n</workflow>`,
+                output: `<workflow id="${dagID}" state="running">\n${params.config.nodes.length} nodes registered.\nDo not poll this workflow. It runs asynchronously and will wake the parent session when attention is required.\n</workflow>`,
                 metadata: { workflowId: dagID } as Metadata,
               }
             }

--- a/packages/opencode/test/command/command.test.ts
+++ b/packages/opencode/test/command/command.test.ts
@@ -79,6 +79,15 @@ describe("legacy command registry", () => {
     }),
   )
 
+  it.effect("returns after starting a DAG instead of polling its status", () =>
+    Effect.sync(() => {
+      const expanded = SessionPrompt.expandCommandTemplate(CommandPlugin.DagFlowContent, "Run two parallel workers")
+
+      expect(expanded).toContain("Do not poll")
+      expect(expanded).toContain("End the current response")
+    }),
+  )
+
   it.effect("keeps the blank-task guard when dag-flow has no arguments", () =>
     Effect.sync(() => {
       const expanded = SessionPrompt.expandCommandTemplate(CommandPlugin.DagFlowContent, "   ")

--- a/packages/opencode/test/dag/dag-loop-recovery-integration.test.ts
+++ b/packages/opencode/test/dag/dag-loop-recovery-integration.test.ts
@@ -14,6 +14,7 @@ import { InstanceRef } from "@/effect/instance-ref"
 import { EventV2Bridge } from "@/event-v2-bridge"
 import { SessionPrompt } from "@/session/prompt"
 import { Session } from "@/session/session"
+import { SessionStatus } from "@/session/status"
 
 type ChildStatus = "active" | "completed" | "failed" | "unknown"
 
@@ -38,6 +39,7 @@ function recoveryLayer(input: {
   const events = EventV2.layer.pipe(Layer.provide(database))
   const bridge = EventV2Bridge.layer.pipe(Layer.provide(events))
   const store = DagStore.layer.pipe(Layer.provide(database))
+  const status = SessionStatus.layer.pipe(Layer.provide(bridge))
   const projector = DagProjector.layer.pipe(
     Layer.provide(events),
     Layer.provide(database),
@@ -46,7 +48,7 @@ function recoveryLayer(input: {
     Layer.provide(bridge),
     Layer.provide(store),
   )
-  const base = Layer.mergeAll(database, events, bridge, store, projector, dag)
+  const base = Layer.mergeAll(database, events, bridge, store, projector, dag, status)
   const session = Layer.mock(Session.Service, {
     create: Effect.fn("test.Session.create")((_value?: unknown) =>
       Effect.sync(() => {

--- a/packages/opencode/test/dag/dag-wake-integration.test.ts
+++ b/packages/opencode/test/dag/dag-wake-integration.test.ts
@@ -1,0 +1,462 @@
+import { describe, expect, it } from "bun:test"
+import { Deferred, Effect, Layer, Option, Queue } from "effect"
+import type { SessionV1 } from "@opencode-ai/core/v1/session"
+import { Database } from "@opencode-ai/core/database/database"
+import { DagProjector } from "@opencode-ai/core/dag/projector"
+import { WorkflowNodeTable, WorkflowTable } from "@opencode-ai/core/dag/sql"
+import { DagStore } from "@opencode-ai/core/dag/store"
+import { EventV2 } from "@opencode-ai/core/event"
+import { ProjectTable } from "@opencode-ai/core/project/sql"
+import { SessionTable } from "@opencode-ai/core/session/sql"
+import { Agent } from "@/agent/agent"
+import { Dag, type NodeConfig } from "@/dag/dag"
+import { DagLoop } from "@/dag/runtime/loop"
+import { InstanceRef } from "@/effect/instance-ref"
+import { EventV2Bridge } from "@/event-v2-bridge"
+import { SessionPrompt } from "@/session/prompt"
+import { MessageID } from "@/session/schema"
+import { Session } from "@/session/session"
+import { SessionStatus } from "@/session/status"
+import { pollWithTimeout } from "../lib/effect"
+
+interface PromptGate {
+  readonly title: string
+  readonly release: Deferred.Deferred<string>
+}
+
+interface ParentPromptGate {
+  readonly input: SessionPrompt.PromptInput
+  readonly release: Deferred.Deferred<"success" | "failure">
+}
+
+function takeWithin<A>(queue: Queue.Queue<A>, message: string) {
+  return Queue.take(queue).pipe(
+    Effect.timeoutOption("1 second"),
+    Effect.flatMap(Option.match({
+      onNone: () => Effect.fail(new Error(message)),
+      onSome: Effect.succeed,
+    })),
+  )
+}
+
+function reply(sessionID: string, text: string): SessionV1.WithParts {
+  return {
+    info: {
+      id: MessageID.ascending(),
+      role: "assistant",
+      parentID: MessageID.ascending(),
+      sessionID: sessionID as never,
+      mode: "build",
+      agent: "build",
+      cost: 0,
+      path: { cwd: process.cwd(), root: process.cwd() },
+      tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+      modelID: "test-model" as never,
+      providerID: "test" as never,
+      time: { created: Date.now() },
+      finish: "stop",
+    },
+    parts: text ? [{ type: "text", text }] as never : [],
+  }
+}
+
+function node(id: string, dependsOn: string[] = []): NodeConfig {
+  return {
+    id,
+    name: id,
+    worker_type: "build",
+    depends_on: dependsOn,
+    required: true,
+    prompt_template: { inline: id },
+    report_to_parent: true,
+  }
+}
+
+function promptText(input: SessionPrompt.PromptInput) {
+  return input.parts
+    .filter((part) => part.type === "text")
+    .map((part) => part.text)
+    .join("\n")
+}
+
+function wakeLayer(input: {
+  readonly childPrompts: Queue.Queue<PromptGate>
+  readonly parentPrompts: Queue.Queue<ParentPromptGate>
+  readonly parentSettled: Queue.Queue<void>
+}) {
+  const database = Database.layerFromPath(":memory:")
+  const events = EventV2.layer.pipe(Layer.provide(database))
+  const bridge = EventV2Bridge.layer.pipe(Layer.provide(events))
+  const store = DagStore.layer.pipe(Layer.provide(database))
+  const status = SessionStatus.layer.pipe(Layer.provide(bridge))
+  const projector = DagProjector.layer.pipe(
+    Layer.provide(events),
+    Layer.provide(database),
+  )
+  const dag = Dag.layer.pipe(
+    Layer.provide(bridge),
+    Layer.provide(store),
+  )
+  const base = Layer.mergeAll(database, events, bridge, store, projector, dag, status)
+  const childTitles = new Map<string, string>()
+  const created: string[] = []
+  const session = Layer.mock(Session.Service, {
+    get: () => Effect.succeed({ id: "ses_parent", permission: [], agent: "build" } as never),
+    create: (value) =>
+      Effect.sync(() => {
+        const id = `ses_child_${created.length + 1}`
+        created.push(id)
+        childTitles.set(id, (value?.title ?? id).replace(" (DAG node)", ""))
+        return { id } as never
+      }),
+    messages: () => Effect.succeed([]),
+  })
+  const deliver = Effect.fn("test.SessionPrompt.deliver")(function* (value: SessionPrompt.PromptInput) {
+    const sessionID = value.sessionID as string
+    if (sessionID === "ses_parent") {
+      const release = yield* Deferred.make<"success" | "failure">()
+      yield* Queue.offer(input.parentPrompts, { input: value, release })
+      const outcome = yield* Deferred.await(release).pipe(
+        Effect.ensuring(Queue.offer(input.parentSettled, undefined)),
+      )
+      if (outcome === "failure") return yield* Effect.die(new Error("provider unavailable"))
+      return reply(sessionID, "parent handled wake")
+    }
+    const release = yield* Deferred.make<string>()
+    yield* Queue.offer(input.childPrompts, {
+      title: childTitles.get(sessionID) ?? sessionID,
+      release,
+    })
+    return reply(sessionID, yield* Deferred.await(release))
+  })
+  const prompt = Layer.mock(SessionPrompt.Service, {
+    cancel: () => Effect.void,
+    prompt: deliver,
+    promptIfIdle: (value) => deliver(value).pipe(Effect.map(Option.some)),
+  })
+  const agent = Layer.mock(Agent.Service, {
+    get: () => Effect.succeed({
+      name: "build",
+      mode: "all",
+      permission: [],
+      options: {},
+      description: "",
+      prompt: "",
+      model: { providerID: "test" as never, modelID: "test-model" as never },
+      tools: {},
+      hooks: {},
+    }),
+  })
+  const loop = DagLoop.layer.pipe(
+    Layer.provide(base),
+    Layer.provide(session),
+    Layer.provide(prompt),
+    Layer.provide(agent),
+  )
+  return Layer.merge(base, loop)
+}
+
+function runWakeTest<A>(
+  test: (services: {
+    readonly dag: Dag.Interface
+    readonly loop: DagLoop.Interface
+    readonly store: DagStore.Interface
+    readonly status: SessionStatus.Interface
+    readonly childPrompts: Queue.Queue<PromptGate>
+    readonly parentPrompts: Queue.Queue<ParentPromptGate>
+    readonly parentSettled: Queue.Queue<void>
+  }) => Effect.Effect<A, Error>,
+  beforeInit?: (services: {
+    readonly database: Database.Interface
+  }) => Effect.Effect<void>,
+) {
+  return Effect.gen(function* () {
+    const childPrompts = yield* Queue.unbounded<PromptGate>()
+    const parentPrompts = yield* Queue.unbounded<ParentPromptGate>()
+    const parentSettled = yield* Queue.unbounded<void>()
+    return yield* Effect.gen(function* () {
+      const dag = yield* Dag.Service
+      const loop = yield* DagLoop.Service
+      const store = yield* DagStore.Service
+      const status = yield* SessionStatus.Service
+      const database = yield* Database.Service
+      yield* database.db.insert(ProjectTable).values({
+        id: "project-1" as never,
+        worktree: process.cwd() as never,
+        sandboxes: [],
+      }).run().pipe(Effect.orDie)
+      yield* database.db.insert(SessionTable).values({
+        id: "ses_parent" as never,
+        project_id: "project-1" as never,
+        slug: "parent",
+        directory: process.cwd() as never,
+        title: "Parent",
+        version: "test",
+      }).run().pipe(Effect.orDie)
+      if (beforeInit) yield* beforeInit({ database })
+      yield* loop.init()
+      return yield* test({ dag, loop, store, status, childPrompts, parentPrompts, parentSettled })
+    }).pipe(
+      Effect.provide(wakeLayer({ childPrompts, parentPrompts, parentSettled })),
+      Effect.provideService(InstanceRef, {
+        directory: process.cwd(),
+        worktree: process.cwd(),
+        project: { id: "project-1" },
+      } as never),
+      Effect.scoped,
+    )
+  })
+}
+
+describe("DagLoop atomic wake integration", () => {
+  it("does not block a second workflow's downstream scheduling on a parent wake", async () => {
+    await Effect.runPromise(
+      runWakeTest(({ dag, childPrompts, parentPrompts }) =>
+        Effect.gen(function* () {
+          yield* dag.create({
+            projectID: "project-1",
+            sessionID: "ses_parent",
+            title: "Wake source",
+            config: { name: "wake-source", nodes: [node("wake-source")] },
+          })
+          yield* dag.create({
+            projectID: "project-1",
+            sessionID: "ses_parent",
+            title: "Independent pipeline",
+            config: { name: "pipeline", nodes: [node("root"), node("downstream", ["root"])] },
+          })
+
+          const first = yield* takeWithin(childPrompts, "first root node did not start")
+          const second = yield* takeWithin(childPrompts, `second root node did not start after ${first.title}`)
+          const prompts = new Map([first, second].map((item) => [item.title, item]))
+          yield* Deferred.succeed(prompts.get("wake-source")!.release, "wake result")
+
+          const parent = yield* takeWithin(parentPrompts, "terminal workflow did not trigger a parent wake")
+          yield* Deferred.succeed(prompts.get("root")!.release, "root result")
+
+          const downstream = yield* takeWithin(
+            childPrompts,
+            "downstream scheduling waited for the blocked parent wake",
+          )
+          expect(downstream.title).toBe("downstream")
+
+          yield* Deferred.succeed(parent.release, "success")
+          yield* Deferred.succeed(downstream.release, "done")
+        }),
+      ),
+    )
+  })
+
+  it("batches parallel results and the terminal workflow into one deterministic prompt", async () => {
+    await Effect.runPromise(
+      runWakeTest(({ dag, childPrompts, parentPrompts }) =>
+        Effect.gen(function* () {
+          yield* dag.create({
+            projectID: "project-1",
+            sessionID: "ses_parent",
+            title: "Parallel batch",
+            config: {
+              name: "parallel-batch",
+              nodes: [node("a"), node("b"), node("aggregate", ["a", "b"])],
+            },
+          })
+
+          const first = yield* takeWithin(childPrompts, "first parallel node did not start")
+          const second = yield* takeWithin(childPrompts, "second parallel node did not start")
+          const parallel = new Map([first, second].map((item) => [item.title, item]))
+          yield* Deferred.succeed(parallel.get("a")!.release, "A")
+          yield* Deferred.succeed(parallel.get("b")!.release, "B")
+
+          const aggregate = yield* takeWithin(
+            childPrompts,
+            "aggregate scheduling waited for an intermediate parent wake",
+          )
+          expect(aggregate.title).toBe("aggregate")
+          expect(Option.isNone(yield* Queue.poll(parentPrompts))).toBe(true)
+          yield* Deferred.succeed(aggregate.release, "AB")
+
+          const parent = yield* takeWithin(parentPrompts, "terminal batch did not wake the parent")
+          const text = promptText(parent.input)
+          expect(text).toContain('Node "a" completed: A')
+          expect(text).toContain('Node "b" completed: B')
+          expect(text).toContain('Node "aggregate" completed: AB')
+          expect(text).toContain('Workflow "Parallel batch" has reached terminal status')
+          expect(text).not.toContain("You MUST act")
+          expect(text.indexOf('Node "a"')).toBeLessThan(text.indexOf('Node "b"'))
+          expect(text.indexOf('Node "b"')).toBeLessThan(text.indexOf('Node "aggregate"'))
+          yield* Deferred.succeed(parent.release, "success")
+        }),
+      ),
+    )
+  })
+
+  it("keeps rows committed during delivery for a later stable batch", async () => {
+    await Effect.runPromise(
+      runWakeTest(({ dag, childPrompts, parentPrompts }) =>
+        Effect.gen(function* () {
+          yield* dag.create({
+            projectID: "project-1",
+            sessionID: "ses_parent",
+            title: "First workflow",
+            config: { name: "first", nodes: [node("first-node")] },
+          })
+          const firstNode = yield* takeWithin(childPrompts, "first workflow did not start")
+          yield* Deferred.succeed(firstNode.release, "first")
+          const firstParent = yield* takeWithin(parentPrompts, "first workflow did not wake the parent")
+
+          yield* dag.create({
+            projectID: "project-1",
+            sessionID: "ses_parent",
+            title: "Late workflow",
+            config: { name: "late", nodes: [node("late-node")] },
+          })
+          const lateNode = yield* takeWithin(childPrompts, "late workflow did not start")
+          yield* Deferred.succeed(lateNode.release, "late")
+          expect(promptText(firstParent.input)).not.toContain("late-node")
+
+          yield* Deferred.succeed(firstParent.release, "success")
+          const secondParent = yield* takeWithin(parentPrompts, "late result was not delivered in a later batch")
+          expect(promptText(secondParent.input)).toContain('Node "late-node" completed: late')
+          yield* Deferred.succeed(secondParent.release, "success")
+        }),
+      ),
+    )
+  })
+
+  it("leaves the whole batch unreported when parent delivery fails", async () => {
+    await Effect.runPromise(
+      runWakeTest(({ dag, store, childPrompts, parentPrompts, parentSettled }) =>
+        Effect.gen(function* () {
+          yield* dag.create({
+            projectID: "project-1",
+            sessionID: "ses_parent",
+            title: "Retryable workflow",
+            config: { name: "retryable", nodes: [node("retryable-node")] },
+          })
+          const child = yield* takeWithin(childPrompts, "retryable node did not start")
+          yield* Deferred.succeed(child.release, "retry me")
+          const parent = yield* takeWithin(parentPrompts, "retryable batch did not wake the parent")
+          yield* Deferred.succeed(parent.release, "failure")
+          yield* takeWithin(parentSettled, "failed parent prompt did not settle")
+
+          expect(yield* store.getUnreportedWakeNodes("ses_parent")).toHaveLength(1)
+          expect(yield* store.getUnreportedWakeWorkflows("ses_parent")).toHaveLength(1)
+        }),
+      ),
+    )
+  })
+
+  it("redelivers an unreported durable batch during startup", async () => {
+    await Effect.runPromise(
+      runWakeTest(
+        ({ parentPrompts }) =>
+          Effect.gen(function* () {
+            const parent = yield* takeWithin(parentPrompts, "startup scan did not redeliver the durable batch")
+            const text = promptText(parent.input)
+            expect(text).toContain('Node "recovered-node" completed: recovered')
+            expect(text).toContain('Workflow "Recovered workflow" has reached terminal status')
+            yield* Deferred.succeed(parent.release, "success")
+          }),
+        ({ database }) =>
+          database.db.transaction((tx) =>
+            Effect.gen(function* () {
+              yield* tx.insert(WorkflowTable).values({
+                id: "recovered-workflow",
+                project_id: "project-1" as never,
+                session_id: "ses_parent" as never,
+                title: "Recovered workflow",
+                status: "completed",
+                config: "{}",
+                seq: 10,
+                wake_reported: false,
+              }).run()
+              yield* tx.insert(WorkflowNodeTable).values({
+                id: "recovered-node",
+                workflow_id: "recovered-workflow",
+                name: "recovered-node",
+                worker_type: "build",
+                status: "completed",
+                required: true,
+                depends_on: [],
+                output: "recovered",
+                wake_eligible: true,
+                wake_reported: false,
+                seq: 9,
+              }).run()
+            }),
+          ).pipe(Effect.orDie),
+      ),
+    )
+  })
+
+  it("keeps a wake unreported while the parent is busy and delivers it on idle", async () => {
+    await Effect.runPromise(
+      runWakeTest(({ dag, store, status, childPrompts, parentPrompts }) =>
+        Effect.gen(function* () {
+          yield* status.set("ses_parent" as never, { type: "busy" })
+          const dagID = yield* dag.create({
+            projectID: "project-1",
+            sessionID: "ses_parent",
+            title: "Busy parent",
+            config: { name: "busy-parent", nodes: [node("busy-node")] },
+          })
+          const child = yield* takeWithin(childPrompts, "busy-parent node did not start")
+          yield* Deferred.succeed(child.release, "held result")
+          yield* pollWithTimeout(
+            store.getWorkflow(dagID).pipe(
+              Effect.map((workflow) => workflow?.status === "completed" ? true as const : undefined),
+            ),
+            "workflow did not complete while its parent was busy",
+          )
+
+          expect(Option.isNone(yield* Queue.poll(parentPrompts))).toBe(true)
+          expect(yield* store.getUnreportedWakeNodes("ses_parent")).toHaveLength(1)
+          expect(yield* store.getUnreportedWakeWorkflows("ses_parent")).toHaveLength(1)
+
+          yield* status.set("ses_parent" as never, { type: "idle" })
+          const parent = yield* takeWithin(parentPrompts, "idle transition did not deliver the retained batch")
+          expect(promptText(parent.input)).toContain('Node "busy-node" completed: held result')
+          yield* Deferred.succeed(parent.release, "success")
+        }),
+      ),
+    )
+  })
+
+  it("wakes at paused and stepping decision boundaries", async () => {
+    await Effect.runPromise(
+      runWakeTest(({ dag, store, childPrompts, parentPrompts, parentSettled }) =>
+        Effect.gen(function* () {
+          const dagID = yield* dag.create({
+            projectID: "project-1",
+            sessionID: "ses_parent",
+            title: "Controlled workflow",
+            config: {
+              name: "controlled",
+              nodes: [node("root"), node("next", ["root"]), node("after", ["next"])],
+            },
+          })
+          const root = yield* takeWithin(childPrompts, "controlled root did not start")
+          yield* dag.pause(dagID)
+          yield* Deferred.succeed(root.release, "checkpoint")
+
+          const paused = yield* takeWithin(parentPrompts, "paused boundary did not wake the parent")
+          expect(promptText(paused.input)).toContain('Node "root" completed: checkpoint')
+          yield* Deferred.succeed(paused.release, "success")
+          yield* takeWithin(parentSettled, "paused parent prompt did not settle")
+
+          yield* dag.resume(dagID)
+          expect(yield* dag.step(dagID)).toEqual({ status: "stepping", nodeID: "next" })
+          const next = yield* takeWithin(childPrompts, "stepping boundary did not start the selected node")
+          yield* Deferred.succeed(next.release, "stepped")
+          const stepped = yield* takeWithin(parentPrompts, "stepping boundary did not wake the parent")
+          expect(promptText(stepped.input)).toContain('Node "next" completed: stepped')
+          yield* Deferred.succeed(stepped.release, "success")
+          yield* takeWithin(parentSettled, "stepping parent prompt did not settle")
+
+          expect((yield* store.getWorkflow(dagID))?.status).toBe("stepping")
+          expect((yield* store.getNode(dagID, "after"))?.status).toBe("pending")
+        }),
+      ),
+    )
+  })
+})

--- a/packages/opencode/test/dag/workflow-tool.test.ts
+++ b/packages/opencode/test/dag/workflow-tool.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it } from "bun:test"
 import { Effect, Exit, Layer, Schema } from "effect"
 import { Dag } from "@/dag/dag"
 import { Agent } from "@/agent/agent"
+import { DagStore } from "@opencode-ai/core/dag/store"
+import { DagEvent } from "@opencode-ai/schema/dag-event"
+import { EventV2Bridge } from "@/event-v2-bridge"
 import { Session } from "@/session/session"
 import { MessageID, SessionID } from "@/session/schema"
 import type { Tool } from "@/tool/tool"
@@ -10,85 +13,88 @@ import { Parameters, WorkflowTool } from "@/tool/workflow"
 import { testEffect } from "../lib/effect"
 
 const projectID = "project_test"
-const created: Parameters<Dag.Interface["create"]>[0][] = []
+const published: Array<{ type: string; data: unknown }> = []
+const store = Layer.mock(DagStore.Service, {
+  getWorkflow: (id: string) =>
+    Effect.succeed(
+      id === "dag_status"
+        ? {
+            id,
+            projectId: projectID,
+            sessionId: "ses_workflow_parent",
+            title: "Status workflow",
+            status: "running",
+            config: "{}",
+            seq: 1,
+            wakeReported: false,
+            startedAt: 1,
+            completedAt: null,
+            timeCreated: 1,
+            timeUpdated: 2,
+          }
+        : undefined,
+    ),
+  getNodes: () =>
+    Effect.succeed([
+      {
+        id: "node_running",
+        workflowId: "dag_status",
+        name: "Running node",
+        workerType: "build",
+        status: "running",
+        required: true,
+        dependsOn: [],
+        modelId: null,
+        modelProviderId: null,
+        childSessionId: "ses_child",
+        output: null,
+        capturedOutput: null,
+        errorReason: null,
+        deadlineMs: null,
+        wakeEligible: true,
+        wakeReported: false,
+        replanAttempts: 0,
+        seq: 1,
+        startedAt: 1,
+        completedAt: null,
+        timeCreated: 1,
+        timeUpdated: 2,
+      },
+    ]),
+})
+const events = Layer.mock(EventV2Bridge.Service, {
+  publish: (definition, data) =>
+    Effect.sync(() => {
+      published.push({ type: definition.type, data })
+      return { id: "event_test", type: definition.type, data } as never
+    }),
+})
+const dag = Dag.layer.pipe(
+  Layer.provide(store),
+  Layer.provide(events),
+)
 const runtime = testEffect(
   Layer.mergeAll(
-    Layer.succeed(
-      Agent.Service,
-      Agent.Service.of({
-        get: () => Effect.succeed({}),
-      } as unknown as Agent.Interface),
-    ),
-    Layer.succeed(
-      Truncate.Service,
-      Truncate.Service.of({
-        output: (content) => Effect.succeed({ content, truncated: false }),
-      } as Truncate.Interface),
-    ),
-    Layer.succeed(
-      Dag.Service,
-      Dag.Service.of({
-        create: (input: Parameters<Dag.Interface["create"]>[0]) =>
-          Effect.sync(() => {
-            created.push(input)
-            return Dag.ID.create()
-          }),
-        store: {
-          getWorkflow: (id: string) =>
-            Effect.succeed(
-              id === "dag_status"
-                ? {
-                    id,
-                    projectId: projectID,
-                    sessionId: "ses_workflow_parent",
-                    title: "Status workflow",
-                    status: "running",
-                    config: "{}",
-                    seq: 1,
-                    wakeReported: false,
-                    startedAt: 1,
-                    completedAt: null,
-                    timeCreated: 1,
-                    timeUpdated: 2,
-                  }
-                : undefined,
-            ),
-          getNodes: () =>
-            Effect.succeed([
-              {
-                id: "node_running",
-                workflowId: "dag_status",
-                name: "Running node",
-                workerType: "build",
-                status: "running",
-                required: true,
-                dependsOn: [],
-                modelId: null,
-                modelProviderId: null,
-                childSessionId: "ses_child",
-                output: null,
-                capturedOutput: null,
-                errorReason: null,
-                deadlineMs: null,
-                wakeEligible: true,
-                wakeReported: false,
-                replanAttempts: 0,
-                seq: 1,
-                startedAt: 1,
-                completedAt: null,
-                timeCreated: 1,
-                timeUpdated: 2,
-              },
-            ]),
-        },
-      } as unknown as Dag.Interface),
-    ),
-    Layer.succeed(
-      Session.Service,
-      Session.Service.of({
-        get: (id: Parameters<Session.Interface["get"]>[0]) => Effect.succeed({ id, projectID } as Session.Info),
-      } as unknown as Session.Interface),
-    ),
+    Layer.mock(Agent.Service, {
+      get: () =>
+        Effect.succeed({
+          name: "build",
+          mode: "all",
+          permission: [],
+          options: {},
+          description: "",
+          prompt: "",
+          tools: {},
+          hooks: {},
+        }),
+    }),
+    Layer.mock(Truncate.Service, {
+      output: (content) => Effect.succeed({ content, truncated: false }),
+    }),
+    dag,
+    Layer.mock(Session.Service, {
+      get: (id: Parameters<Session.Interface["get"]>[0]) => Effect.succeed({ id, projectID } as Session.Info),
+    }),
   ),
 )
 
@@ -162,6 +168,7 @@ describe("workflow tool execution", () => {
       for (const action of ["start", "extend", "status", "control"]) {
         expect(workflow.description).toContain(`**${action}**`)
       }
+      expect(workflow.description).toContain("Do not poll")
       expect(workflow.description).not.toContain("$ARGUMENTS")
     }),
   )
@@ -194,7 +201,7 @@ describe("workflow tool execution", () => {
 
   runtime.effect("start derives the project ID from the parent session", () =>
     Effect.gen(function* () {
-      created.length = 0
+      published.length = 0
       const parentID = SessionID.make("ses_workflow_parent")
       const info = yield* WorkflowTool
       const workflow = yield* info.init()
@@ -220,15 +227,16 @@ describe("workflow tool execution", () => {
 
       const workflowID = result.metadata.workflowId
       expect(workflowID).toBeDefined()
-      expect(created).toHaveLength(1)
-      expect(created[0]?.projectID).toBe(projectID)
-      expect(created[0]?.sessionID).toBe(parentID)
+      expect(result.output).toContain("Do not poll")
+      expect(published.find((event) => event.type === DagEvent.WorkflowCreated.type)?.data).toEqual(
+        expect.objectContaining({ projectID, sessionID: parentID }),
+      )
     }),
   )
 
   runtime.effect("start passes the decoded required default to Dag.create", () =>
     Effect.gen(function* () {
-      created.length = 0
+      published.length = 0
       const info = yield* WorkflowTool
       const workflow = yield* info.init()
 
@@ -259,13 +267,15 @@ describe("workflow tool execution", () => {
         } satisfies Tool.Context,
       )
 
-      expect(created[0]?.config.nodes[0]?.required).toBe(false)
+      expect(published.find((event) => event.type === DagEvent.NodeRegistered.type)?.data).toEqual(
+        expect.objectContaining({ required: false }),
+      )
     }),
   )
 
   runtime.effect("start rejects a project ID outside the parent session project", () =>
     Effect.gen(function* () {
-      created.length = 0
+      published.length = 0
       const parentID = SessionID.make("ses_workflow_parent")
       const info = yield* WorkflowTool
       const workflow = yield* info.init()
@@ -292,7 +302,7 @@ describe("workflow tool execution", () => {
         .pipe(Effect.exit)
 
       expect(Exit.isFailure(exit)).toBe(true)
-      expect(created).toHaveLength(0)
+      expect(published).toHaveLength(0)
     }),
   )
 })

--- a/packages/opencode/test/effect/runner.test.ts
+++ b/packages/opencode/test/effect/runner.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect } from "bun:test"
-import { Cause, Deferred, Effect, Exit, Fiber, Latch, Ref, Scope } from "effect"
+import { Cause, Deferred, Effect, Exit, Fiber, Latch, Option, Ref, Scope } from "effect"
 import { Runner } from "@/effect/runner"
 import { it } from "../lib/effect"
 
@@ -110,6 +110,47 @@ describe("Runner", () => {
       expect(a).toBe("first-result")
       expect(b).toBe("first-result")
       expect(yield* Ref.get(ran)).toEqual(["first"])
+    }),
+  )
+
+  it.live(
+    "ensureRunningHandle reserves the runner before its result is awaited",
+    Effect.gen(function* () {
+      const s = yield* Scope.Scope
+      const runner = Runner.make<string>(s)
+      const gate = yield* Deferred.make<void>()
+
+      const handle = yield* runner.ensureRunningHandle(Deferred.await(gate).pipe(Effect.as("done")))
+      expect(runner.busy).toBe(true)
+      expect(runner.state._tag).toBe("Running")
+
+      yield* Deferred.succeed(gate, undefined)
+      expect(yield* handle).toBe("done")
+      expect(runner.busy).toBe(false)
+    }),
+  )
+
+  it.live(
+    "startIfIdle atomically rejects replacement work while the first run is active",
+    Effect.gen(function* () {
+      const s = yield* Scope.Scope
+      const runner = Runner.make<string>(s)
+      const gate = yield* Deferred.make<void>()
+      const replacementRan = yield* Ref.make(false)
+
+      const first = yield* runner.startIfIdle(Deferred.await(gate).pipe(Effect.as("first")))
+      const second = yield* runner.startIfIdle(
+        Ref.set(replacementRan, true).pipe(Effect.as("second")),
+      )
+
+      expect(Option.isSome(first)).toBe(true)
+      expect(Option.isNone(second)).toBe(true)
+      expect(yield* Ref.get(replacementRan)).toBe(false)
+      expect(runner.busy).toBe(true)
+
+      yield* Deferred.succeed(gate, undefined)
+      if (Option.isSome(first)) expect(yield* first.value).toBe("first")
+      expect(runner.busy).toBe(false)
     }),
   )
 

--- a/packages/opencode/test/project/bootstrap-dag-wiring.test.ts
+++ b/packages/opencode/test/project/bootstrap-dag-wiring.test.ts
@@ -1,13 +1,80 @@
-import { describe, expect, test } from "bun:test"
-import { DagLoop } from "@/dag/runtime/loop"
-import { DagSummaryPublisher } from "@/dag/runtime/summary-publisher"
-import { InstanceBootstrap } from "@/project/bootstrap"
+import { describe, expect } from "bun:test"
+import { Dag } from "@/dag/dag"
+import { InstanceState } from "@/effect/instance-state"
+import { InstanceStore } from "@/project/instance-store"
+import { Project } from "@/project/project"
+import { Session } from "@/session/session"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { SessionProjector } from "@opencode-ai/core/session/projector"
+import { Effect, Layer } from "effect"
+import { tmpdirScoped } from "../fixture/fixture"
+import { pollWithTimeout, testEffect } from "../lib/effect"
+
+const appLayer = LayerNode.buildLayer(
+  LayerNode.group([InstanceStore.node, Dag.node, Project.node, Session.node, SessionProjector.node]),
+)
+const appIt = testEffect(Layer.mergeAll(appLayer, CrossSpawnSpawner.defaultLayer))
 
 describe("instance bootstrap DAG wiring", () => {
-  test("production LayerNode graph provides the DAG runtime and summary publisher", () => {
-    expect(InstanceBootstrap.node.dependencies).toContain(DagLoop.node)
-    expect(InstanceBootstrap.node.dependencies).toContain(DagSummaryPublisher.node)
-    expect(() => LayerNode.buildLayer(InstanceBootstrap.node)).not.toThrow()
-  })
+  appIt.live("recovers a persisted workflow when InstanceStore bootstraps the production graph", () =>
+    Effect.gen(function* () {
+      const directory = yield* tmpdirScoped({ git: true })
+      const instances = yield* InstanceStore.Service
+      const workflowID = yield* instances.provide(
+        { directory },
+        Effect.gen(function* () {
+          const context = yield* InstanceState.context
+          const session = yield* Session.Service
+          const dag = yield* Dag.Service
+          const parent = yield* session.create({ title: "bootstrap DAG wiring" })
+          yield* pollWithTimeout(
+            session.get(parent.id).pipe(
+              Effect.as(true as const),
+              Effect.catch(() => Effect.succeed(undefined)),
+            ),
+            "session projection did not become visible",
+          )
+          return yield* dag.create({
+            projectID: context.project.id,
+            sessionID: parent.id,
+            title: "condition false",
+            config: {
+              name: "condition false",
+              nodes: [
+                {
+                  id: "skip",
+                  name: "skip without a model call",
+                  worker_type: "reviewer",
+                  depends_on: [],
+                  required: true,
+                  prompt_template: { inline: "unused" },
+                  condition: "missing == true",
+                },
+              ],
+            },
+          })
+        }),
+      )
+      yield* instances.reload({ directory })
+      yield* instances.provide(
+        { directory },
+        Effect.gen(function* () {
+          const dag = yield* Dag.Service
+          const result = yield* pollWithTimeout(
+            Effect.gen(function* () {
+              const workflow = yield* dag.store.getWorkflow(workflowID)
+              const nodes = yield* dag.store.getNodes(workflowID)
+              if (workflow?.status !== "completed" || nodes[0]?.status !== "skipped") return
+              return { workflow, node: nodes[0] }
+            }),
+            "bootstrap did not start the DAG scheduler",
+            "1 second",
+          )
+          expect(result.workflow.status).toBe("completed")
+          expect(result.node.status).toBe("skipped")
+        }),
+      )
+    }),
+  )
 })

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -181,12 +181,23 @@ let stopBlockAlways = false
 let stopSystemMessages: string[] = []
 let stopAdditionalContexts: string[] = []
 let subagentStopBlockAlways = false
+let userPromptAdmissionStarted: Deferred.Deferred<void> | undefined
+let userPromptAdmissionGate: Deferred.Deferred<void> | undefined
 const hookRecorderLayer = Layer.succeed(
   SettingsHook.Service,
   SettingsHook.Service.of({
     trigger: (payload) =>
-      Effect.sync(() => {
+      Effect.gen(function* () {
         hookRecorded.push(payload)
+        if (
+          payload.event === "UserPromptSubmit"
+          && payload.prompt.includes("hold-human-admission")
+          && userPromptAdmissionStarted
+          && userPromptAdmissionGate
+        ) {
+          yield* Deferred.succeed(userPromptAdmissionStarted, undefined).pipe(Effect.ignore)
+          yield* Deferred.await(userPromptAdmissionGate)
+        }
         let blocked: { reason: string; command: string } | undefined
         if (payload.event === "Stop") {
           if (stopBlockAlways || stopBlockNext > 0) {
@@ -1676,6 +1687,110 @@ it.instance("concurrent loop callers all receive same error result", () =>
   }),
 )
 
+it.instance("idle-only synthetic admission cannot overtake a concurrent human prompt", () =>
+  Effect.gen(function* () {
+    const { llm } = yield* useServerConfig(providerCfg)
+    const prompt = yield* SessionPrompt.Service
+    const sessions = yield* Session.Service
+    const chat = yield* sessions.create({ title: "Pinned" })
+    const admissionStarted = yield* Deferred.make<void>()
+    const admissionGate = yield* Deferred.make<void>()
+    userPromptAdmissionStarted = admissionStarted
+    userPromptAdmissionGate = admissionGate
+    yield* Effect.addFinalizer(() =>
+      Effect.sync(() => {
+        userPromptAdmissionStarted = undefined
+        userPromptAdmissionGate = undefined
+      }),
+    )
+    yield* llm.hang
+
+    const human = yield* prompt
+      .prompt({
+        sessionID: chat.id,
+        agent: "build",
+        model: ref,
+        parts: [{ type: "text", text: "hold-human-admission" }],
+      })
+      .pipe(Effect.forkChild({ startImmediately: true }))
+    yield* awaitWithTimeout(
+      Deferred.await(admissionStarted),
+      "human prompt did not enter admission",
+    )
+
+    const wake = yield* prompt
+      .promptIfIdle({
+        sessionID: chat.id,
+        agent: "build",
+        model: ref,
+        parts: [{ type: "text", text: "synthetic DAG wake", synthetic: true }],
+      })
+      .pipe(Effect.forkChild({ startImmediately: true }))
+
+    yield* Deferred.succeed(admissionGate, undefined)
+    const wakeResult = yield* awaitWithTimeout(
+      Fiber.join(wake),
+      "idle-only prompt did not reject after human admission won",
+    )
+    expect(wakeResult._tag).toBe("None")
+    expect(
+      (yield* sessions.messages({ sessionID: chat.id }))
+        .flatMap((message) => message.parts)
+        .some((part) => part.type === "text" && part.text === "synthetic DAG wake"),
+    ).toBe(false)
+
+    yield* llm.wait(1)
+    yield* prompt.cancel(chat.id)
+    yield* Fiber.await(human)
+  }),
+)
+
+it.instance("interrupting idle-only admission releases the reserved runner", () =>
+  Effect.gen(function* () {
+    const { prompt, run, chat } = yield* boot()
+    const admissionStarted = yield* Deferred.make<void>()
+    const admissionGate = yield* Deferred.make<void>()
+    userPromptAdmissionStarted = admissionStarted
+    userPromptAdmissionGate = admissionGate
+    yield* Effect.addFinalizer(() =>
+      Deferred.succeed(admissionGate, undefined).pipe(
+        Effect.ignore,
+        Effect.andThen(
+          Effect.sync(() => {
+            userPromptAdmissionStarted = undefined
+            userPromptAdmissionGate = undefined
+          }),
+        ),
+      ),
+    )
+
+    const wake = yield* prompt
+      .promptIfIdle({
+        sessionID: chat.id,
+        agent: "build",
+        model: ref,
+        parts: [{ type: "text", text: "hold-human-admission", synthetic: true }],
+      })
+      .pipe(Effect.forkChild({ startImmediately: true }))
+    yield* awaitWithTimeout(
+      Deferred.await(admissionStarted),
+      "idle-only prompt did not enter admission",
+    )
+
+    yield* Fiber.interrupt(wake)
+    yield* pollWithTimeout(
+      run.assertNotBusy(chat.id).pipe(
+        Effect.match({
+          onFailure: () => undefined,
+          onSuccess: () => true as const,
+        }),
+      ),
+      "interrupted idle-only admission left the runner busy",
+      "1 second",
+    )
+  }),
+)
+
 it.instance("prompt submitted during an active run is included in the next LLM input", () =>
   Effect.gen(function* () {
     const { llm } = yield* useServerConfig(providerCfg)
@@ -2088,6 +2203,38 @@ unix(
       }),
     ),
   30_000,
+)
+
+it.instance("stores the slash invocation as visible text and hides the expanded command template", () =>
+  Effect.gen(function* () {
+    const { llm } = yield* useServerConfig((url) => ({
+      ...providerCfg(url),
+      command: {
+        probe: {
+          template: "Expanded command instructions:\n$ARGUMENTS",
+        },
+      },
+    }))
+    const { prompt, sessions, chat } = yield* boot()
+    yield* llm.text("done")
+
+    yield* prompt.command({
+      sessionID: chat.id,
+      command: "probe",
+      arguments: "inspect layout",
+    })
+
+    const user = (yield* sessions.messages({ sessionID: chat.id })).find((message) => message.info.role === "user")
+    const texts = user?.parts.filter((part): part is SessionV1.TextPart => part.type === "text") ?? []
+
+    expect(texts.filter((part) => !part.synthetic).map((part) => part.text)).toEqual([
+      "/probe inspect layout",
+    ])
+    expect(texts.filter((part) => part.synthetic).map((part) => part.text)).toContain(
+      "Expanded command instructions:\ninspect layout",
+    )
+    expect(JSON.stringify(yield* llm.inputs)).toContain("Expanded command instructions")
+  }),
 )
 
 unixNoLLMServer(

--- a/packages/tui/src/feature-plugins/system/dag-inspector.tsx
+++ b/packages/tui/src/feature-plugins/system/dag-inspector.tsx
@@ -41,6 +41,10 @@ function DagInspector(props: { api: TuiPluginApi }) {
       setWorkflowLoad("loaded")
       return
     }
+    setFetchedWorkflows([])
+    setSelectedWorkflow(undefined)
+    setSelectedNode(undefined)
+    setNodes([])
     setWorkflowLoad("loading")
     void props.api.client.dag
       .summary({ sessionID })

--- a/packages/tui/test/feature-plugins/dag-inspector.test.tsx
+++ b/packages/tui/test/feature-plugins/dag-inspector.test.tsx
@@ -32,6 +32,7 @@ type RenderOpts = {
   serverWorkflows?: DagWorkflowSummary[]
   nodes?: DagNode[]
   initialRoute?: TuiRouteCurrent
+  summary?: (sessionID: string) => Promise<{ data: DagWorkflowSummary[] }>
 }
 
 function dagNode(overrides: Partial<DagNode> & { id: string }): DagNode {
@@ -78,7 +79,8 @@ async function renderDagInspector(opts: RenderOpts = {}) {
       keymap,
       client: {
         dag: {
-          summary: async () => ({ data: opts.serverWorkflows ?? workflowsState }),
+          summary: async (input: { sessionID: string }) =>
+            opts.summary?.(input.sessionID) ?? { data: opts.serverWorkflows ?? workflowsState },
           nodes: async (input: { dagID: string }) => {
             nodesCalls.push(input.dagID)
             return { data: opts.nodes ?? [] }
@@ -169,6 +171,7 @@ async function renderDagInspector(opts: RenderOpts = {}) {
       } as never)
     },
     current: () => current(),
+    setRoute: setCurrent,
   }
 }
 
@@ -231,6 +234,29 @@ describe("DagInspector", () => {
     try {
       await viewer.app.waitForFrame((frame) => frame.includes("No workflows"))
     } finally {
+      viewer.app.renderer.destroy()
+    }
+  })
+
+  test("switching sessions clears the previous server snapshot before the new fetch resolves", async () => {
+    let resolveSecond: ((value: { data: DagWorkflowSummary[] }) => void) | undefined
+    const second = new Promise<{ data: DagWorkflowSummary[] }>((resolve) => {
+      resolveSecond = resolve
+    })
+    const viewer = await renderDagInspector({
+      summary: (sessionID) =>
+        sessionID === SESSION_ID
+          ? Promise.resolve({ data: [wfSummary({ title: "Previous session workflow" })] })
+          : second,
+    })
+    try {
+      await viewer.app.waitForFrame((frame) => frame.includes("Previous session workflow"))
+      viewer.setRoute({ name: "dag", params: { sessionID: "ses_2" } })
+      await viewer.app.waitForFrame(
+        (frame) => frame.includes("Loading workflows...") && !frame.includes("Previous session workflow"),
+      )
+    } finally {
+      resolveSecond?.({ data: [] })
       viewer.app.renderer.destroy()
     }
   })


### PR DESCRIPTION
## Summary

- make DAG terminal handling non-blocking and batch deterministic wake results at autonomous boundaries
- add atomic idle-only prompt admission, transactional wake acknowledgement, restart recovery, and interruption-safe runner release
- fix DAG production wiring, visible `/dag-flow` invocation, stale inspector state, and polling guidance

## TDD / Validation

- Core focused tests: 8 passed
- OpenCode focused tests: 59 passed
- TUI DAG inspector tests: 14 passed
- Prompt admission race/interruption tests: 2 passed
- Atomic wake stability: 140/140 passed (`--rerun-each 20`)
- `bun typecheck`: core, opencode, tui passed
- commit/push hooks: 29-package turbo typecheck passed
- production build and Darwin ARM64 binary smoke test passed
- OpenSpec `atomic-dag-wake`: strict valid, 15/15 tasks complete (local ignored artifacts)
- final Spec and Standards reviews: no findings

## Manual reproduction

A/B parallel workflow completed with overlap; aggregate scheduling began immediately after the second dependency completed, with one terminal parent wake and no status-poll loop.