### PR TITLE
fix(dag): preserve optional fan-in state

### DIFF
--- a/packages/core/src/dag/core/scheduling.ts
+++ b/packages/core/src/dag/core/scheduling.ts
@@ -44,7 +44,7 @@ export class WorkflowRuntime {
       else if (node.status === "unsatisfied") this.unsatisfied.add(node.id)
       else if (node.status === "running") this.running.add(node.id)
     })
-    unsatisfiedIDs.forEach((id) => this.cascadeUnsatisfied(id))
+    unsatisfiedIDs.filter((id) => this.required.has(id)).forEach((id) => this.cascadeUnsatisfied(id))
   }
 
   markSatisfied(nodeID: string): void {
@@ -57,7 +57,7 @@ export class WorkflowRuntime {
     this.unsatisfied.add(nodeID)
     this.running.delete(nodeID)
     this.satisfied.delete(nodeID)
-    this.cascadeUnsatisfied(nodeID)
+    if (this.required.has(nodeID)) this.cascadeUnsatisfied(nodeID)
   }
 
   private cascadeUnsatisfied(nodeID: string): void {
@@ -99,7 +99,10 @@ export class WorkflowRuntime {
   getReadyNodes(): string[] {
     if (this.paused) return []
     const ready = this.graph
-      .getExecutableNodes(this.satisfied)
+      .getExecutableNodes(new Set([
+        ...this.satisfied,
+        ...[...this.unsatisfied].filter((id) => !this.required.has(id)),
+      ]))
       .filter((id) => !this.satisfied.has(id) && !this.unsatisfied.has(id) && !this.running.has(id))
     if (this.stepMode && ready.length > 0) return [ready.slice().sort()[0]]
     return ready

--- a/packages/core/src/dag/core/types.ts
+++ b/packages/core/src/dag/core/types.ts
@@ -213,10 +213,9 @@ export function assertValidNodeTransition(nodeId: string, from: NodeStatus, to: 
 }
 
 export function assertValidWorkflowTransition(workflowId: string, from: WorkflowStatus, to: WorkflowStatus): void {
+  if (getValidNextWorkflowStatuses(from).includes(to)) return
   if (isWorkflowTerminalStatus(from)) {
     throw new TerminalViolationError(workflowId, from, to)
   }
-  if (!getValidNextWorkflowStatuses(from).includes(to)) {
-    throw new InvalidTransitionError(workflowId, from, to)
-  }
+  throw new InvalidTransitionError(workflowId, from, to)
 }

--- a/packages/core/test/dag-core.test.ts
+++ b/packages/core/test/dag-core.test.ts
@@ -162,6 +162,40 @@ describe("iron laws (transition tables)", () => {
     )
   })
 
+  it("covers the complete node transition matrix", () => {
+    const transitions = [
+      [NodeStatus.PENDING, [NodeStatus.QUEUED, NodeStatus.RUNNING, NodeStatus.SKIPPED, NodeStatus.FAILED]],
+      [NodeStatus.QUEUED, [NodeStatus.RUNNING, NodeStatus.SKIPPED]],
+      [NodeStatus.RUNNING, [NodeStatus.COMPLETED, NodeStatus.FAILED, NodeStatus.PAUSED, NodeStatus.PENDING, NodeStatus.SKIPPED]],
+      [NodeStatus.PAUSED, [NodeStatus.RUNNING]],
+      [NodeStatus.COMPLETED, []],
+      [NodeStatus.FAILED, []],
+      [NodeStatus.ABORTED, []],
+      [NodeStatus.SKIPPED, []],
+    ] as const
+
+    for (const [status, expected] of transitions) {
+      expect(getValidNextNodeStatuses(status)).toEqual([...expected])
+    }
+  })
+
+  it("covers the complete workflow transition matrix", () => {
+    const transitions = [
+      [WorkflowStatus.PENDING, [WorkflowStatus.RUNNING]],
+      [WorkflowStatus.RUNNING, [WorkflowStatus.PAUSED, WorkflowStatus.STEPPING, WorkflowStatus.COMPLETED, WorkflowStatus.FAILED, WorkflowStatus.CANCELLED]],
+      [WorkflowStatus.STEPPING, [WorkflowStatus.RUNNING, WorkflowStatus.PAUSED, WorkflowStatus.COMPLETED, WorkflowStatus.FAILED, WorkflowStatus.CANCELLED]],
+      [WorkflowStatus.PAUSED, [WorkflowStatus.RUNNING, WorkflowStatus.CANCELLED]],
+      [WorkflowStatus.COMPLETED, [WorkflowStatus.ARCHIVED]],
+      [WorkflowStatus.FAILED, [WorkflowStatus.ARCHIVED]],
+      [WorkflowStatus.CANCELLED, [WorkflowStatus.ARCHIVED]],
+      [WorkflowStatus.ARCHIVED, []],
+    ] as const
+
+    for (const [status, expected] of transitions) {
+      expect(getValidNextWorkflowStatuses(status)).toEqual([...expected])
+    }
+  })
+
   it("assertValidNodeTransition throws TerminalViolationError from terminal", () => {
     expect(() => assertValidNodeTransition("n1", NodeStatus.COMPLETED, NodeStatus.RUNNING)).toThrow(
       TerminalViolationError,
@@ -176,6 +210,42 @@ describe("iron laws (transition tables)", () => {
 
   it("assertValidWorkflowTransition allows PAUSED → RUNNING (resume)", () => {
     expect(() => assertValidWorkflowTransition("w1", WorkflowStatus.PAUSED, WorkflowStatus.RUNNING)).not.toThrow()
+  })
+
+  it("assertValidWorkflowTransition accepts every declared workflow transition", () => {
+    for (const from of Object.values(WorkflowStatus)) {
+      for (const to of getValidNextWorkflowStatuses(from)) {
+        expect(() => assertValidWorkflowTransition("w1", from, to)).not.toThrow()
+      }
+    }
+  })
+
+  it("assertValidNodeTransition accepts every declared node transition", () => {
+    for (const from of Object.values(NodeStatus)) {
+      for (const to of getValidNextNodeStatuses(from)) {
+        expect(() => assertValidNodeTransition("n1", from, to)).not.toThrow()
+      }
+    }
+  })
+
+  it("rejects every undeclared workflow transition", () => {
+    for (const from of Object.values(WorkflowStatus)) {
+      for (const to of Object.values(WorkflowStatus)) {
+        if (getValidNextWorkflowStatuses(from).includes(to)) continue
+        const error = isWorkflowTerminalStatus(from) ? TerminalViolationError : InvalidTransitionError
+        expect(() => assertValidWorkflowTransition("w1", from, to)).toThrow(error)
+      }
+    }
+  })
+
+  it("rejects every undeclared node transition", () => {
+    for (const from of Object.values(NodeStatus)) {
+      for (const to of Object.values(NodeStatus)) {
+        if (getValidNextNodeStatuses(from).includes(to)) continue
+        const error = isNodeTerminalStatus(from) ? TerminalViolationError : InvalidTransitionError
+        expect(() => assertValidNodeTransition("n1", from, to)).toThrow(error)
+      }
+    }
   })
 })
 
@@ -202,6 +272,40 @@ describe("transitions (event mappings + aggregation)", () => {
 
   it("transitionToWorkflowEvent: PENDING → RUNNING emits workflow.started", () => {
     expect(transitionToWorkflowEvent(WorkflowStatus.PENDING, WorkflowStatus.RUNNING)).toBe("workflow.started")
+  })
+
+  it("maps every node target state to its durable event", () => {
+    const events = [
+      [NodeStatus.PENDING, null],
+      [NodeStatus.QUEUED, null],
+      [NodeStatus.RUNNING, "node.started"],
+      [NodeStatus.PAUSED, "node.paused"],
+      [NodeStatus.COMPLETED, "node.completed"],
+      [NodeStatus.FAILED, "node.failed"],
+      [NodeStatus.ABORTED, "node.aborted"],
+      [NodeStatus.SKIPPED, "node.skipped"],
+    ] as const
+
+    for (const [status, event] of events) {
+      expect(transitionToNodeEvent(NodeStatus.PENDING, status)).toBe(event)
+    }
+  })
+
+  it("maps every workflow target state to its durable event", () => {
+    const events = [
+      [WorkflowStatus.PENDING, "workflow.created"],
+      [WorkflowStatus.RUNNING, "workflow.started"],
+      [WorkflowStatus.PAUSED, "workflow.paused"],
+      [WorkflowStatus.STEPPING, "workflow.stepped"],
+      [WorkflowStatus.COMPLETED, "workflow.completed"],
+      [WorkflowStatus.FAILED, "workflow.failed"],
+      [WorkflowStatus.CANCELLED, "workflow.cancelled"],
+      [WorkflowStatus.ARCHIVED, "workflow.archived"],
+    ] as const
+
+    for (const [status, event] of events) {
+      expect(transitionToWorkflowEvent(WorkflowStatus.PENDING, status)).toBe(event)
+    }
   })
 
   it("aggregateBranchStatus: any FAILED → FAILED", () => {
@@ -432,11 +536,21 @@ describe("WorkflowRuntime", () => {
     expect(rt.getReadyNodes()).toEqual(["c"])
   })
 
-  it("markUnsatisfied blocks dependents", () => {
-    const rt = new WorkflowRuntime(linearNodes(), 4)
+  it("required markUnsatisfied blocks dependents", () => {
+    const rt = new WorkflowRuntime(
+      linearNodes().map((node) => node.id === "a" ? { ...node, required: true } : node),
+      4,
+    )
     expect(rt.getReadyNodes()).toEqual(["a"])
     rt.markUnsatisfied("a")
     expect(rt.getReadyNodes()).toEqual([])
+  })
+
+  it("optional markUnsatisfied unblocks dependents", () => {
+    const rt = new WorkflowRuntime(linearNodes(), 4)
+    rt.markUnsatisfied("a")
+    expect(rt.getReadyNodes()).toEqual(["b"])
+    expect(rt.hasRequiredFailure()).toBe(false)
   })
 
   it("markRunning excludes a node from getReadyNodes", () => {
@@ -469,8 +583,11 @@ describe("WorkflowRuntime", () => {
     const rt = new WorkflowRuntime(linearNodes(), 4)
     rt.markSatisfied("a")
     rt.markUnsatisfied("b")
-    expect(rt.isComplete()).toBe(true)
+    expect(rt.getReadyNodes()).toEqual(["c"])
+    expect(rt.isComplete()).toBe(false)
     expect(rt.hasRequiredFailure()).toBe(false)
+    rt.markSatisfied("c")
+    expect(rt.isComplete()).toBe(true)
   })
 
   it("hasRequiredFailure detects required node failure", () => {
@@ -533,8 +650,8 @@ describe("WorkflowRuntime", () => {
 
   it("constructor seeds from unsatisfied node statuses", () => {
     const rt = new WorkflowRuntime(linearNodes({ a: "unsatisfied" }), 4)
-    expect(rt.getReadyNodes()).toEqual([])
-    expect(rt.isComplete()).toBe(true)
+    expect(rt.getReadyNodes()).toEqual(["b"])
+    expect(rt.isComplete()).toBe(false)
     expect(rt.hasRequiredFailure()).toBe(false)
   })
 
@@ -556,7 +673,10 @@ describe("WorkflowRuntime", () => {
   })
 
   it("markUnsatisfied cascades to transitive dependents", () => {
-    const rt = new WorkflowRuntime(linearNodes(), 4)
+    const rt = new WorkflowRuntime(
+      linearNodes().map((node) => node.id === "a" ? { ...node, required: true } : node),
+      4,
+    )
     rt.markUnsatisfied("a")
     expect(rt.isComplete()).toBe(true)
     expect(rt.getReadyNodes()).toEqual([])
@@ -564,7 +684,7 @@ describe("WorkflowRuntime", () => {
 
   it("markUnsatisfied cascade respects already-satisfied nodes", () => {
     const nodes: SchedulingNode[] = [
-      { id: "a", dependsOn: [], status: "pending", required: false },
+      { id: "a", dependsOn: [], status: "pending", required: true },
       { id: "b", dependsOn: ["a"], status: "pending", required: false },
       { id: "c", dependsOn: [], status: "pending", required: false },
     ]

--- a/packages/opencode/src/dag/runtime/loop.ts
+++ b/packages/opencode/src/dag/runtime/loop.ts
@@ -15,7 +15,7 @@ import { Session } from "@/session/session"
 import { SessionPrompt } from "@/session/prompt"
 import { SessionID } from "@/session/schema"
 import { SessionStatus } from "@/session/status"
-import { resolveTemplate } from "../templates/resolve"
+import { renderTemplate } from "../templates/resolve"
 import { sanitizeInput } from "../templates/sanitize"
 import { spawnNode } from "./spawn"
 import { evaluateCondition, resolveInputMapping } from "./eval"
@@ -107,7 +107,17 @@ export const layer = Layer.effect(
               const allNodes = yield* store.getNodes(dagID)
               resolvedMapping = resolveInputMapping(inputMapping, (depId) => {
                 const depNode = allNodes.find((n) => n.id === depId)
-                return depNode?.output ?? null
+                if (!depNode) return null
+                if (depNode.output !== null) return depNode.output
+                if (depNode.status === "failed") {
+                  return `Dependency "${depId}" failed: ${depNode.errorReason ?? "unknown error"}`
+                }
+                if (depNode.status === "skipped") {
+                  return `Dependency "${depId}" skipped: ${depNode.errorReason ?? "no output"}`
+                }
+                if (depNode.status === "aborted") return `Dependency "${depId}" aborted`
+                if (depNode.status === "completed") return `Dependency "${depId}" completed without output`
+                return null
               })
             }
 
@@ -115,51 +125,43 @@ export const layer = Layer.effect(
             // outputs) before interpolation and Context serialization.
             resolvedMapping = sanitizeInput(resolvedMapping)
 
-            let promptText: string
-            if (nodeConfig?.prompt_template) {
-              const resolved = yield* resolveTemplate(nodeConfig.prompt_template, ctx.directory).pipe(
-                Effect.tap((text) =>
-                  text.trim() === ""
-                    ? Effect.logWarning("DAG node resolved template is empty", { dagID, nodeID })
-                    : Effect.void,
-                ),
-                Effect.map((text) => ({ ok: true as const, text })),
-                Effect.catch((err: unknown) =>
-                  Effect.gen(function* () {
-                    yield* dag.nodeFailed(dagID, nodeID, `Template resolution failed: ${String(err)}`, "exec_failed").pipe(Effect.ignore)
-                    return { ok: false as const, text: "" }
-                  }),
-                ),
-              )
-              if (!resolved.ok) {
-                entry.runtime.markUnsatisfied(nodeID)
-                continue
-              }
-              promptText = resolved.text
-            } else {
-              promptText = node.name
+            const resolved = yield* (nodeConfig?.prompt_template
+              ? renderTemplate(nodeConfig.prompt_template, ctx.directory, resolvedMapping).pipe(
+                  Effect.tap((result) =>
+                    result.text.trim() === ""
+                      ? Effect.logWarning("DAG node resolved template is empty", { dagID, nodeID })
+                      : Effect.void,
+                  ),
+                  Effect.map((result) => ({ ok: true as const, ...result })),
+                  Effect.catch((err: unknown) =>
+                    Effect.gen(function* () {
+                      yield* dag.nodeFailed(dagID, nodeID, `Template resolution failed: ${String(err)}`, "exec_failed").pipe(Effect.ignore)
+                      return { ok: false as const, text: "", unresolvedPlaceholders: [] }
+                    }),
+                  ),
+                )
+              : Effect.succeed({
+                  ok: true as const,
+                  text: node.name,
+                  unresolvedPlaceholders: [],
+                }))
+            if (!resolved.ok) {
+              entry.runtime.markUnsatisfied(nodeID)
+              continue
             }
 
-            for (const [key, value] of Object.entries(resolvedMapping)) {
-              if (value !== null && value !== undefined) {
-                promptText = promptText.replaceAll(`{{${key}}}`, String(value))
-              }
-            }
-
-            const unresolvedPlaceholders = [...promptText.matchAll(/{{\s*([^{}]+?)\s*}}/g)]
-              .map((match) => match[1])
-            if (unresolvedPlaceholders.length > 0) {
+            if (resolved.unresolvedPlaceholders.length > 0) {
               yield* dag.nodeFailed(
                 dagID,
                 nodeID,
-                `Unresolved template placeholders: ${unresolvedPlaceholders.join(", ")}`,
+                `Unresolved template placeholders: ${resolved.unresolvedPlaceholders.join(", ")}`,
                 "verdict_fail",
               ).pipe(Effect.ignore)
               entry.runtime.markUnsatisfied(nodeID)
               continue
             }
 
-            promptParts.push({ type: "text", text: promptText })
+            promptParts.push({ type: "text", text: resolved.text })
 
             if (Object.keys(resolvedMapping).length > 0) {
               promptParts.push({ type: "text", text: `\n\nContext:\n${JSON.stringify(resolvedMapping, null, 2)}` })

--- a/packages/opencode/src/dag/templates/resolve.ts
+++ b/packages/opencode/src/dag/templates/resolve.ts
@@ -25,7 +25,7 @@ export interface TemplateRef {
   input?: Record<string, unknown>
 }
 
-const INTERPOLATION_RE = /\{\{(\w+)\}\}/g
+const INTERPOLATION_RE = /{{\s*([^{}]+?)\s*}}/g
 
 /** A template id must be a single path segment (no separators, no parent refs)
  * so it cannot escape the dag-prompts directory via path traversal. */
@@ -40,8 +40,16 @@ function isSafeTemplateId(id: string): boolean {
  * @param projectDir  The project root (for `.opencode/dag-prompts/` lookup)
  */
 export function resolveTemplate(ref: TemplateRef, projectDir: string): Effect.Effect<string, Error> {
+  return renderTemplate(ref, projectDir).pipe(Effect.map((result) => result.text))
+}
+
+export function renderTemplate(
+  ref: TemplateRef,
+  projectDir: string,
+  dynamicInput: Record<string, unknown> = {},
+) {
   return Effect.gen(function* () {
-    const input = sanitizeInput(ref.input ?? {})
+    const input = sanitizeInput({ ...dynamicInput, ...(ref.input ?? {}) })
     const raw = yield* readTemplateSource(ref, projectDir)
     return interpolate(raw, input)
   })
@@ -100,9 +108,13 @@ function readById(id: string, projectDir: string): Effect.Effect<string, Error> 
   })
 }
 
-function interpolate(template: string, input: Record<string, unknown>): string {
-  return template.replace(INTERPOLATION_RE, (match, key: string) => {
+function interpolate(template: string, input: Record<string, unknown>) {
+  const unresolvedPlaceholders: string[] = []
+  const text = template.replace(INTERPOLATION_RE, (match, key: string) => {
     const value = input[key]
-    return value !== undefined ? String(value) : match
+    if (value !== null && value !== undefined) return String(value)
+    unresolvedPlaceholders.push(key)
+    return match
   })
+  return { text, unresolvedPlaceholders }
 }

--- a/packages/opencode/test/dag/dag-recovery.test.ts
+++ b/packages/opencode/test/dag/dag-recovery.test.ts
@@ -276,6 +276,30 @@ describe("reconcileWorkflow", () => {
 })
 
 describe("rehydration via toSchedulingNodes", () => {
+  it("maps every durable node status into the scheduling state machine", () => {
+    const nodes = [
+      makeNodeRow({ id: "pending", status: "pending" }),
+      makeNodeRow({ id: "queued", status: "queued" }),
+      makeNodeRow({ id: "running", status: "running" }),
+      makeNodeRow({ id: "paused", status: "paused" }),
+      makeNodeRow({ id: "completed", status: "completed" }),
+      makeNodeRow({ id: "failed", status: "failed" }),
+      makeNodeRow({ id: "aborted", status: "aborted" }),
+      makeNodeRow({ id: "skipped", status: "skipped" }),
+    ]
+
+    expect(toSchedulingNodes(nodes).map((node) => [node.id, node.status])).toEqual([
+      ["pending", "pending"],
+      ["queued", "pending"],
+      ["running", "running"],
+      ["paused", "pending"],
+      ["completed", "satisfied"],
+      ["failed", "unsatisfied"],
+      ["aborted", "satisfied"],
+      ["skipped", "satisfied"],
+    ])
+  })
+
   it("running nodes are seeded as running in WorkflowRuntime", () => {
     const nodes = [makeNodeRow({ id: "n1", status: "running", childSessionId: "ses_1" })]
     const rt = new WorkflowRuntime(toSchedulingNodes(nodes), 4)
@@ -301,6 +325,16 @@ describe("rehydration via toSchedulingNodes", () => {
     expect(rt.getReadyNodes()).toEqual([])
     expect(rt.isComplete()).toBe(true)
     expect(rt.hasRequiredFailure()).toBe(true)
+  })
+
+  it("failed optional nodes after reconciliation unblock dependents", () => {
+    const nodes = [
+      makeNodeRow({ id: "n1", status: "failed", required: false }),
+      makeNodeRow({ id: "n2", status: "pending", dependsOn: ["n1"], required: true }),
+    ]
+    const rt = new WorkflowRuntime(toSchedulingNodes(nodes), 4)
+    expect(rt.getReadyNodes()).toEqual(["n2"])
+    expect(rt.hasRequiredFailure()).toBe(false)
   })
 
   it("paused workflow rehydrates with setPaused(true)", () => {

--- a/packages/opencode/test/dag/dag-wake-integration.test.ts
+++ b/packages/opencode/test/dag/dag-wake-integration.test.ts
@@ -214,6 +214,140 @@ function runWakeTest<A>(
 }
 
 describe("DagLoop atomic wake integration", () => {
+  it("preserves documented template variables inside static template input", async () => {
+    await Effect.runPromise(
+      runWakeTest(({ dag, childPrompts }) =>
+        Effect.gen(function* () {
+          yield* dag.create({
+            projectID: "project-1",
+            sessionID: "ses_parent",
+            title: "Static template documentation",
+            config: {
+              name: "static-template-documentation",
+              nodes: [
+                {
+                  ...node("review-guidance"),
+                  prompt_template: {
+                    inline: "Review this guidance:\n{{guidance}}",
+                    input: {
+                      guidance: "Workflow examples use {{node-id}} as a documented template variable.",
+                    },
+                  },
+                },
+              ],
+            },
+          })
+
+          const review = yield* takeWithin(childPrompts, "review-guidance did not start")
+          expect(promptText(review.input)).toContain(
+            "Workflow examples use {{node-id}} as a documented template variable.",
+          )
+          yield* Deferred.succeed(review.release, "The guidance is clear.")
+        }),
+      ),
+    )
+  })
+
+  it("preserves documented template variables inside dependency output", async () => {
+    await Effect.runPromise(
+      runWakeTest(({ dag, store, childPrompts }) =>
+        Effect.gen(function* () {
+          const dagID = yield* dag.create({
+            projectID: "project-1",
+            sessionID: "ses_parent",
+            title: "Documented template variable",
+            config: {
+              name: "documented-template-variable",
+              nodes: [
+                node("analyze-security"),
+                {
+                  ...node("review-security", ["analyze-security"]),
+                  prompt_template: { inline: "Review this analysis:\n{{analyze-security}}" },
+                },
+              ],
+            },
+          })
+
+          const analyze = yield* takeWithin(childPrompts, "analyze-security did not start")
+          yield* Deferred.succeed(
+            analyze.release,
+            "Workflow examples use {{node-id}} as a documented template variable.",
+          )
+
+          const review = yield* takeWithin(childPrompts, "review-security did not start")
+          expect(review.title).toBe("review-security")
+          expect(promptText(review.input)).toContain(
+            "Workflow examples use {{node-id}} as a documented template variable.",
+          )
+          yield* Deferred.succeed(review.release, "No security issues found.")
+
+          yield* pollWithTimeout(
+            store.getWorkflow(dagID).pipe(
+              Effect.map((workflow) => workflow?.status === "completed" ? workflow : undefined),
+            ),
+            "workflow did not complete",
+          )
+        }),
+      ),
+    )
+  })
+
+  it("runs a required fan-in after an optional dependency fails", async () => {
+    await Effect.runPromise(
+      runWakeTest(({ dag, store, childPrompts }) =>
+        Effect.gen(function* () {
+          const dagID = yield* dag.create({
+            projectID: "project-1",
+            sessionID: "ses_parent",
+            title: "Optional review failure",
+            config: {
+              name: "optional-review-failure",
+              nodes: [
+                node("analysis"),
+                {
+                  ...node("review-quality", ["analysis"]),
+                  required: false,
+                },
+                {
+                  ...node("review-security", ["analysis"]),
+                  required: false,
+                  condition: "analysis.output.verdict ==",
+                },
+                {
+                  ...node("arbitrate", ["review-quality", "review-security"]),
+                  prompt_template: {
+                    inline: "Quality review: {{review-quality}}\nSecurity review: {{review-security}}",
+                  },
+                },
+              ],
+            },
+          })
+
+          const analysis = yield* takeWithin(childPrompts, "analysis did not start")
+          yield* Deferred.succeed(analysis.release, "The implementation follows the approved design.")
+
+          const quality = yield* takeWithin(childPrompts, "review-quality did not start")
+          expect(quality.title).toBe("review-quality")
+          yield* Deferred.succeed(quality.release, "No quality issues found.")
+
+          const arbitrate = yield* takeWithin(childPrompts, "arbitrate did not start")
+          const text = promptText(arbitrate.input)
+          expect(text).toContain("No quality issues found.")
+          expect(text).toContain('Dependency "review-security" failed:')
+          yield* Deferred.succeed(arbitrate.release, "Proceed with one review unavailable.")
+
+          yield* pollWithTimeout(
+            store.getWorkflow(dagID).pipe(
+              Effect.map((workflow) => workflow?.status === "completed" ? workflow : undefined),
+            ),
+            "workflow did not complete",
+          )
+          expect((yield* store.getNode(dagID, "review-security"))?.status).toBe("failed")
+        }),
+      ),
+    )
+  })
+
   it("injects direct dependency outputs into an aggregate node by default", async () => {
     await Effect.runPromise(
       runWakeTest(({ dag, childPrompts }) =>


### PR DESCRIPTION
## 问题

- 依赖输出中的字面量 `{{node-id}}` 被二次扫描为未解析模板，导致 review 节点在创建子会话前失败。
- optional 节点失败会把全部后继级联为 unsatisfied；当后继为 required 扇入节点时，工作流被内部完成检查取消。

## 修复

- 模板改为单遍渲染，只检查原始模板占位符，不重新解释输入值中的 mustache 文本，并支持带连字符的节点 ID。
- optional 失败视为已结算依赖，允许扇入节点继续运行；同时把失败/跳过信息作为正常上下文传递。
- 修正声明允许的 terminal → archived 工作流转换校验。
- 穷举 Node/Workflow 全状态转换矩阵、事件映射、恢复映射，并覆盖 optional/required 调度分支。

## TDD / 验证

- `packages/core`: `bun test test/dag-core.test.ts` — 71 pass
- `packages/opencode`: `bun test test/dag` — 180 pass
- 全仓提交/推送钩子：29/29 typecheck
- 正常输入输出集成场景覆盖：依赖输出含 `{{node-id}}`、静态模板输入含 `{{node-id}}`、optional security review 失败后 required arbiter 正常输出并完成工作流

备注：本地全包测试另见既有宿主环境限制（FSEvents 无法启动导致 watcher/PTY/HTTP 连锁失败），与本 PR 修改范围无关；PR 到 `dev` 的正式门禁为 Typecheck。