### PR TITLE
fix(dag): apply workflow defaults and repair inspector

### DIFF
--- a/packages/core/src/plugin/command/dag-flow.txt
+++ b/packages/core/src/plugin/command/dag-flow.txt
@@ -16,5 +16,7 @@ For a non-empty task:
 4. On success, report the exact Workflow ID and initial state returned by the tool, then tell the user to run `/dag` for live inspection.
 5. The workflow runs asynchronously and wakes this parent session when attention or a terminal result is ready. Do not poll it with `action=status`, sleep, retry, or loop merely to wait. End the current response after the brief success report.
 6. On failure, state that the workflow was not started and report the actual error. Never invent a Workflow ID.
+7. Do not start replacement workflows merely to repair an orchestration mistake. Report the failure and its exact cause unless the user explicitly asked for automatic retries.
+8. A completed aggregate node must actually contain the requested synthesis. Never describe unresolved placeholders or an aggregate-node error message as a successful final result.
 
 Use the orchestration guidance below to design and manage the workflow.

--- a/packages/core/src/plugin/command/workflow.md
+++ b/packages/core/src/plugin/command/workflow.md
@@ -135,6 +135,52 @@ Phase 5 (expand? iterate? complete?)
 
 Not every task needs all five phases. A well-specified task may skip directly to Phase 3. A task with a clear design but uncertain scope may start at Phase 2. The lifecycle is a decision tree, not a pipeline.
 
+## Node inputs and model selection
+
+Every node automatically receives the outputs of its direct `depends_on` nodes:
+
+- The exact dependency ID is the default template variable. A node with `depends_on: [node-a, node-b]` can use `{{node-a}}` and `{{node-b}}` directly.
+- The same values are appended to the child prompt as structured context, so a downstream node can aggregate them without interpolation.
+- Use `input_mapping` only to rename a variable or select a field. Its direction is **template variable → upstream source**, for example:
+
+```yaml
+input_mapping:
+  resultA: node-a
+  resultB: node-b
+  count: node-c.output.count
+prompt_template:
+  inline: "Summarize {{resultA}}, {{resultB}}, and count={{count}}."
+```
+
+Put shared node defaults in the workflow's `config.node_defaults`. Every node
+inherits omitted values from this durable workflow config, while an explicit
+node value wins:
+
+```yaml
+node_defaults:
+  required: false
+  report_to_parent: false
+  worker_config:
+    timeout_ms: 600000
+  model:
+    providerID: local-proxy-compatible
+    modelID: glm-5.2
+```
+
+This is the preferred place for a workflow-wide model. If both the node and
+`config.node_defaults.model` omit it, resolution continues to the selected
+agent model and then the parent session model.
+
+When overriding a model, split the provider and provider-local model ID:
+
+```yaml
+model:
+  providerID: local-proxy-compatible
+  modelID: glm-5.2
+```
+
+Do not put `local-proxy-compatible/glm-5.2` into `modelID` while also setting `providerID`; that repeats the provider prefix.
+
 ## Collaboration Patterns
 
 Four structural patterns cover the common cases. Real workflows often combine them.

--- a/packages/opencode/src/dag/dag.ts
+++ b/packages/opencode/src/dag/dag.ts
@@ -29,6 +29,15 @@ export type ID = typeof ID.Type
 export const NodeID = DagEvent.NodeID
 export type NodeID = typeof NodeID.Type
 
+export const DEFAULT_WORKFLOW_CONFIG = {
+  maxConcurrency: 5,
+  maxNodeReplanAttempts: 5,
+  maxTotalNodes: 100,
+  nodeTimeoutMs: 10 * 60 * 1000,
+  nodeRequired: false,
+  reportToParent: false,
+} as const
+
 /** A node as declared in the workflow's YAML config. */
 export interface NodeConfig {
   id: string
@@ -47,12 +56,70 @@ export interface NodeConfig {
   output_schema?: Record<string, unknown>
 }
 
+export interface NodeDefaults {
+  required?: boolean
+  worker_config?: { timeout_ms?: number }
+  report_to_parent?: boolean
+  model?: { modelID: string; providerID: string }
+}
+
 export interface WorkflowConfig {
   name: string
   max_concurrency?: number
   max_node_replan_attempts?: number
   max_total_nodes?: number
+  node_defaults?: NodeDefaults
   nodes: NodeConfig[]
+}
+
+export function normalizeModel(model: NodeConfig["model"]) {
+  if (!model) return undefined
+  const prefix = `${model.providerID}/`
+  if (!model.modelID.startsWith(prefix)) return model
+  const modelID = model.modelID.slice(prefix.length)
+  if (!modelID) return model
+  return {
+    ...model,
+    modelID,
+  }
+}
+
+function normalizeNodeDefaults(defaults: NodeDefaults | undefined): NodeDefaults {
+  return {
+    required: defaults?.required ?? DEFAULT_WORKFLOW_CONFIG.nodeRequired,
+    worker_config: {
+      timeout_ms: defaults?.worker_config?.timeout_ms ?? DEFAULT_WORKFLOW_CONFIG.nodeTimeoutMs,
+    },
+    report_to_parent: defaults?.report_to_parent ?? DEFAULT_WORKFLOW_CONFIG.reportToParent,
+    ...(defaults?.model ? { model: normalizeModel(defaults.model) } : {}),
+  }
+}
+
+function normalizeNodeConfig(node: NodeConfig, defaults: NodeDefaults): NodeConfig {
+  const model = normalizeModel(node.model ?? defaults.model)
+  return {
+    ...node,
+    required: node.required ?? defaults.required ?? DEFAULT_WORKFLOW_CONFIG.nodeRequired,
+    worker_config: {
+      ...defaults.worker_config,
+      ...node.worker_config,
+      timeout_ms: node.worker_config?.timeout_ms ?? defaults.worker_config?.timeout_ms ?? DEFAULT_WORKFLOW_CONFIG.nodeTimeoutMs,
+    },
+    report_to_parent: node.report_to_parent ?? defaults.report_to_parent ?? DEFAULT_WORKFLOW_CONFIG.reportToParent,
+    ...(model ? { model } : {}),
+  }
+}
+
+function normalizeWorkflowConfig(config: WorkflowConfig): WorkflowConfig {
+  const defaults = normalizeNodeDefaults(config.node_defaults)
+  return {
+    ...config,
+    max_concurrency: config.max_concurrency ?? DEFAULT_WORKFLOW_CONFIG.maxConcurrency,
+    max_node_replan_attempts: config.max_node_replan_attempts ?? DEFAULT_WORKFLOW_CONFIG.maxNodeReplanAttempts,
+    max_total_nodes: config.max_total_nodes ?? DEFAULT_WORKFLOW_CONFIG.maxTotalNodes,
+    node_defaults: defaults,
+    nodes: config.nodes.map((node) => normalizeNodeConfig(node, defaults)),
+  }
 }
 
 /**
@@ -126,9 +193,6 @@ export interface Interface {
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/Dag") {}
 
-const DEFAULT_MAX_NODE_REPLAN_ATTEMPTS = 5
-const DEFAULT_MAX_TOTAL_NODES = 100
-
 export const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
@@ -174,8 +238,9 @@ export const layer = Layer.effect(
       title: string
       config: WorkflowConfig
     }) {
+      const config = normalizeWorkflowConfig(input.config)
       const validation = validateRequiredNodes({
-        nodes: input.config.nodes.map((n) => ({ id: n.id, depends_on: n.depends_on, required: n.required })),
+        nodes: config.nodes.map((n) => ({ id: n.id, depends_on: n.depends_on, required: n.required })),
       })
       if (!validation.valid) return yield* Effect.fail(new Error(`Invalid workflow config: ${validation.errors.join("; ")}`))
 
@@ -185,7 +250,7 @@ export const layer = Layer.effect(
       const cyclePath: string[] | null = yield* Effect.sync(() => {
         try {
           const graph = buildGraph(
-            input.config.nodes.map((n) => ({ id: n.id, dependsOn: n.depends_on, status: "pending" as const, required: n.required })),
+            config.nodes.map((n) => ({ id: n.id, dependsOn: n.depends_on, status: "pending" as const, required: n.required })),
           )
           return graph.hasCycle() ? (graph.findCycles()[0] ?? null) : null
         } catch (e) {
@@ -204,11 +269,11 @@ export const layer = Layer.effect(
         projectID: input.projectID as never,
         sessionID: input.sessionID as never,
         title: input.title,
-        config: JSON.stringify(input.config),
+        config: JSON.stringify(config),
         status: "pending",
         timestamp: ts,
       })
-      for (const node of input.config.nodes) {
+      for (const node of config.nodes) {
         yield* events.publish(DagEvent.NodeRegistered, {
           dagID,
           nodeID: node.id as never,
@@ -256,7 +321,7 @@ export const layer = Layer.effect(
               : ("pending" as const),
       }))
       const config = parseWorkflowConfig((yield* store.getWorkflow(dagID))?.config ?? "")
-      const maxConcurrency = Math.max(1, config?.max_concurrency ?? 5)
+      const maxConcurrency = Math.max(1, config?.max_concurrency ?? DEFAULT_WORKFLOW_CONFIG.maxConcurrency)
       const runtime = new WorkflowRuntime(schedulingNodes, maxConcurrency)
       const ready = runtime.getReadyNodes()
       if (ready.length === 0) return { status: "no_ready_nodes" as const }
@@ -313,16 +378,18 @@ export const layer = Layer.effect(
 
     const _replan = Effect.fn("Dag._replan")(function* (dagID: string, fragment: { nodes: NodeConfig[] }) {
       const wf = yield* guardWorkflowNotTerminal(dagID, "replan")
+      const wfConfig = parseWorkflowConfig(wf.config)
+      const defaults = normalizeNodeDefaults(wfConfig?.node_defaults)
+      const normalizedFragment = { nodes: fragment.nodes.map((node) => normalizeNodeConfig(node, defaults)) }
       const nodes = yield* store.getNodes(dagID)
       const plan = planReplan(
         { nodes: nodes.map((n) => ({ id: n.id, status: n.status as never, depends_on: n.dependsOn })) },
-        { nodes: fragment.nodes.map((n) => ({ id: n.id, depends_on: n.depends_on, restart: n.restart, cancel: n.cancel })) },
+        { nodes: normalizedFragment.nodes.map((n) => ({ id: n.id, depends_on: n.depends_on, restart: n.restart, cancel: n.cancel })) },
       )
       if (plan.errors.length > 0) return yield* Effect.fail(new Error(`Replan rejected: ${plan.errors.join("; ")}`))
 
-      const wfConfig = parseWorkflowConfig(wf.config)
-      const maxReplanAttempts = wfConfig?.max_node_replan_attempts ?? DEFAULT_MAX_NODE_REPLAN_ATTEMPTS
-      const maxTotalNodes = wfConfig?.max_total_nodes ?? DEFAULT_MAX_TOTAL_NODES
+      const maxReplanAttempts = wfConfig?.max_node_replan_attempts ?? DEFAULT_WORKFLOW_CONFIG.maxNodeReplanAttempts
+      const maxTotalNodes = wfConfig?.max_total_nodes ?? DEFAULT_WORKFLOW_CONFIG.maxTotalNodes
 
       // Enforce total node ceiling BEFORE any event publication so a rejected
       // replan leaves no durable side effects. Count ALL nodes ever registered
@@ -342,7 +409,7 @@ export const layer = Layer.effect(
       }
       const effectiveRestart = plan.restart.filter((id) => !ceilingBreached.includes(id))
 
-      const fragmentById = new Map(fragment.nodes.map((n) => [n.id, n]))
+      const fragmentById = new Map(normalizedFragment.nodes.map((n) => [n.id, n]))
       for (const id of plan.add) {
         const node = fragmentById.get(id)!
         yield* events.publish(DagEvent.NodeRegistered, {
@@ -393,7 +460,7 @@ export const layer = Layer.effect(
 
       // Persist the merged config using the effective plan (without ceiling-breached restarts)
       if (wfConfig) {
-        const mergedConfig = computeMergedConfig(wfConfig, fragment, effectivePlan)
+        const mergedConfig = computeMergedConfig(wfConfig, normalizedFragment, effectivePlan)
         yield* events.publish(DagEvent.WorkflowConfigUpdated, {
           dagID: dagID as ID,
           config: JSON.stringify(mergedConfig),

--- a/packages/opencode/src/dag/runtime/loop.ts
+++ b/packages/opencode/src/dag/runtime/loop.ts
@@ -102,9 +102,10 @@ export const layer = Layer.effect(
             const promptParts: { type: "text"; text: string }[] = []
 
             let resolvedMapping: Record<string, unknown> = {}
-            if (nodeConfig?.input_mapping) {
+            const inputMapping = nodeConfig?.input_mapping ?? Object.fromEntries(node.dependsOn.map((dependency) => [dependency, dependency]))
+            if (Object.keys(inputMapping).length > 0) {
               const allNodes = yield* store.getNodes(dagID)
-              resolvedMapping = resolveInputMapping(nodeConfig.input_mapping, (depId) => {
+              resolvedMapping = resolveInputMapping(inputMapping, (depId) => {
                 const depNode = allNodes.find((n) => n.id === depId)
                 return depNode?.output ?? null
               })
@@ -143,6 +144,19 @@ export const layer = Layer.effect(
               if (value !== null && value !== undefined) {
                 promptText = promptText.replaceAll(`{{${key}}}`, String(value))
               }
+            }
+
+            const unresolvedPlaceholders = [...promptText.matchAll(/{{\s*([^{}]+?)\s*}}/g)]
+              .map((match) => match[1])
+            if (unresolvedPlaceholders.length > 0) {
+              yield* dag.nodeFailed(
+                dagID,
+                nodeID,
+                `Unresolved template placeholders: ${unresolvedPlaceholders.join(", ")}`,
+                "verdict_fail",
+              ).pipe(Effect.ignore)
+              entry.runtime.markUnsatisfied(nodeID)
+              continue
             }
 
             promptParts.push({ type: "text", text: promptText })
@@ -224,7 +238,7 @@ export const layer = Layer.effect(
             })
           }
           const nodes = yield* store.getNodes(dagID)
-          const maxConcurrency = Math.max(1, config?.max_concurrency ?? 5)
+          const maxConcurrency = Math.max(1, config?.max_concurrency ?? Dag.DEFAULT_WORKFLOW_CONFIG.maxConcurrency)
           const runtime = new WorkflowRuntime(toSchedulingNodes(nodes), maxConcurrency)
           const semaphore = Semaphore.makeUnsafe(maxConcurrency)
           const isPaused = wf.status === "paused"
@@ -255,7 +269,7 @@ export const layer = Layer.effect(
               if (!wf) return
               const config = parseWorkflowConfig(wf.config)
               const nodes = yield* store.getNodes(dagID)
-              const maxConcurrency = Math.max(1, config?.max_concurrency ?? 5)
+              const maxConcurrency = Math.max(1, config?.max_concurrency ?? Dag.DEFAULT_WORKFLOW_CONFIG.maxConcurrency)
               const runtime = new WorkflowRuntime(toSchedulingNodes(nodes), maxConcurrency)
               const semaphore = Semaphore.makeUnsafe(maxConcurrency)
               const entry: WorkflowEntry = { runtime, semaphore, evalLock: Semaphore.makeUnsafe(1), parentSessionID: wf.sessionId, config, fibers: new Map() }

--- a/packages/opencode/src/dag/runtime/spawn.ts
+++ b/packages/opencode/src/dag/runtime/spawn.ts
@@ -27,9 +27,6 @@ import { registerCaptureSlot, clearCaptureSlot } from "./capture"
 
 type PromptParts = SessionPrompt.PromptInput["parts"]
 
-/** System-wide default node timeout (10 minutes) when worker_config.timeout_ms is omitted. */
-const DEFAULT_NODE_TIMEOUT_MS = 10 * 60 * 1000
-
 const isTransitionRejection = (err: unknown): err is InvalidTransitionError | TerminalViolationError =>
   err instanceof InvalidTransitionError || err instanceof TerminalViolationError
 
@@ -68,18 +65,28 @@ export function spawnNode(
       return yield* Effect.fail(new Error(`Unknown worker_type: ${input.node.workerType}`))
     }
 
-    const nodeModel =
+    const parent = yield* sessions.get(SessionID.make(input.parentSessionID))
+    const persistedNodeModel =
       input.node.modelId && input.node.modelProviderId
-        ? { modelID: input.node.modelId as never, providerID: input.node.modelProviderId as never }
+        ? Dag.normalizeModel({
+            modelID: input.node.modelId,
+            providerID: input.node.modelProviderId,
+          })
         : undefined
+    const nodeModel = persistedNodeModel
+      ? {
+          modelID: persistedNodeModel.modelID as never,
+          providerID: persistedNodeModel.providerID as never,
+        }
+      : undefined
     const model = nodeModel
       ?? (agent.model ? { modelID: agent.model.modelID, providerID: agent.model.providerID } : undefined)
+      ?? (parent.model ? { modelID: parent.model.id, providerID: parent.model.providerID } : undefined)
     if (!model) {
       yield* dag.nodeFailed(input.dagID, input.nodeID, `no model configured for agent: ${agent.name}`, "exec_failed")
       return yield* Effect.fail(new Error(`No model configured for agent: ${agent.name}`))
     }
 
-    const parent = yield* sessions.get(SessionID.make(input.parentSessionID))
     const childPermission = deriveSubagentSessionPermission({
       parentSessionPermission: parent.permission ?? [],
       subagent: agent,
@@ -89,6 +96,7 @@ export function spawnNode(
       parentID: SessionID.make(input.parentSessionID),
       title: `${input.node.name} (DAG node)`,
       agent: agent.name,
+      model: { id: model.modelID, providerID: model.providerID },
       permission: childPermission,
     })
 
@@ -97,7 +105,7 @@ export function spawnNode(
     // can inherit it. The actual timeout race uses the REMAINING time from
     // when the semaphore permit is acquired — queue wait counts toward the
     // deadline, preventing a node that queued past its deadline from running.
-    const timeoutMs = input.timeoutMs ?? DEFAULT_NODE_TIMEOUT_MS
+    const timeoutMs = input.timeoutMs ?? Dag.DEFAULT_WORKFLOW_CONFIG.nodeTimeoutMs
     const spawnTime = yield* Clock.currentTimeMillis
     const deadlineMs = spawnTime + timeoutMs
 
@@ -201,6 +209,20 @@ export function spawnNode(
             }
           } else {
             const rawText = resultOpt.value.parts.findLast((p) => p.type === "text")?.text ?? ""
+            if (rawText.trim() === "") {
+              yield* dag.nodeFailed(
+                input.dagID,
+                input.nodeID,
+                "provider returned empty output",
+                "verdict_fail",
+              ).pipe(
+                Effect.catchIf(
+                  isTransitionRejection,
+                  () => Effect.logWarning("nodeFailed (empty output) guard rejected — node already terminal"),
+                ),
+              )
+              return
+            }
             yield* dag.nodeCompleted(input.dagID, input.nodeID, rawText).pipe(
               Effect.catchIf(
                 isTransitionRejection,

--- a/packages/opencode/src/tool/workflow.ts
+++ b/packages/opencode/src/tool/workflow.ts
@@ -17,24 +17,31 @@ const NodeSchema = Schema.Struct({
   name: Schema.String.annotate({ description: "Human-readable node name" }),
   worker_type: Schema.String.annotate({ description: "Agent type (explore, build, general, plan, or custom)" }),
   depends_on: Schema.Array(Schema.String).annotate({ description: "Node IDs this node waits for ([] for root)" }),
-  required: Schema.Boolean.pipe(
-    Schema.optional,
-    Schema.withDecodingDefaultType(Effect.succeed(false)),
-  ).annotate({ description: "If true and this node fails, the workflow is cancelled. Default: false" }),
+  required: Schema.optional(Schema.Boolean).annotate({
+    description: "If true and this node fails, the workflow is cancelled. Inherits config.node_defaults.required",
+  }),
   prompt_template: Schema.Struct({
     id: Schema.optional(Schema.String),
     inline: Schema.optional(Schema.String),
     input: Schema.optional(Schema.Record(Schema.String, Schema.Unknown)),
-  }).annotate({ description: 'Template: { id: "..." } or { inline: "...", input: {...} }' }),
+  }).annotate({
+    description: 'Template: { id: "..." } or { inline: "...", input: {...} }. Direct dependency outputs are available as {{node-id}} by default',
+  }),
   worker_config: Schema.optional(
     Schema.Struct({
       timeout_ms: Schema.optional(Schema.Number),
     }),
-  ).annotate({ description: "{ timeout_ms } — bounds node execution (defaults to 10 minutes)" }),
-  input_mapping: Schema.optional(Schema.Record(Schema.String, Schema.String)).annotate({ description: "Map upstream node outputs into template variables" }),
-  report_to_parent: Schema.optional(Schema.Boolean).annotate({ description: "If true, the parent agent is woken when this node completes or fails" }),
+  ).annotate({ description: "{ timeout_ms } — bounds node execution. Inherits config.node_defaults.worker_config" }),
+  input_mapping: Schema.optional(Schema.Record(Schema.String, Schema.String)).annotate({
+    description: 'Optional variable-to-source map, e.g. { resultA: "node-a", count: "node-b.output.count" }. Omit to expose each direct dependency under its node ID',
+  }),
+  report_to_parent: Schema.optional(Schema.Boolean).annotate({
+    description: "If true, the parent agent is woken when this node completes or fails. Inherits config.node_defaults.report_to_parent",
+  }),
   condition: Schema.optional(Schema.String).annotate({ description: "Expression evaluated before spawn; node is skipped if false" }),
-  model: Schema.optional(Schema.Struct({ modelID: Schema.String, providerID: Schema.String })).annotate({ description: "{ modelID, providerID } override for this node" }),
+  model: Schema.optional(Schema.Struct({ modelID: Schema.String, providerID: Schema.String })).annotate({
+    description: 'Optional node override. modelID is provider-local, e.g. { providerID: "local-proxy-compatible", modelID: "glm-5.2" }, never repeat providerID inside modelID. Omit to inherit config.node_defaults.model, then the agent or parent-session model',
+  }),
   restart: Schema.optional(Schema.Boolean).annotate({ description: "(replan only) Re-spawn this running node with new prompt" }),
   cancel: Schema.optional(Schema.Boolean).annotate({ description: "(replan only) Cancel this node" }),
   output_schema: Schema.optional(Schema.Record(Schema.String, Schema.Unknown)).annotate({ description: "JSON Schema; child agent must call submit_result to submit structured output" }),
@@ -42,6 +49,25 @@ const NodeSchema = Schema.Struct({
 
 const WorkflowGraphSchema = Schema.Struct({
   name: Schema.String.annotate({ description: "Workflow name" }),
+  node_defaults: Schema.optional(
+    Schema.Struct({
+      required: Schema.optional(Schema.Boolean),
+      worker_config: Schema.optional(
+        Schema.Struct({
+          timeout_ms: Schema.optional(Schema.Number),
+        }),
+      ),
+      report_to_parent: Schema.optional(Schema.Boolean),
+      model: Schema.optional(
+        Schema.Struct({
+          modelID: Schema.String,
+          providerID: Schema.String,
+        }),
+      ),
+    }),
+  ).annotate({
+    description: "Defaults inherited by nodes that omit required, worker_config, report_to_parent, or model",
+  }),
   max_concurrency: Schema.optional(Schema.Number).annotate({ description: "Max parallel nodes. Default: 5" }),
   max_node_replan_attempts: Schema.optional(Schema.Number).annotate({ description: "Max replan restarts per node ID. Default: 5" }),
   max_total_nodes: Schema.optional(Schema.Number).annotate({ description: "Cumulative node cap across the workflow lifetime. Default: 100" }),

--- a/packages/opencode/test/dag/dag-wake-integration.test.ts
+++ b/packages/opencode/test/dag/dag-wake-integration.test.ts
@@ -21,6 +21,7 @@ import { pollWithTimeout } from "../lib/effect"
 
 interface PromptGate {
   readonly title: string
+  readonly input: SessionPrompt.PromptInput
   readonly release: Deferred.Deferred<string>
 }
 
@@ -125,6 +126,7 @@ function wakeLayer(input: {
     const release = yield* Deferred.make<string>()
     yield* Queue.offer(input.childPrompts, {
       title: childTitles.get(sessionID) ?? sessionID,
+      input: value,
       release,
     })
     return reply(sessionID, yield* Deferred.await(release))
@@ -209,6 +211,82 @@ function runWakeTest<A>(
 }
 
 describe("DagLoop atomic wake integration", () => {
+  it("injects direct dependency outputs into an aggregate node by default", async () => {
+    await Effect.runPromise(
+      runWakeTest(({ dag, childPrompts }) =>
+        Effect.gen(function* () {
+          yield* dag.create({
+            projectID: "project-1",
+            sessionID: "ses_parent",
+            title: "Default aggregate inputs",
+            config: {
+              name: "default-aggregate-inputs",
+              nodes: [
+                node("node-a"),
+                node("node-b"),
+                {
+                  ...node("summary", ["node-a", "node-b"]),
+                  prompt_template: { inline: "汇总结果：{{node-a}} 和 {{node-b}}" },
+                },
+              ],
+            },
+          })
+
+          const first = yield* takeWithin(childPrompts, "first parallel node did not start")
+          const second = yield* takeWithin(childPrompts, "second parallel node did not start")
+          const roots = new Map([first, second].map((item) => [item.title, item]))
+          yield* Deferred.succeed(roots.get("node-a")!.release, "A")
+          yield* Deferred.succeed(roots.get("node-b")!.release, "B")
+
+          const summary = yield* takeWithin(childPrompts, "summary node did not start")
+          expect(summary.title).toBe("summary")
+          expect(promptText(summary.input)).toContain("汇总结果：A 和 B")
+          expect(promptText(summary.input)).not.toContain("{{node-a}}")
+          expect(promptText(summary.input)).not.toContain("{{node-b}}")
+          yield* Deferred.succeed(summary.release, "A and B")
+        }),
+      ),
+    )
+  })
+
+  it("fails an aggregate node before execution when template placeholders remain unresolved", async () => {
+    await Effect.runPromise(
+      runWakeTest(({ dag, store, childPrompts }) =>
+        Effect.gen(function* () {
+          const dagID = yield* dag.create({
+            projectID: "project-1",
+            sessionID: "ses_parent",
+            title: "Unresolved aggregate input",
+            config: {
+              name: "unresolved-aggregate-input",
+              nodes: [
+                node("node-a"),
+                {
+                  ...node("summary", ["node-a"]),
+                  input_mapping: {},
+                  prompt_template: { inline: "汇总结果：{{node-a}}" },
+                },
+              ],
+            },
+          })
+
+          const root = yield* takeWithin(childPrompts, "root node did not start")
+          yield* Deferred.succeed(root.release, "A")
+
+          yield* pollWithTimeout(
+            store.getNode(dagID, "summary").pipe(
+              Effect.map((item) => item?.status === "failed" ? item : undefined),
+            ),
+            "summary node did not fail",
+          )
+          const summary = yield* store.getNode(dagID, "summary")
+          expect(summary?.errorReason).toContain("Unresolved template placeholders")
+          expect(yield* Queue.poll(childPrompts)).toEqual(Option.none())
+        }),
+      ),
+    )
+  })
+
   it("does not block a second workflow's downstream scheduling on a parent wake", async () => {
     await Effect.runPromise(
       runWakeTest(({ dag, childPrompts, parentPrompts }) =>

--- a/packages/opencode/test/dag/spawn-completion.test.ts
+++ b/packages/opencode/test/dag/spawn-completion.test.ts
@@ -101,6 +101,89 @@ function findEvent(events: TrackedEvent[], type: string) {
 }
 
 describe("spawnNode completion bridge", () => {
+  it("inherits the parent session model when the node and agent omit one", async () => {
+    const { events, dagLayer } = makeEventTracker()
+    let promptModel: SessionPrompt.PromptInput["model"]
+    const agentWithoutModel = Layer.mock(Agent.Service, {
+      get: () =>
+        Effect.succeed({
+          name: "general",
+          mode: "all",
+          permission: [],
+          options: {},
+          description: "",
+          prompt: "",
+          tools: {},
+          hooks: {},
+        }),
+    })
+    const parentWithModel = Layer.mock(Session.Service, {
+      get: () =>
+        Effect.succeed({
+          id: "ses_parent",
+          permission: [],
+          agent: "build",
+          model: { providerID: "local-proxy-compatible", id: "glm-5.2" },
+        } as never),
+      create: () => Effect.succeed({ id: "ses_child" as never } as never),
+    })
+    const prompt = Layer.mock(SessionPrompt.Service, {
+      prompt: (input) =>
+        Effect.sync(() => {
+          promptModel = input.model
+          return reply("done")
+        }),
+    })
+
+    await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const result = yield* spawnNode(Semaphore.makeUnsafe(1), makeSpawnInput())
+          yield* Fiber.await(result.fiber)
+        }),
+      ).pipe(Effect.provide(Layer.mergeAll(dagLayer, agentWithoutModel, parentWithModel, prompt))) as Effect.Effect<never>,
+    )
+
+    expect(promptModel as unknown).toEqual({
+      providerID: "local-proxy-compatible",
+      modelID: "glm-5.2",
+    })
+    expect(findEvent(events, "nodeCompleted")).toBeDefined()
+  })
+
+  it("canonicalizes a provider-qualified model from a persisted node", async () => {
+    const { events, dagLayer } = makeEventTracker()
+    let promptModel: SessionPrompt.PromptInput["model"]
+    const prompt = Layer.mock(SessionPrompt.Service, {
+      prompt: (input) =>
+        Effect.sync(() => {
+          promptModel = input.model
+          return reply("done")
+        }),
+    })
+
+    await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const result = yield* spawnNode(Semaphore.makeUnsafe(1), {
+            ...makeSpawnInput(),
+            node: makeNodeRow({
+              modelId: "local-proxy-compatible/glm-5.2",
+              modelProviderId: "local-proxy-compatible",
+            }),
+          })
+          yield* Fiber.await(result.fiber)
+        }),
+      ).pipe(Effect.provide(Layer.mergeAll(dagLayer, agentLayer, sessionLayer, prompt))) as Effect.Effect<never>,
+    )
+
+    expect(promptModel as unknown).toEqual({
+      providerID: "local-proxy-compatible",
+      modelID: "glm-5.2",
+    })
+    expect(findEvent(events, "nodeCompleted")).toBeDefined()
+  })
+
   it("publishes NodeCompleted with output text on success", async () => {
     const { events, dagLayer } = makeEventTracker()
     await runSpawn(dagLayer, makePromptLayer(reply("Task completed successfully")))
@@ -113,13 +196,12 @@ describe("spawnNode completion bridge", () => {
     expect(started).toBeDefined()
   })
 
-  it("publishes NodeCompleted with empty output when no text part", async () => {
+  it("publishes NodeFailed when the provider returns no text output", async () => {
     const { events, dagLayer } = makeEventTracker()
     await runSpawn(dagLayer, makePromptLayer(reply("")))
 
-    const completed = findEvent(events, "nodeCompleted")
-    expect(completed).toBeDefined()
-    expect(completed!.output).toBe("")
+    expect(findEvent(events, "nodeCompleted")).toBeUndefined()
+    expect(findEvent(events, "nodeFailed")?.reason).toContain("empty output")
   })
 
   it("publishes NodeFailed when prompt fails", async () => {

--- a/packages/opencode/test/dag/workflow-tool.test.ts
+++ b/packages/opencode/test/dag/workflow-tool.test.ts
@@ -32,11 +32,42 @@ const store = Layer.mock(DagStore.Service, {
             timeCreated: 1,
             timeUpdated: 2,
           }
+        : id === "dag_defaults"
+          ? {
+              id,
+              projectId: projectID,
+              sessionId: "ses_workflow_parent",
+              title: "Configured defaults",
+              status: "running",
+              config: JSON.stringify({
+                name: "configured-defaults",
+                node_defaults: {
+                  required: true,
+                  report_to_parent: true,
+                  worker_config: { timeout_ms: 1234 },
+                  model: {
+                    providerID: "local-proxy-compatible",
+                    modelID: "local-proxy-compatible/glm-5.2",
+                  },
+                },
+                max_concurrency: 5,
+                max_node_replan_attempts: 5,
+                max_total_nodes: 100,
+                nodes: [],
+              }),
+              seq: 1,
+              wakeReported: false,
+              startedAt: 1,
+              completedAt: null,
+              timeCreated: 1,
+              timeUpdated: 2,
+            }
         : undefined,
     ),
-  getNodes: () =>
-    Effect.succeed([
-      {
+  getNodes: (id: string) =>
+    Effect.succeed(
+      id === "dag_status"
+        ? [{
         id: "node_running",
         workflowId: "dag_status",
         name: "Running node",
@@ -59,8 +90,9 @@ const store = Layer.mock(DagStore.Service, {
         completedAt: null,
         timeCreated: 1,
         timeUpdated: 2,
-      },
-    ]),
+          }]
+        : [],
+    ),
 })
 const events = Layer.mock(EventV2Bridge.Service, {
   publish: (definition, data) =>
@@ -137,12 +169,18 @@ describe("workflow tool schema (negative tests)", () => {
     expect(() => decode({ action: "control", workflow_id: "wf-1", operation: "start" })).toThrow()
   })
 
-  it("defaults an omitted node required flag to false", () => {
+  it("leaves omitted node defaults unresolved for the workflow config", () => {
     const decode = Schema.decodeUnknownSync(Parameters)
     const input = decode({
       action: "start",
       config: {
         name: "required-default",
+        node_defaults: {
+          required: true,
+          report_to_parent: true,
+          worker_config: { timeout_ms: 1234 },
+          model: { providerID: "configured", modelID: "configured/model" },
+        },
         nodes: [
           {
             id: "optional-node",
@@ -155,7 +193,13 @@ describe("workflow tool schema (negative tests)", () => {
       },
     })
 
-    expect(input.config?.nodes[0]?.required).toBe(false)
+    expect(input.config?.nodes[0]?.required).toBeUndefined()
+    expect(input.config?.node_defaults).toEqual({
+      required: true,
+      report_to_parent: true,
+      worker_config: { timeout_ms: 1234 },
+      model: { providerID: "configured", modelID: "configured/model" },
+    })
   })
 })
 
@@ -269,6 +313,254 @@ describe("workflow tool execution", () => {
 
       expect(published.find((event) => event.type === DagEvent.NodeRegistered.type)?.data).toEqual(
         expect.objectContaining({ required: false }),
+      )
+    }),
+  )
+
+  runtime.effect("start resolves omitted values from workflow config defaults", () =>
+    Effect.gen(function* () {
+      published.length = 0
+      const info = yield* WorkflowTool
+      const workflow = yield* info.init()
+
+      yield* workflow.execute(
+        {
+          action: "start",
+          config: {
+            name: "configured-defaults",
+            node_defaults: {
+              required: true,
+              report_to_parent: true,
+              worker_config: { timeout_ms: 1234 },
+              model: {
+                providerID: "local-proxy-compatible",
+                modelID: "local-proxy-compatible/glm-5.2",
+              },
+            },
+            nodes: [
+              {
+                id: "inherits",
+                name: "Inherits defaults",
+                worker_type: "general",
+                depends_on: [],
+                prompt_template: { inline: "work" },
+              },
+              {
+                id: "overrides",
+                name: "Overrides defaults",
+                worker_type: "general",
+                depends_on: [],
+                required: false,
+                report_to_parent: false,
+                worker_config: { timeout_ms: 4321 },
+                prompt_template: { inline: "work" },
+                model: { providerID: "other", modelID: "other-model" },
+              },
+            ],
+          },
+        },
+        {
+          sessionID: SessionID.make("ses_workflow_parent"),
+          messageID: MessageID.ascending(),
+          agent: "build",
+          abort: new AbortController().signal,
+          messages: [],
+          metadata: () => Effect.void,
+          ask: () => Effect.void,
+        } satisfies Tool.Context,
+      )
+
+      const created = published.find((event) => event.type === DagEvent.WorkflowCreated.type)?.data as {
+        config?: string
+      }
+      const config = JSON.parse(created.config ?? "{}")
+      expect(config).toEqual(
+        expect.objectContaining({
+          max_concurrency: 5,
+          max_node_replan_attempts: 5,
+          max_total_nodes: 100,
+        }),
+      )
+      expect(config.nodes[0]).toEqual(
+        expect.objectContaining({
+          required: true,
+          report_to_parent: true,
+          worker_config: { timeout_ms: 1234 },
+          model: { providerID: "local-proxy-compatible", modelID: "glm-5.2" },
+        }),
+      )
+      expect(config.nodes[1]).toEqual(
+        expect.objectContaining({
+          required: false,
+          report_to_parent: false,
+          worker_config: { timeout_ms: 4321 },
+          model: { providerID: "other", modelID: "other-model" },
+        }),
+      )
+    }),
+  )
+
+  runtime.effect("start canonicalizes a provider-qualified model ID", () =>
+    Effect.gen(function* () {
+      published.length = 0
+      const info = yield* WorkflowTool
+      const workflow = yield* info.init()
+
+      yield* workflow.execute(
+        {
+          action: "start",
+          config: {
+            name: "canonical-model",
+            nodes: [
+              {
+                id: "worker",
+                name: "Worker",
+                worker_type: "general",
+                depends_on: [],
+                prompt_template: { inline: "work" },
+                model: {
+                  providerID: "local-proxy-compatible",
+                  modelID: "local-proxy-compatible/glm-5.2",
+                },
+              },
+            ],
+          },
+        },
+        {
+          sessionID: SessionID.make("ses_workflow_parent"),
+          messageID: MessageID.ascending(),
+          agent: "build",
+          abort: new AbortController().signal,
+          messages: [],
+          metadata: () => Effect.void,
+          ask: () => Effect.void,
+        } satisfies Tool.Context,
+      )
+
+      expect(published.find((event) => event.type === DagEvent.NodeRegistered.type)?.data).toEqual(
+        expect.objectContaining({
+          model: {
+            providerID: "local-proxy-compatible",
+            modelID: "glm-5.2",
+          },
+        }),
+      )
+      const created = published.find((event) => event.type === DagEvent.WorkflowCreated.type)?.data as {
+        config?: string
+      }
+      expect(JSON.parse(created.config ?? "{}").nodes[0].model).toEqual({
+        providerID: "local-proxy-compatible",
+        modelID: "glm-5.2",
+      })
+    }),
+  )
+
+  runtime.effect("extend resolves new nodes from the persisted workflow defaults", () =>
+    Effect.gen(function* () {
+      published.length = 0
+      const info = yield* WorkflowTool
+      const workflow = yield* info.init()
+
+      yield* workflow.execute(
+        {
+          action: "extend",
+          workflow_id: "dag_defaults",
+          nodes: [
+            {
+              id: "added",
+              name: "Added node",
+              worker_type: "general",
+              depends_on: [],
+              prompt_template: { inline: "work" },
+            },
+          ],
+        },
+        {
+          sessionID: SessionID.make("ses_workflow_parent"),
+          messageID: MessageID.ascending(),
+          agent: "build",
+          abort: new AbortController().signal,
+          messages: [],
+          metadata: () => Effect.void,
+          ask: () => Effect.void,
+        } satisfies Tool.Context,
+      )
+
+      expect(published.find((event) => event.type === DagEvent.NodeRegistered.type)?.data).toEqual(
+        expect.objectContaining({
+          nodeID: "added",
+          required: true,
+          model: {
+            providerID: "local-proxy-compatible",
+            modelID: "glm-5.2",
+          },
+        }),
+      )
+      const updated = published.find((event) => event.type === DagEvent.WorkflowConfigUpdated.type)?.data as {
+        config?: string
+      }
+      expect(JSON.parse(updated.config ?? "{}").nodes[0]).toEqual(
+        expect.objectContaining({
+          report_to_parent: true,
+          worker_config: { timeout_ms: 1234 },
+        }),
+      )
+    }),
+  )
+
+  runtime.effect("replan resolves new nodes from the persisted workflow defaults", () =>
+    Effect.gen(function* () {
+      published.length = 0
+      const info = yield* WorkflowTool
+      const workflow = yield* info.init()
+
+      yield* workflow.execute(
+        {
+          action: "control",
+          workflow_id: "dag_defaults",
+          operation: "replan",
+          fragment: {
+            name: "replan-fragment",
+            nodes: [
+              {
+                id: "replanned",
+                name: "Replanned node",
+                worker_type: "general",
+                depends_on: [],
+                prompt_template: { inline: "work" },
+              },
+            ],
+          },
+        },
+        {
+          sessionID: SessionID.make("ses_workflow_parent"),
+          messageID: MessageID.ascending(),
+          agent: "build",
+          abort: new AbortController().signal,
+          messages: [],
+          metadata: () => Effect.void,
+          ask: () => Effect.void,
+        } satisfies Tool.Context,
+      )
+
+      expect(published.find((event) => event.type === DagEvent.NodeRegistered.type)?.data).toEqual(
+        expect.objectContaining({
+          nodeID: "replanned",
+          required: true,
+          model: {
+            providerID: "local-proxy-compatible",
+            modelID: "glm-5.2",
+          },
+        }),
+      )
+      const updated = published.find((event) => event.type === DagEvent.WorkflowConfigUpdated.type)?.data as {
+        config?: string
+      }
+      expect(JSON.parse(updated.config ?? "{}").nodes[0]).toEqual(
+        expect.objectContaining({
+          report_to_parent: true,
+          worker_config: { timeout_ms: 1234 },
+        }),
       )
     }),
   )

--- a/packages/tui/src/config/keybind.ts
+++ b/packages/tui/src/config/keybind.ts
@@ -76,7 +76,7 @@ export const Definitions = {
 
   dag_open: keybind("none", "Open DAG inspector"),
   dag_close: keybind("escape,q", "Close DAG inspector"),
-  dag_enter: keybind("enter", "Enter selected DAG node's session"),
+  dag_enter: keybind("return", "Enter selected DAG node's session"),
   dag_down: keybind("j,down", "Select next DAG node"),
   dag_up: keybind("k,up", "Select previous DAG node"),
   dag_next_workflow: keybind("l,right,tab", "Select next DAG workflow"),

--- a/packages/tui/src/feature-plugins/system/dag-inspector-utils.ts
+++ b/packages/tui/src/feature-plugins/system/dag-inspector-utils.ts
@@ -41,3 +41,29 @@ export function computeWaves(nodes: readonly DagNode[]): DagNode[][] {
   }
   return result
 }
+
+export function formatDagError(error: string) {
+  return error
+    .replace(/^Cause\(\[Die\((.*)\)\]\)$/, "$1")
+    .replace(/^ProviderModelNotFoundError:\s*/, "")
+}
+
+export type DagControlOperation = "pause" | "resume" | "cancel"
+
+export function dagControlUnavailableMessage(status: string | undefined, operation: DagControlOperation) {
+  const allowed =
+    operation === "pause"
+      ? status === "running" || status === "stepping"
+      : operation === "resume"
+        ? status === "paused" || status === "stepping"
+        : status === "running" || status === "stepping" || status === "paused"
+  if (allowed) return undefined
+  const action = operation === "pause" ? "paused" : operation === "resume" ? "resumed" : "cancelled"
+  return `Workflow is ${status ?? "unavailable"} and cannot be ${action}`
+}
+
+export function dagControlProgressMessage(operation: DagControlOperation) {
+  if (operation === "pause") return "Pausing workflow..."
+  if (operation === "resume") return "Resuming workflow..."
+  return "Cancelling workflow..."
+}

--- a/packages/tui/src/feature-plugins/system/dag-inspector.tsx
+++ b/packages/tui/src/feature-plugins/system/dag-inspector.tsx
@@ -5,7 +5,14 @@ import { createMemo, For, Show, createSignal, createEffect, onCleanup } from "so
 import { Spinner } from "../../component/spinner"
 import { TextAttributes } from "@opentui/core"
 import { useBindings, useCommandShortcut } from "../../keymap"
-import { computeWaves, type DagNode } from "./dag-inspector-utils"
+import {
+  computeWaves,
+  dagControlProgressMessage,
+  dagControlUnavailableMessage,
+  formatDagError,
+  type DagControlOperation,
+  type DagNode,
+} from "./dag-inspector-utils"
 import type { DagWorkflowSummary } from "@opencode-ai/sdk/v2"
 
 const id = "internal:system-dag-inspector"
@@ -23,6 +30,7 @@ function DagInspector(props: { api: TuiPluginApi }) {
   const [nodes, setNodes] = createSignal<DagNode[]>([])
   const [fetchedWorkflows, setFetchedWorkflows] = createSignal<ReadonlyArray<DagWorkflowSummary> | undefined>()
   const [workflowLoad, setWorkflowLoad] = createSignal<"loading" | "loaded" | "error">("loading")
+  const [actionMessage, setActionMessage] = createSignal<string | undefined>()
 
   const workflows = createMemo(() => {
     const sid = params()?.sessionID
@@ -45,6 +53,7 @@ function DagInspector(props: { api: TuiPluginApi }) {
     setSelectedWorkflow(undefined)
     setSelectedNode(undefined)
     setNodes([])
+    setActionMessage(undefined)
     setWorkflowLoad("loading")
     void props.api.client.dag
       .summary({ sessionID })
@@ -149,16 +158,30 @@ function DagInspector(props: { api: TuiPluginApi }) {
     setSelectedWorkflow(wfs[next]?.id)
   }
 
-  const control = (operation: "pause" | "resume" | "cancel") => {
+  const control = (operation: DagControlOperation) => {
     const wf = selectedWorkflow()
     if (!wf) return
+    const workflow = workflows().find((item) => item.id === wf)
+    const unavailable = dagControlUnavailableMessage(workflow?.status, operation)
+    if (unavailable) {
+      const message = unavailable
+      setActionMessage(message)
+      props.api.ui.toast({ variant: "info", message })
+      return
+    }
+    setActionMessage(dagControlProgressMessage(operation))
     void props.api.client.dag
       .control({ dagID: wf, operation })
-      .then(() => fetchNodes(wf))
+      .then(() => {
+        setActionMessage(`Workflow ${operation} requested`)
+        return fetchNodes(wf)
+      })
       .catch((error: unknown) => {
+        const message = `DAG ${operation} failed: ${error instanceof Error ? error.message : String(error)}`
+        setActionMessage(message)
         props.api.ui.toast({
           variant: "error",
-          message: `DAG ${operation} failed: ${error instanceof Error ? error.message : String(error)}`,
+          message,
         })
       })
   }
@@ -167,7 +190,9 @@ function DagInspector(props: { api: TuiPluginApi }) {
     const node = orderedNodes().find((n) => n.id === selectedNode())
     if (!node) return
     if (!node.child_session_id) {
-      props.api.ui.toast({ variant: "info", message: "Node has no session yet" })
+      const message = "Node has no session yet"
+      setActionMessage(message)
+      props.api.ui.toast({ variant: "info", message })
       return
     }
     props.api.ui.dialog.clear()
@@ -275,11 +300,11 @@ function DagInspector(props: { api: TuiPluginApi }) {
   }
 
   return (
-    <box flexDirection="column" width="100%" height="100%">
-      <box flexDirection="row" width="100%" flexGrow={1}>
+    <box flexDirection="column" width="100%" height="100%" padding={1} gap={1}>
+      <box flexDirection="row" width="100%" flexGrow={1} minHeight={0} gap={1}>
         {/* Left column: workflow list */}
-        <box width="30%" border={["right"]} borderColor={theme().background}>
-          <box flexDirection="column" padding={1}>
+        <box width="30%" minWidth={24} border={["right"]} borderColor={theme().borderSubtle}>
+          <box flexDirection="column" paddingRight={1}>
             <text fg={theme().text} attributes={TextAttributes.BOLD}>
               Workflows
             </text>
@@ -312,7 +337,7 @@ function DagInspector(props: { api: TuiPluginApi }) {
         </box>
 
         {/* Right column: node tree in topological waves */}
-        <box flexGrow={1} padding={1}>
+        <box flexGrow={1} minWidth={0} paddingLeft={1}>
           <Show
             when={selectedWorkflow()}
             fallback={
@@ -330,6 +355,11 @@ function DagInspector(props: { api: TuiPluginApi }) {
                 {workflows().find((w) => w.id === selectedWorkflow())?.title ?? "Unknown"}
               </text>
               <text fg={theme().textMuted}>ID: {selectedWorkflow()}</text>
+              <Show when={actionMessage()}>
+                <text fg={theme().warning} wrapMode="word">
+                  {actionMessage()}
+                </text>
+              </Show>
 
               {/* Wave header: nodes at the same topological depth, NOT a barrier */}
               <For each={layers()}>
@@ -341,37 +371,41 @@ function DagInspector(props: { api: TuiPluginApi }) {
                     <For each={layer}>
                       {(node) => (
                         <box
-                          flexDirection="row"
-                          gap={1}
+                          flexDirection="column"
+                          width="100%"
                           onMouseUp={() => setSelectedNode(node.id)}
                           style={{ backgroundColor: selectedNode() === node.id ? theme().backgroundMenu : undefined }}
                         >
-                          <Show
-                            when={node.status !== "running"}
-                            fallback={<Spinner color={theme().textMuted} />}
-                          >
-                            <text
-                              flexShrink={0}
-                              style={{
-                                fg: statusColor(node.status),
-                              }}
+                          <box flexDirection="row" gap={1} width="100%">
+                            <Show
+                              when={node.status !== "running"}
+                              fallback={<Spinner color={theme().textMuted} />}
                             >
-                              •
+                              <text
+                                flexShrink={0}
+                                style={{
+                                  fg: statusColor(node.status),
+                                }}
+                              >
+                                •
+                              </text>
+                            </Show>
+                            <text fg={theme().text} wrapMode="word">
+                              {node.name}
                             </text>
-                          </Show>
-                          <text fg={theme().text} wrapMode="word">
-                            {node.name}
-                          </text>
-                          <text fg={theme().textMuted}>[{node.worker_type}]</text>
-                          <Show when={node.depends_on.length > 0}>
-                            <text fg={theme().textMuted}>
-                              [deps: {node.depends_on.join(", ")}]
-                            </text>
-                          </Show>
+                            <text fg={theme().textMuted}>[{node.worker_type}]</text>
+                            <Show when={node.depends_on.length > 0}>
+                              <text fg={theme().textMuted} wrapMode="word">
+                                [deps: {node.depends_on.join(", ")}]
+                              </text>
+                            </Show>
+                          </box>
                           <Show when={node.status === "failed" && node.error_reason}>
-                            <text fg={theme().error} wrapMode="word">
-                              ⚠ {node.error_reason}
-                            </text>
+                            <box paddingLeft={2} paddingRight={1}>
+                              <text fg={theme().error} wrapMode="word">
+                                ⚠ {formatDagError(node.error_reason!)}
+                              </text>
+                            </box>
                           </Show>
                         </box>
                       )}
@@ -385,7 +419,7 @@ function DagInspector(props: { api: TuiPluginApi }) {
       </box>
 
       {/* Footer: shortcut hints */}
-      <box flexDirection="row" gap={2} paddingLeft={1} flexShrink={0}>
+      <box flexDirection="row" gap={2} flexShrink={0}>
         <text fg={theme().textMuted}>↑/↓ node</text>
         <text fg={theme().textMuted}>←/→ workflow</text>
         <Show when={enterShortcut()}>

--- a/packages/tui/test/feature-plugins/dag-inspector-utils.test.ts
+++ b/packages/tui/test/feature-plugins/dag-inspector-utils.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test"
-import { computeWaves, type DagNode } from "../../src/feature-plugins/system/dag-inspector-utils"
+import {
+  computeWaves,
+  dagControlProgressMessage,
+  dagControlUnavailableMessage,
+  formatDagError,
+  type DagNode,
+} from "../../src/feature-plugins/system/dag-inspector-utils"
 
 const node = (id: string, depends_on: string[] = [], name = id): DagNode => ({
   id,
@@ -45,5 +51,41 @@ describe("computeWaves", () => {
   test("dependency on a missing node is treated as satisfied (replan removed it)", () => {
     const waves = computeWaves([node("a", ["ghost"]), node("b", ["a"])])
     expect(waves.map((w) => w.map((n) => n.id))).toEqual([["a"], ["b"]])
+  })
+})
+
+describe("formatDagError", () => {
+  test("removes Effect and provider error wrappers without hiding the useful message", () => {
+    expect(
+      formatDagError(
+        "Cause([Die(ProviderModelNotFoundError: Model not found: local/local/glm. Did you mean: glm?)])",
+      ),
+    ).toBe("Model not found: local/local/glm. Did you mean: glm?")
+  })
+})
+
+describe("DAG control state", () => {
+  test("allows only operations valid for the current workflow status", () => {
+    expect(dagControlUnavailableMessage("running", "pause")).toBeUndefined()
+    expect(dagControlUnavailableMessage("stepping", "pause")).toBeUndefined()
+    expect(dagControlUnavailableMessage("paused", "resume")).toBeUndefined()
+    expect(dagControlUnavailableMessage("completed", "pause")).toBe(
+      "Workflow is completed and cannot be paused",
+    )
+    expect(dagControlUnavailableMessage("cancelled", "cancel")).toBe(
+      "Workflow is cancelled and cannot be cancelled",
+    )
+    expect(dagControlUnavailableMessage("pending", "cancel")).toBe(
+      "Workflow is pending and cannot be cancelled",
+    )
+    expect(dagControlUnavailableMessage("archived", "cancel")).toBe(
+      "Workflow is archived and cannot be cancelled",
+    )
+  })
+
+  test("formats progress without component-level branching", () => {
+    expect(dagControlProgressMessage("pause")).toBe("Pausing workflow...")
+    expect(dagControlProgressMessage("resume")).toBe("Resuming workflow...")
+    expect(dagControlProgressMessage("cancel")).toBe("Cancelling workflow...")
   })
 })

--- a/packages/tui/test/feature-plugins/dag-inspector.test.tsx
+++ b/packages/tui/test/feature-plugins/dag-inspector.test.tsx
@@ -60,6 +60,7 @@ async function renderDagInspector(opts: RenderOpts = {}) {
 
   // Trackable spies
   const nodesCalls: string[] = []
+  const controlCalls: { dagID: string; operation: string }[] = []
   const commandCalls: unknown[] = []
   const navigations: { name: string; params?: Record<string, unknown> }[] = []
   const toasts: { variant?: string; message: string }[] = []
@@ -84,6 +85,10 @@ async function renderDagInspector(opts: RenderOpts = {}) {
           nodes: async (input: { dagID: string }) => {
             nodesCalls.push(input.dagID)
             return { data: opts.nodes ?? [] }
+          },
+          control: async (input: { dagID: string; operation: string }) => {
+            controlCalls.push(input)
+            return { data: undefined }
           },
         },
         session: {
@@ -161,6 +166,7 @@ async function renderDagInspector(opts: RenderOpts = {}) {
     commandCalls: () => commandCalls,
     toasts: () => toasts,
     nodesCalls: () => nodesCalls,
+    controlCalls: () => controlCalls,
     setWorkflows: (wfs: DagWorkflowSummary[]) => {
       workflowsState = wfs
     },
@@ -354,6 +360,85 @@ describe("DagInspector", () => {
       expect(viewer.navigations()).toContainEqual(
         expect.objectContaining({ name: "session", params: expect.objectContaining({ sessionID: "child_ses_1" }) }),
       )
+    } finally {
+      viewer.app.renderer.destroy()
+    }
+  })
+
+  test("pressing Enter navigates into the selected node's child session", async () => {
+    const viewer = await renderDagInspector({
+      workflows: [wfSummary({ id: "wf-1" })],
+      nodes: [dagNode({ id: "n-1", name: "build", status: "running", child_session_id: "child_ses_1" })],
+    })
+    try {
+      await viewer.app.waitForFrame((frame) => frame.includes("build"))
+      viewer.app.mockInput.pressEnter()
+      await waitForCondition(() => viewer.navigations().some((item) => item.name === "session"))
+      expect(viewer.navigations()).toContainEqual(
+        expect.objectContaining({ name: "session", params: expect.objectContaining({ sessionID: "child_ses_1" }) }),
+      )
+    } finally {
+      viewer.app.renderer.destroy()
+    }
+  })
+
+  test("pressing p pauses a running workflow", async () => {
+    const viewer = await renderDagInspector({
+      workflows: [wfSummary({ id: "wf-1", status: "running" })],
+      nodes: [dagNode({ id: "n-1", name: "build", status: "running" })],
+    })
+    try {
+      await viewer.app.waitForFrame((frame) => frame.includes("build"))
+      viewer.app.mockInput.pressKey("p")
+      await waitForCondition(() => viewer.controlCalls().length > 0)
+      expect(viewer.controlCalls()).toContainEqual({ dagID: "wf-1", operation: "pause" })
+    } finally {
+      viewer.app.renderer.destroy()
+    }
+  })
+
+  test("pressing p pauses a stepping workflow", async () => {
+    const viewer = await renderDagInspector({
+      workflows: [wfSummary({ id: "wf-1", status: "stepping" })],
+      nodes: [dagNode({ id: "n-1", name: "build", status: "running" })],
+    })
+    try {
+      await viewer.app.waitForFrame((frame) => frame.includes("build"))
+      viewer.app.mockInput.pressKey("p")
+      await waitForCondition(() => viewer.controlCalls().length > 0)
+      expect(viewer.controlCalls()).toContainEqual({ dagID: "wf-1", operation: "pause" })
+    } finally {
+      viewer.app.renderer.destroy()
+    }
+  })
+
+  test("pressing p on a terminal workflow explains why pause is unavailable", async () => {
+    const viewer = await renderDagInspector({
+      workflows: [wfSummary({ id: "wf-1", status: "completed", completedNodes: 2 })],
+      nodes: [dagNode({ id: "n-1", name: "build", status: "completed" })],
+    })
+    try {
+      await viewer.app.waitForFrame((frame) => frame.includes("build"))
+      viewer.app.mockInput.pressKey("p")
+      await waitForCondition(() => viewer.toasts().length > 0)
+      expect(viewer.controlCalls()).toEqual([])
+      expect(viewer.toasts().at(-1)?.message).toMatch(/completed.*cannot be paused/i)
+    } finally {
+      viewer.app.renderer.destroy()
+    }
+  })
+
+  test("the inspector leaves a blank outer row below its footer", async () => {
+    const viewer = await renderDagInspector({
+      workflows: [wfSummary({ id: "wf-1" })],
+      nodes: [dagNode({ id: "n-1", name: "build", status: "running" })],
+    })
+    try {
+      await viewer.app.waitForFrame((frame) => {
+        const rows = frame.split("\n")
+        const footer = rows.findIndex((row) => row.includes("open session"))
+        return footer >= 0 && rows.slice(footer + 1).some((row) => row.trim() === "")
+      })
     } finally {
       viewer.app.renderer.destroy()
     }


### PR DESCRIPTION
## Summary
- resolve node defaults from workflow config, then fall back to agent and parent-session model
- canonicalize provider-qualified model IDs for new and persisted workflows
- inject direct dependency outputs by default and reject unresolved templates or empty node output
- repair DAG inspector spacing, Return navigation, state-aware pause/resume/cancel, and readable errors

## Validation
- opencode typecheck and all DAG tests: 172 passed
- TUI typecheck and DAG inspector tests: 28 passed
- core typecheck passed
- repository pre-commit and pre-push typecheck: 29 packages passed
- multi-platform build and darwin-arm64 smoke test passed
- real PTY fan-out: node-a=A, node-b=B, summary aggregated both without model or input_mapping