### PR TITLE
feat(dag): add deep admission QA

### DIFF
--- a/docs/harness-dag.md
+++ b/docs/harness-dag.md
@@ -1,0 +1,115 @@
+# DAG 编排与深度准入
+
+OpenCode-DAG 提供两种兼容的工作流入口：
+
+- `standard`：默认模式。适合边界清楚的普通 DAG，不要求准入问答；启动时省略
+  顶层 `mode` 参数，行为不变。
+- `deep`：面向复杂、研究密集、需要多阶段拆解和交叉校验的任务。启动前必须在
+  主会话完成准入，并提供有效的 `READY` 或知情 `WAIVED` 记录。
+
+除非用户明确要求 `deep`，仅当任务至少具有两个复杂度信号时才建议使用：
+独立工作流、跨领域不确定性、高影响范围、冲突约束、证据收集、多视角验证。
+简单或已经充分限定的任务应继续使用 `standard`、单个 `task`，或直接执行。
+
+## 主会话 QA
+
+准入问答发生在创建 DAG 之前，并复用主会话的用户提问能力。不要把 QA
+建模成子节点或子工作流，因为问答结果用于定义图本身。
+
+QA 覆盖六个维度：目标、范围、约束与假设、验收标准、证据与审查、风险与失败
+模式。系统支持三种有界策略，且只要已经满足准入条件就提前结束：
+
+| 模式 | 最大轮数 | 用途 |
+| --- | ---: | --- |
+| `LIGHT` | 1 | 需求基本完整，只需确认关键缺口 |
+| `STANDARD` | 3 | `deep` 的默认准入策略 |
+| `GRILL` | 5 | 用户提出 `GRILL-ME` 等对抗式核查要求 |
+
+轮数耗尽但仍有阻塞问题时，结果必须是 `NOT_READY`，不能静默降级为
+`READY`。`GRILL` 会额外寻找矛盾、隐藏假设、薄弱证据、失败模式和可证伪条件；
+它是同一准入协议的策略，不是独立人格或命令。
+
+## Requirement Brief
+
+每次准入都生成带版本和确定性指纹的结构化 Brief：
+
+```json
+{
+  "goal": "要实现的结果",
+  "scope": {
+    "in": ["包含内容"],
+    "out": ["明确排除"]
+  },
+  "constraints": ["约束"],
+  "assumptions": ["假设"],
+  "acceptance_criteria": ["验收标准"],
+  "evidence_required": ["所需证据"],
+  "risks": ["风险"],
+  "review_plan": ["核对与审查计划"],
+  "open_questions": ["非阻塞问题"],
+  "blocking_questions": ["阻塞问题"]
+}
+```
+
+准入记录还包含 `protocol_version`、`brief_revision`、`qa_mode`、`verdict`、
+`state` 和 `fingerprint`。目标、范围、约束、假设或验收标准发生实质变化时，
+应增加 Brief 修订号、生成新指纹，并把旧准入置为 `INVALIDATED` 后重新问答。
+
+`action: start` 调用中，`mode` 和 `admission` 与 `config` 同级，而不是
+`config` 的子字段。指纹计算会裁剪目标和所有数组字符串、删除空项、对数组排序，
+按 Brief 的固定字段顺序序列化为紧凑 JSON，再计算小写十六进制 SHA-256。
+
+## Verdict 与恢复路径
+
+- `READY`：目标、范围边界、验收标准、证据要求和审查计划均完整，且
+  `blocking_questions` 为空。
+- `NOT_READY`：仍有阻塞问题。用户可以继续回答、缩小范围、切换为
+  `standard`，或进行知情豁免；此时不能创建深度工作流。
+- `WAIVED`：用户明确接受未解决风险。必须同时记录非空的 `waiver_reason` 和
+  `acknowledged_risks`。
+
+成功启动后，最终记录作为 `CONSUMED` 与工作流配置一起持久化。恢复时读取该
+记录，不重放 QA。状态查询只投影 verdict、模式、修订、指纹和豁免审计信息；
+完整 Brief 保留在持久配置中，原始问答聊天不会复制到每个子节点。
+
+## Review 生命周期
+
+实现前的审查并非反模式，错误在于把它包装成已经审查代码差异：
+
+- `review.phase: design` 审查需求、设计、架构、威胁模型或测试策略。它可以位于
+  explore/design 之后、implementation 之前，但不能声称验证了实现正确性、
+  实际 diff 或测试执行结果。
+- `review.phase: diff` 审查实际实现。生产拓扑必须遵循
+  `implementation → verification(PASS) → diff review → final gate/audit`。
+
+深度 diff review 必须声明 `implementation_node_id` 和
+`verification_node_id`，映射实现产生的 diff（或 changed-files 证据）、
+实现指纹和验证结果，并以验证 verdict 为 `PASS` 作为执行条件。审查结果返回
+`ACCEPT` 或 `REJECT`，同时回显被审实现指纹。
+
+如果返回 `REJECT`，修正路径是：
+
+```text
+REJECT
+  → corrected implementation
+  → verification(PASS)
+  → new diff review
+```
+
+实现变化会产生新指纹，旧 `ACCEPT` 不能满足最终门禁。验证不是 `PASS`、diff
+为空、占位符未解析或结果指纹过期时，diff review 在创建子会话前或完成节点前
+被阻断。
+
+压测 DAG 可以为了构造扇出、扇入而在较早阶段安排审查，但必须标记为
+`design`，并明确它不提供实现差异保证。真实质量门禁不能用这种压测拓扑替代。
+
+## 兼容性与公共接口
+
+严格准入和 review 拓扑校验仅用于 `deep`。现有 `standard` 图可以继续省略
+准入和 review 元数据；若显式声明了不完整的 diff review 元数据，引擎只产生
+非阻塞诊断。
+
+本能力扩展的是模型可调用的 `workflow` 工具配置。现有 HTTP DAG
+查询仍返回持久化工作流行和字符串化 `config`，HTTP 请求/响应 schema、
+SDK 的 DAG summary 类型以及 TUI re-export 均未改变，因此不需要重新生成
+JavaScript SDK。

--- a/packages/core/src/plugin/command/orchestration-policy.md
+++ b/packages/core/src/plugin/command/orchestration-policy.md
@@ -16,6 +16,81 @@ Explicit user constraints override profile defaults:
 - "Do not modify files" does not disable a useful brainstorm or review DAG; it makes every node read-only.
 - Preserve named roles, exact model assignments, scope limits, and prohibited actions in every node prompt.
 
+## Deep Admission QA
+
+`standard` remains the compatibility default and may start without admission.
+Simple or already-bounded work stays `standard` and MUST NOT be forced through
+deep admission QA. Recommend `deep` only when the request has at least two deep-complexity signals: independent workstreams, cross-domain uncertainty,
+high blast radius, conflicting constraints, evidence gathering, or multiple
+verification perspectives. Explicit `deep` intent still requires admission; it
+selects the mode, not a bypass.
+
+Run admission before constructing or starting the graph. Questions belong to
+the existing parent-session question interaction because the answers define the
+graph. You MUST NOT create an admission child node, QA workflow, separate
+persona, or privileged command. `GRILL-ME` selects `GRILL`; equivalent explicit
+requests for adversarial qualification do the same.
+
+Cover these six dimensions, asking only material unresolved questions:
+
+1. goal;
+2. scope;
+3. constraints and assumptions;
+4. acceptance criteria;
+5. evidence and review;
+6. risks and failure modes.
+
+Use one adaptive policy with bounded modes:
+
+- `LIGHT`: at most 1 question round for a nearly complete brief.
+- `STANDARD`: at most 3 question rounds and the default for deep admission.
+- `GRILL`: at most 5 question rounds, probing contradictions, hidden
+  assumptions, evidence quality, failure modes, and falsifiers.
+
+Stop early as soon as the brief is ready. Exhausting a budget with unresolved
+blockers yields `NOT_READY`; it never silently yields `READY`.
+
+Maintain a versioned Requirement Brief with this structure:
+
+```json
+{
+  "goal": "string",
+  "scope": {
+    "in": [],
+    "out": []
+  },
+  "constraints": [],
+  "assumptions": [],
+  "acceptance_criteria": [],
+  "evidence_required": [],
+  "risks": [],
+  "review_plan": [],
+  "open_questions": [],
+  "blocking_questions": []
+}
+```
+
+Before start, show a concise brief summary and verdict:
+`READY | NOT_READY | WAIVED`, plus QA mode, brief revision, fingerprint, and
+remaining blockers. `READY` requires a non-empty goal, scope boundaries,
+acceptance criteria, evidence obligations, review plan, and no blocking
+questions. For `NOT_READY`, remain in the parent conversation and offer:
+continue QA, reduce scope, use `standard`, or explicitly waive. A `WAIVED`
+start is informed only when both `waiver_reason` and `acknowledged_risks` are
+non-empty; preserve them for audit.
+
+Compute `fingerprint` exactly as the workflow boundary does: trim `goal`; for
+every array in the Brief, trim strings, remove blanks, and sort them; preserve
+the documented key order; then SHA-256 hash the compact JSON object and encode
+it as lowercase hexadecimal. Use normal local calculation tools rather than
+inventing a digest.
+
+Material changes to goal, scope, constraints, assumptions, or acceptance
+criteria create a new brief revision, invalidate the prior fingerprint, and
+return admission to questioning. Only a successful deep workflow start consumes
+a `READY` or `WAIVED` record. Do not replay QA from a consumed record after
+recovery.
+
 ## Role Resolution
 
 Profiles declare capability slots, not fixed agent names. Resolve each slot in this order:
@@ -59,6 +134,31 @@ Choose only the phases the task still needs:
 8. verification, CI when available, final audit, and report.
 
 Omit phases whose evidence is already satisfied. Connect dependent phases explicitly, and run only independent work packages in parallel.
+
+## Review Lifecycle
+
+Name what a review can actually prove. A pre-implementation review is a
+`design` review of requirements, architecture, threat model, plan, or test
+strategy. It may appear in the flow `design review → implementation`, but it
+MUST NOT claim implementation-diff assurance, code-correctness verification, or
+executed-test evidence.
+
+A production implementation review uses:
+`implementation → verification(PASS) → diff review → final gate/audit`.
+The implementation supplies an actual diff or changed-file artifact and an
+implementation fingerprint. Verification consumes that implementation and must
+return `PASS` before the diff review can run. The diff review returns
+`ACCEPT | REJECT` and echoes the reviewed fingerprint.
+
+Route rejection through a finite correction wave:
+`REJECT → corrected implementation → verification(PASS) → new diff review`.
+If implementation changes, the old review fingerprint is stale and cannot
+satisfy a final gate.
+
+Synthetic stress-test graphs may intentionally place reviews early to exercise
+fan-out and fan-in. Label those nodes `design` reviews and state the limitation;
+they MUST NOT claim implementation-diff assurance merely because their worker
+type says review.
 
 ## Gates and Business Verdicts
 

--- a/packages/core/src/plugin/command/workflow.md
+++ b/packages/core/src/plugin/command/workflow.md
@@ -24,6 +24,21 @@ does not require this implicit-trigger test. If a task fits in one context
 window and has no inter-step dependencies, use the `task` tool instead. For
 trivial work, use direct tools.
 
+## Standard and deep workflow entry
+
+Omitting the top-level start parameter `mode` preserves `standard` behavior. Use `deep` for explicit
+deep intent or requests with at least two substantial complexity signals, such
+as independent workstreams, cross-domain uncertainty, high blast radius,
+conflicting constraints, evidence gathering, or multiple verification
+perspectives.
+
+Before a deep start, qualify the request interactively in the parent session
+and pass `mode: deep` plus a versioned `READY` or informed `WAIVED` admission
+record beside `config` in the `action: start` tool call. Do not put admission
+QA inside the graph: its answers define the graph. Use the orchestration policy
+below for QA modes, round budgets, verdict recovery, revision invalidation, and
+waiver audit fields.
+
 ## Orchestration Lifecycle
 
 Heavy tasks follow a meta-workflow: multiple workflows chained together, each producing a decision that shapes the next. The lifecycle is not a rigid template — assess the task and enter at the phase that matches its current state.
@@ -160,11 +175,18 @@ config:
       prompt_template: { id: patcher-assemble }
 ```
 
-### Phase 4 — Audit + Merge
+### Phase 4 — Verify + Diff Review + Audit
 
-Goal: verify integration, merge results, update progress tracking.
+Goal: verify integration, review the actual implementation, merge results, and
+update progress tracking.
 
-A workflow runs review nodes (adversarial review pattern) on the assembled output, then a final auditor confirms completeness. Progress tracking (todowrite, OpenSpec tasks, or project board) is updated to reflect what shipped.
+Production assurance follows `implementation → verification(PASS) → diff
+review → final gate/audit`. A diff review maps the implementation's actual diff
+and fingerprint plus the verification output. If it returns `REJECT`, route the
+findings through corrected implementation and verification before a new diff
+review. A final auditor then confirms completeness. Progress tracking
+(todowrite, OpenSpec tasks, or project board) is updated to reflect what
+shipped.
 
 ### Phase 5 — Expansion Decision
 

--- a/packages/core/test/plugin/command.test.ts
+++ b/packages/core/test/plugin/command.test.ts
@@ -132,6 +132,105 @@ describe("CommandPlugin.Plugin", () => {
     }),
   )
 
+  it.effect("defines parent-session admission fixtures for standard deep and GRILL requests", () =>
+    Effect.sync(() => {
+      const fixtures = [
+        {
+          name: "simple request remains standard",
+          expected: "Simple or already-bounded work stays `standard`",
+        },
+        {
+          name: "qualified complex request recommends deep",
+          expected: "at least two deep-complexity signals",
+        },
+        {
+          name: "explicit deep enters admission",
+          expected: "Explicit `deep` intent still requires admission",
+        },
+        {
+          name: "questions stay in the parent session",
+          expected: "MUST NOT create an admission child node",
+        },
+        {
+          name: "explicit GRILL-ME selects adversarial QA",
+          expected: "`GRILL-ME` selects `GRILL`",
+        },
+      ]
+
+      for (const fixture of fixtures) {
+        expect(
+          CommandPlugin.OrchestrationPolicyContent,
+          fixture.name,
+        ).toContain(fixture.expected)
+      }
+    }),
+  )
+
+  it.effect("defines bounded Requirement Brief verdict and recovery contracts", () =>
+    Effect.sync(() => {
+      expect(CommandPlugin.OrchestrationPolicyContent).toContain("## Deep Admission QA")
+      for (const dimension of [
+        "goal",
+        "scope",
+        "constraints and assumptions",
+        "acceptance criteria",
+        "evidence and review",
+        "risks and failure modes",
+      ]) {
+        expect(CommandPlugin.OrchestrationPolicyContent).toContain(dimension)
+      }
+      for (const field of [
+        "acceptance_criteria",
+        "evidence_required",
+        "review_plan",
+        "open_questions",
+        "blocking_questions",
+      ]) {
+        expect(CommandPlugin.OrchestrationPolicyContent).toContain(field)
+      }
+      expect(CommandPlugin.OrchestrationPolicyContent).toContain('"in": []')
+      expect(CommandPlugin.OrchestrationPolicyContent).toContain('"out": []')
+      expect(CommandPlugin.OrchestrationPolicyContent).not.toContain("in_scope")
+      expect(CommandPlugin.OrchestrationPolicyContent).not.toContain("out_of_scope")
+      expect(CommandPlugin.OrchestrationPolicyContent).toContain("`LIGHT`: at most 1 question round")
+      expect(CommandPlugin.OrchestrationPolicyContent).toContain("`STANDARD`: at most 3 question rounds")
+      expect(CommandPlugin.OrchestrationPolicyContent).toContain("`GRILL`: at most 5 question rounds")
+      expect(CommandPlugin.OrchestrationPolicyContent).toContain("Stop early as soon as the brief is ready")
+      expect(CommandPlugin.OrchestrationPolicyContent).toContain("READY | NOT_READY | WAIVED")
+      expect(CommandPlugin.OrchestrationPolicyContent).toContain("continue QA, reduce scope, use `standard`, or explicitly waive")
+      expect(CommandPlugin.OrchestrationPolicyContent).toContain("waiver_reason")
+      expect(CommandPlugin.OrchestrationPolicyContent).toContain("acknowledged_risks")
+      expect(CommandPlugin.OrchestrationPolicyContent).toContain("Material changes")
+      expect(CommandPlugin.OrchestrationPolicyContent).toContain("invalidate the prior fingerprint")
+      expect(CommandPlugin.OrchestrationPolicyContent).toContain("SHA-256 hash")
+      expect(CommandPlugin.WorkflowFactsContent).toContain(
+        "pass `mode: deep` plus a versioned `READY` or informed `WAIVED` admission",
+      )
+      expect(CommandPlugin.WorkflowFactsContent).toContain(
+        "beside `config` in the `action: start` tool call",
+      )
+      expect(CommandPlugin.WorkflowFactsContent).not.toContain("`config.mode`")
+    }),
+  )
+
+  it.effect("documents truthful design and diff review production topologies", () =>
+    Effect.sync(() => {
+      expect(CommandPlugin.OrchestrationPolicyContent).toContain("design review → implementation")
+      expect(CommandPlugin.OrchestrationPolicyContent).toContain(
+        "implementation → verification(PASS) → diff review → final gate/audit",
+      )
+      expect(CommandPlugin.OrchestrationPolicyContent).toContain(
+        "REJECT → corrected implementation → verification(PASS) → new diff review",
+      )
+      expect(CommandPlugin.OrchestrationPolicyContent).toContain(
+        "Synthetic stress-test graphs",
+      )
+      expect(CommandPlugin.OrchestrationPolicyContent).toContain(
+        "MUST NOT claim implementation-diff assurance",
+      )
+    }),
+  )
+
   it.effect("keeps workflow examples aligned with runtime data flow and safety", () =>
     Effect.sync(() => {
       const graphExamples = [...CommandPlugin.WorkflowFactsContent.matchAll(/```yaml\n([\s\S]*?)```/g)]

--- a/packages/opencode/src/dag/admission.ts
+++ b/packages/opencode/src/dag/admission.ts
@@ -1,0 +1,215 @@
+export * as DagAdmission from "./admission"
+
+import { Schema } from "effect"
+
+export const States = [
+  "UNASSESSED",
+  "QUESTIONING",
+  "READY",
+  "NOT_READY",
+  "WAIVED",
+  "INVALIDATED",
+  "CONSUMED",
+] as const
+
+export type State = (typeof States)[number]
+
+export const Modes = ["LIGHT", "STANDARD", "GRILL"] as const
+export type Mode = (typeof Modes)[number]
+
+export const ExecutionModes = ["standard", "deep"] as const
+export const ExecutionMode = Schema.Literals(ExecutionModes)
+export type ExecutionMode = typeof ExecutionMode.Type
+
+export const QaPolicies = {
+  LIGHT: { max_rounds: 1 },
+  STANDARD: { max_rounds: 3 },
+  GRILL: { max_rounds: 5 },
+} as const satisfies Record<Mode, { max_rounds: number }>
+
+export const Verdicts = ["READY", "NOT_READY", "WAIVED"] as const
+export type Verdict = (typeof Verdicts)[number]
+
+const StringArray = Schema.Array(Schema.String)
+
+export const RequirementBrief = Schema.Struct({
+  goal: Schema.String,
+  scope: Schema.Struct({
+    in: StringArray,
+    out: StringArray,
+  }),
+  constraints: StringArray,
+  assumptions: StringArray,
+  acceptance_criteria: StringArray,
+  evidence_required: StringArray,
+  risks: StringArray,
+  review_plan: StringArray,
+  open_questions: StringArray,
+  blocking_questions: StringArray,
+})
+export type RequirementBrief = typeof RequirementBrief.Type
+
+export const AdmissionRecord = Schema.Struct({
+  protocol_version: Schema.Number,
+  brief_revision: Schema.Number,
+  qa_mode: Schema.Literals(Modes),
+  verdict: Schema.Literals(Verdicts),
+  state: Schema.Literals(States),
+  fingerprint: Schema.String,
+  brief: RequirementBrief,
+  waiver_reason: Schema.optional(Schema.String),
+  acknowledged_risks: Schema.optional(StringArray),
+})
+export type AdmissionRecord = typeof AdmissionRecord.Type
+
+const Transitions = {
+  UNASSESSED: ["QUESTIONING", "WAIVED"],
+  QUESTIONING: ["READY", "NOT_READY", "WAIVED"],
+  READY: ["INVALIDATED", "CONSUMED"],
+  NOT_READY: ["QUESTIONING", "WAIVED", "INVALIDATED"],
+  WAIVED: ["INVALIDATED", "CONSUMED"],
+  INVALIDATED: ["QUESTIONING"],
+  CONSUMED: [],
+} satisfies Record<State, readonly State[]>
+
+export class AdmissionTransitionError extends Error {
+  constructor(current: State, target: State) {
+    super(`Invalid admission transition: ${current} -> ${target}`)
+    this.name = "AdmissionTransitionError"
+  }
+}
+
+export function transitionAdmission(current: State, target: State) {
+  const allowed: readonly State[] = Transitions[current]
+  if (allowed.includes(target)) return target
+  throw new AdmissionTransitionError(current, target)
+}
+
+export function fingerprintBrief(brief: RequirementBrief) {
+  const canonical = {
+    goal: brief.goal.trim(),
+    scope: {
+      in: normalizedStrings(brief.scope.in),
+      out: normalizedStrings(brief.scope.out),
+    },
+    constraints: normalizedStrings(brief.constraints),
+    assumptions: normalizedStrings(brief.assumptions),
+    acceptance_criteria: normalizedStrings(brief.acceptance_criteria),
+    evidence_required: normalizedStrings(brief.evidence_required),
+    risks: normalizedStrings(brief.risks),
+    review_plan: normalizedStrings(brief.review_plan),
+    open_questions: normalizedStrings(brief.open_questions),
+    blocking_questions: normalizedStrings(brief.blocking_questions),
+  }
+  return new Bun.CryptoHasher("sha256").update(JSON.stringify(canonical)).digest("hex")
+}
+
+export function validateAdmission(record: AdmissionRecord) {
+  const errors = [
+    ...(record.protocol_version === 1 ? [] : ["protocol_version must be 1"]),
+    ...(Number.isInteger(record.brief_revision) && record.brief_revision > 0
+      ? []
+      : ["brief_revision must be a positive integer"]),
+    ...briefReadinessErrors(record.brief),
+    ...(record.verdict === "READY" && record.brief.blocking_questions.some((value) => value.trim())
+      ? ["READY admission must not contain blocking_questions"]
+      : []),
+    ...(record.verdict === "NOT_READY" && !record.brief.blocking_questions.some((value) => value.trim())
+      ? ["NOT_READY admission requires blocking_questions"]
+      : []),
+    ...(record.verdict === "WAIVED" && !record.waiver_reason?.trim()
+      ? ["WAIVED admission requires waiver_reason"]
+      : []),
+    ...(record.verdict === "WAIVED" && !record.acknowledged_risks?.some((value) => value.trim())
+      ? ["WAIVED admission requires acknowledged_risks"]
+      : []),
+    ...(record.state === record.verdict || (
+      record.state === "CONSUMED"
+      && (record.verdict === "READY" || record.verdict === "WAIVED")
+    )
+      ? []
+      : ["state must match the final admission verdict"]),
+    ...(record.fingerprint === fingerprintBrief(record.brief)
+      ? []
+      : ["fingerprint does not match the canonical Requirement Brief"]),
+  ]
+  if (errors.length > 0) return { valid: false as const, errors }
+  return { valid: true as const }
+}
+
+export function evaluateQa(input: {
+  qa_mode: Mode
+  rounds_completed: number
+  brief: RequirementBrief
+}) {
+  const maxRounds = QaPolicies[input.qa_mode].max_rounds
+  const roundsRemaining = Math.max(0, maxRounds - input.rounds_completed)
+  const blockers = [
+    ...briefReadinessErrors(input.brief),
+    ...input.brief.blocking_questions.map((value) => value.trim()).filter(Boolean),
+  ]
+  if (blockers.length === 0) {
+    return {
+      state: "READY" as const,
+      blockers,
+      rounds_remaining: roundsRemaining,
+    }
+  }
+  if (roundsRemaining === 0) {
+    return {
+      state: "NOT_READY" as const,
+      blockers,
+      rounds_remaining: roundsRemaining,
+    }
+  }
+  return {
+    state: "QUESTIONING" as const,
+    blockers,
+    rounds_remaining: roundsRemaining,
+  }
+}
+
+export function projectBriefForNode(brief: RequirementBrief) {
+  return {
+    goal: brief.goal.trim().slice(0, 2_000),
+    scope: {
+      in: boundedStrings(brief.scope.in),
+      out: boundedStrings(brief.scope.out),
+    },
+    constraints: boundedStrings(brief.constraints),
+    assumptions: boundedStrings(brief.assumptions),
+    acceptance_criteria: boundedStrings(brief.acceptance_criteria),
+    evidence_required: boundedStrings(brief.evidence_required),
+    risks: boundedStrings(brief.risks),
+    review_plan: boundedStrings(brief.review_plan),
+  }
+}
+
+function normalizedStrings(values: readonly string[]) {
+  return values
+    .map((value) => value.trim())
+    .filter(Boolean)
+    .sort()
+}
+
+function boundedStrings(values: readonly string[]) {
+  return values.slice(0, 20).map((value) => value.trim().slice(0, 500))
+}
+
+function briefReadinessErrors(brief: RequirementBrief) {
+  return [
+    ...(brief.goal.trim() ? [] : ["brief.goal must not be blank"]),
+    ...(brief.scope.in.some((value) => value.trim())
+      ? []
+      : ["brief.scope.in must contain at least one item"]),
+    ...(brief.acceptance_criteria.some((value) => value.trim())
+      ? []
+      : ["brief.acceptance_criteria must contain at least one item"]),
+    ...(brief.evidence_required.some((value) => value.trim())
+      ? []
+      : ["brief.evidence_required must contain at least one item"]),
+    ...(brief.review_plan.some((value) => value.trim())
+      ? []
+      : ["brief.review_plan must contain at least one item"]),
+  ]
+}

--- a/packages/opencode/src/dag/dag.ts
+++ b/packages/opencode/src/dag/dag.ts
@@ -22,6 +22,13 @@ import {
   WorkflowStatus,
   NodeStatus,
 } from "@opencode-ai/core/dag/core/types"
+import {
+  AdmissionRecord,
+  ExecutionMode,
+  transitionAdmission,
+  validateAdmission,
+} from "./admission"
+import { validateReviewLifecycle } from "./review-lifecycle"
 
 // Re-export domain types
 export const ID = DagEvent.DagID
@@ -54,6 +61,11 @@ export interface NodeConfig {
   restart?: boolean
   cancel?: boolean
   output_schema?: Record<string, unknown>
+  review?: {
+    phase: "design" | "diff"
+    implementation_node_id?: string
+    verification_node_id?: string
+  }
 }
 
 export interface NodeDefaults {
@@ -65,6 +77,8 @@ export interface NodeDefaults {
 
 export interface WorkflowConfig {
   name: string
+  mode?: ExecutionMode
+  admission?: AdmissionRecord
   max_concurrency?: number
   max_node_replan_attempts?: number
   max_total_nodes?: number
@@ -114,6 +128,7 @@ function normalizeWorkflowConfig(config: WorkflowConfig): WorkflowConfig {
   const defaults = normalizeNodeDefaults(config.node_defaults)
   return {
     ...config,
+    mode: config.mode ?? "standard",
     max_concurrency: config.max_concurrency ?? DEFAULT_WORKFLOW_CONFIG.maxConcurrency,
     max_node_replan_attempts: config.max_node_replan_attempts ?? DEFAULT_WORKFLOW_CONFIG.maxNodeReplanAttempts,
     max_total_nodes: config.max_total_nodes ?? DEFAULT_WORKFLOW_CONFIG.maxTotalNodes,
@@ -239,8 +254,47 @@ export const layer = Layer.effect(
       config: WorkflowConfig
     }) {
       const config = normalizeWorkflowConfig(input.config)
+      if (config.mode === "deep") {
+        if (!config.admission) {
+          return yield* Effect.fail(new Error(
+            "Deep workflow admission blocked: admission is required; complete parent-session QA or provide an informed waiver",
+          ))
+        }
+        const admission = validateAdmission(config.admission)
+        const stateAccepted = config.admission.state === "READY" || config.admission.state === "WAIVED"
+        if (!admission.valid || !stateAccepted) {
+          const errors = [
+            ...(!stateAccepted
+              ? [`state ${config.admission.state} cannot start a deep workflow; expected READY or WAIVED`]
+              : []),
+            ...(!admission.valid ? admission.errors : []),
+            ...config.admission.brief.blocking_questions,
+          ]
+          return yield* Effect.fail(new Error(
+            `Deep workflow admission blocked: ${errors.join("; ")}. Answer blockers, reduce scope, use standard mode, or provide an informed waiver`,
+          ))
+        }
+      }
+      const durableConfig = config.mode === "deep" && config.admission
+        ? {
+            ...config,
+            admission: {
+              ...config.admission,
+              state: transitionAdmission(config.admission.state, "CONSUMED"),
+            },
+          }
+        : config
+      const reviewLifecycle = validateReviewLifecycle(durableConfig)
+      if (!reviewLifecycle.valid) {
+        return yield* Effect.fail(new Error(
+          `Invalid review lifecycle: ${reviewLifecycle.errors.join("; ")}`,
+        ))
+      }
+      for (const warning of reviewLifecycle.warnings) {
+        yield* Effect.logWarning("DAG review lifecycle diagnostic", { warning })
+      }
       const validation = validateRequiredNodes({
-        nodes: config.nodes.map((n) => ({ id: n.id, depends_on: n.depends_on, required: n.required })),
+        nodes: durableConfig.nodes.map((n) => ({ id: n.id, depends_on: n.depends_on, required: n.required })),
       })
       if (!validation.valid) return yield* Effect.fail(new Error(`Invalid workflow config: ${validation.errors.join("; ")}`))
 
@@ -250,7 +304,7 @@ export const layer = Layer.effect(
       const cyclePath: string[] | null = yield* Effect.sync(() => {
         try {
           const graph = buildGraph(
-            config.nodes.map((n) => ({ id: n.id, dependsOn: n.depends_on, status: "pending" as const, required: n.required })),
+            durableConfig.nodes.map((n) => ({ id: n.id, dependsOn: n.depends_on, status: "pending" as const, required: n.required })),
           )
           return graph.hasCycle() ? (graph.findCycles()[0] ?? null) : null
         } catch (e) {
@@ -269,11 +323,11 @@ export const layer = Layer.effect(
         projectID: input.projectID as never,
         sessionID: input.sessionID as never,
         title: input.title,
-        config: JSON.stringify(config),
+        config: JSON.stringify(durableConfig),
         status: "pending",
         timestamp: ts,
       })
-      for (const node of config.nodes) {
+      for (const node of durableConfig.nodes) {
         yield* events.publish(DagEvent.NodeRegistered, {
           dagID,
           nodeID: node.id as never,
@@ -407,6 +461,20 @@ export const layer = Layer.effect(
       // (cumulative lifetime) — terminal nodes still count toward the cap.
       if (nodes.length + plan.add.length > maxTotalNodes) {
         return yield* Effect.fail(new Error(`Total node ceiling exceeded: ${nodes.length} existing + ${plan.add.length} new > ${maxTotalNodes} max`))
+      }
+
+      if (wfConfig) {
+        const reviewLifecycle = validateReviewLifecycle(
+          computeMergedConfig(wfConfig, normalizedFragment, plan),
+        )
+        if (!reviewLifecycle.valid) {
+          return yield* Effect.fail(new Error(
+            `Invalid review lifecycle: ${reviewLifecycle.errors.join("; ")}`,
+          ))
+        }
+        for (const warning of reviewLifecycle.warnings) {
+          yield* Effect.logWarning("DAG review lifecycle diagnostic", { warning })
+        }
       }
 
       const nodeById = new Map(nodes.map((n) => [n.id, n]))

--- a/packages/opencode/src/dag/review-lifecycle.ts
+++ b/packages/opencode/src/dag/review-lifecycle.ts
@@ -1,0 +1,239 @@
+export * as DagReviewLifecycle from "./review-lifecycle"
+
+import type { NodeConfig, WorkflowConfig } from "./dag"
+
+export function validateReviewLifecycle(config: WorkflowConfig) {
+  const issues = config.nodes.flatMap((node) => {
+    if (!isReviewWorker(node.worker_type)) return []
+    if (!node.review) {
+      if ((config.mode ?? "standard") === "standard") return []
+      return [`${node.id}: deep review worker must declare review.phase as "design" or "diff"`]
+    }
+    if (node.review.phase === "design") return []
+    return validateDiffReview(config, node.id)
+  })
+
+  if ((config.mode ?? "standard") === "standard") {
+    return { valid: true, errors: [], warnings: issues }
+  }
+  return { valid: issues.length === 0, errors: issues, warnings: [] }
+}
+
+export function validateReviewExecutionInput(
+  node: NodeConfig,
+  resolvedMapping: Record<string, unknown>,
+) {
+  if (!node.review || node.review.phase === "design") {
+    return {
+      valid: true,
+      phase: node.review?.phase,
+      satisfies_diff_gate: false,
+      errors: [],
+    }
+  }
+
+  const implementationID = node.review.implementation_node_id
+  const verificationID = node.review.verification_node_id
+  const entries = Object.entries(node.input_mapping ?? {})
+  const implementationKey = entries.find(([, source]) => {
+    const [sourceID, output, field] = source.split(".")
+    return sourceID === implementationID
+      && output === "output"
+      && field !== undefined
+      && ["diff", "patch", "changed_files"].includes(field)
+  })?.[0]
+  const fingerprintKey = entries.find(([, source]) => {
+    const [sourceID, output, field] = source.split(".")
+    return sourceID === implementationID && output === "output" && field === "fingerprint"
+  })?.[0]
+  const verificationKey = entries.find(([, source]) => source.split(".")[0] === verificationID)?.[0]
+  const errors = [
+    ...(hasEvidence(implementationKey ? resolvedMapping[implementationKey] : undefined)
+      ? []
+      : [`${node.id}: implementation evidence is empty or unresolved`]),
+    ...(hasEvidence(fingerprintKey ? resolvedMapping[fingerprintKey] : undefined)
+      ? []
+      : [`${node.id}: implementation fingerprint is empty or unresolved`]),
+    ...(hasPassVerdict(verificationKey ? resolvedMapping[verificationKey] : undefined)
+      ? []
+      : [`${node.id}: verification evidence must contain verdict PASS`]),
+  ]
+  return {
+    valid: errors.length === 0,
+    phase: "diff" as const,
+    satisfies_diff_gate: errors.length === 0,
+    errors,
+  }
+}
+
+export function reviewImplementationFingerprint(
+  node: NodeConfig,
+  resolvedMapping: Record<string, unknown>,
+) {
+  if (node.review?.phase !== "diff") return undefined
+  const implementationID = node.review.implementation_node_id
+  const fingerprintKey = Object.entries(node.input_mapping ?? {}).find(([, source]) => {
+    const [sourceID, output, field] = source.split(".")
+    return sourceID === implementationID && output === "output" && field === "fingerprint"
+  })?.[0]
+  const fingerprint = fingerprintKey ? resolvedMapping[fingerprintKey] : undefined
+  return typeof fingerprint === "string" && fingerprint.trim() !== ""
+    ? fingerprint
+    : undefined
+}
+
+export function validateReviewResult(output: unknown, currentFingerprint: string) {
+  if (typeof output !== "object" || output === null || Array.isArray(output)) {
+    return {
+      valid: false,
+      action: "invalidate" as const,
+      reviewed_fingerprint: "",
+      errors: ["review result must be a structured object"],
+    }
+  }
+
+  const verdict = "verdict" in output ? output.verdict : undefined
+  const fingerprint = "implementation_fingerprint" in output
+    ? output.implementation_fingerprint
+    : undefined
+  const reviewedFingerprint = typeof fingerprint === "string" ? fingerprint : ""
+  const errors = [
+    ...(["ACCEPT", "REJECT"].includes(typeof verdict === "string" ? verdict : "")
+      ? []
+      : ["review result verdict must be ACCEPT or REJECT"]),
+    ...(reviewedFingerprint.trim() === ""
+      ? ["review result must include implementation_fingerprint"]
+      : reviewedFingerprint === currentFingerprint
+        ? []
+        : [`review result fingerprint ${reviewedFingerprint} does not match current implementation ${currentFingerprint}`]),
+  ]
+  return {
+    valid: errors.length === 0,
+    action: errors.length > 0
+      ? "invalidate" as const
+      : verdict === "ACCEPT"
+        ? "proceed" as const
+        : "correct" as const,
+    reviewed_fingerprint: reviewedFingerprint,
+    errors,
+  }
+}
+
+export function reviewContractForNode(node: NodeConfig) {
+  if (!node.review) return undefined
+  if (node.review.phase === "design") {
+    return [
+      "Review contract: this is a design/specification review.",
+      "Evaluate only the pre-implementation artifacts supplied by dependencies.",
+      "You MUST NOT claim to have inspected an implementation diff or executed implementation tests.",
+    ].join(" ")
+  }
+  return [
+    "Review contract: this is an implementation diff review.",
+    "Base the verdict on the supplied actual diff, implementation fingerprint, and verification PASS evidence.",
+    "The structured result must report ACCEPT or REJECT and echo the reviewed implementation fingerprint.",
+  ].join(" ")
+}
+
+function validateDiffReview(config: WorkflowConfig, reviewID: string) {
+  const review = config.nodes.find((node) => node.id === reviewID)
+  if (!review?.review || review.review.phase !== "diff") return []
+
+  const implementationID = review.review.implementation_node_id
+  const verificationID = review.review.verification_node_id
+  const missing = [
+    ...(!implementationID
+      ? [`${reviewID}: diff review must declare implementation_node_id`]
+      : config.nodes.some((node) => node.id === implementationID)
+        ? []
+        : [`${reviewID}: implementation node ${implementationID} does not exist`]),
+    ...(!verificationID
+      ? [`${reviewID}: diff review must declare verification_node_id`]
+      : config.nodes.some((node) => node.id === verificationID)
+        ? []
+        : [`${reviewID}: verification node ${verificationID} does not exist`]),
+  ]
+  if (missing.length > 0 || !implementationID || !verificationID) return missing
+
+  const sources = Object.values(review.input_mapping ?? {})
+  const implementationArtifact = sources.some((source) => {
+    const [nodeID, output, field] = source.split(".")
+    return nodeID === implementationID
+      && output === "output"
+      && field !== undefined
+      && ["diff", "patch", "changed_files"].includes(field)
+  })
+  const verificationOutput = sources.some((source) => source.split(".")[0] === verificationID)
+  const implementationFingerprint = sources.some((source) => {
+    const [nodeID, output, field] = source.split(".")
+    return nodeID === implementationID && output === "output" && field === "fingerprint"
+  })
+
+  return [
+    ...(dependsTransitively(config, reviewID, verificationID)
+      ? []
+      : [`${reviewID}: diff review must depend transitively on verification node ${verificationID}`]),
+    ...(dependsTransitively(config, verificationID, implementationID)
+      ? []
+      : [`${reviewID}: verification node ${verificationID} must depend transitively on implementation node ${implementationID}`]),
+    ...(implementationArtifact
+      ? []
+      : [`${reviewID}: input_mapping must map an actual diff or changed-file artifact from ${implementationID}`]),
+    ...(implementationFingerprint
+      ? []
+      : [`${reviewID}: input_mapping must map implementation fingerprint from ${implementationID}`]),
+    ...(verificationOutput
+      ? []
+      : [`${reviewID}: input_mapping must map verification output from ${verificationID}`]),
+    ...(review.condition?.includes(verificationID) && review.condition.includes("PASS")
+      ? []
+      : [`${reviewID}: condition must require PASS from verification node ${verificationID}`]),
+    ...(hasReviewResultSchema(review.output_schema)
+      ? []
+      : [`${reviewID}: output_schema must require verdict and implementation_fingerprint`]),
+  ]
+}
+
+function hasReviewResultSchema(schema: Record<string, unknown> | undefined) {
+  if (!schema || schema.type !== "object") return false
+  const required = schema.required
+  if (!Array.isArray(required)) return false
+  return ["verdict", "implementation_fingerprint"].every((field) =>
+    required.includes(field),
+  )
+}
+
+function hasEvidence(value: unknown): boolean {
+  if (typeof value === "string") {
+    const text = value.trim()
+    return text.length > 0
+      && !text.includes("{{")
+      && !text.startsWith("Dependency ")
+  }
+  if (Array.isArray(value)) return value.some(hasEvidence)
+  if (typeof value !== "object" || value === null) return false
+  return Object.values(value).some(hasEvidence)
+}
+
+function hasPassVerdict(value: unknown): boolean {
+  if (value === "PASS") return true
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false
+  return "verdict" in value && value.verdict === "PASS"
+}
+
+function dependsTransitively(config: WorkflowConfig, startID: string, targetID: string) {
+  const visited = new Set<string>()
+  const visit = (nodeID: string): boolean => {
+    if (visited.has(nodeID)) return false
+    visited.add(nodeID)
+    const node = config.nodes.find((candidate) => candidate.id === nodeID)
+    if (!node) return false
+    if (node.depends_on.includes(targetID)) return true
+    return node.depends_on.some(visit)
+  }
+  return visit(startID)
+}
+
+function isReviewWorker(workerType: string) {
+  return workerType === "review" || workerType.startsWith("review-")
+}

--- a/packages/opencode/src/dag/runtime/loop.ts
+++ b/packages/opencode/src/dag/runtime/loop.ts
@@ -10,6 +10,12 @@ import { DagStore } from "@opencode-ai/core/dag/store"
 import { WorkflowRuntime, type SchedulingNode } from "@opencode-ai/core/dag/core/scheduling"
 import { isWorkflowTerminalStatus } from "@opencode-ai/core/dag/core/types"
 import { Dag, type WorkflowConfig, parseWorkflowConfig } from "../dag"
+import { projectBriefForNode } from "../admission"
+import {
+  reviewImplementationFingerprint,
+  reviewContractForNode,
+  validateReviewExecutionInput,
+} from "../review-lifecycle"
 import { Agent } from "@/agent/agent"
 import { Session } from "@/session/session"
 import { SessionPrompt } from "@/session/prompt"
@@ -125,6 +131,20 @@ export const layer = Layer.effect(
             // outputs) before interpolation and Context serialization.
             resolvedMapping = sanitizeInput(resolvedMapping)
 
+            if (nodeConfig) {
+              const reviewInput = validateReviewExecutionInput(nodeConfig, resolvedMapping)
+              if (!reviewInput.valid) {
+                yield* dag.nodeFailed(
+                  dagID,
+                  nodeID,
+                  `Review input contract failed: ${reviewInput.errors.join("; ")}`,
+                  "verdict_fail",
+                ).pipe(Effect.ignore)
+                entry.runtime.markUnsatisfied(nodeID)
+                continue
+              }
+            }
+
             const resolved = yield* (nodeConfig?.prompt_template
               ? renderTemplate(nodeConfig.prompt_template, ctx.directory, resolvedMapping).pipe(
                   Effect.tap((result) =>
@@ -163,6 +183,18 @@ export const layer = Layer.effect(
 
             promptParts.push({ type: "text", text: resolved.text })
 
+            const reviewContract = nodeConfig ? reviewContractForNode(nodeConfig) : undefined
+            if (reviewContract) {
+              promptParts.push({ type: "text", text: `\n\n${reviewContract}` })
+            }
+
+            if (entry.config?.mode === "deep" && entry.config.admission) {
+              promptParts.push({
+                type: "text",
+                text: `\n\nRequirement Brief:\n${JSON.stringify(projectBriefForNode(entry.config.admission.brief), null, 2)}`,
+              })
+            }
+
             if (Object.keys(resolvedMapping).length > 0) {
               promptParts.push({ type: "text", text: `\n\nContext:\n${JSON.stringify(resolvedMapping, null, 2)}` })
             }
@@ -187,6 +219,9 @@ export const layer = Layer.effect(
               outputSchema: nodeConfig?.output_schema as Record<string, unknown> | undefined,
               timeoutMs: nodeConfig?.worker_config?.timeout_ms,
               reportToParent: nodeConfig?.report_to_parent,
+              reviewImplementationFingerprint: nodeConfig
+                ? reviewImplementationFingerprint(nodeConfig, resolvedMapping)
+                : undefined,
             }).pipe(
               Effect.tap((result) => Effect.sync(() => entry.fibers.set(nodeID, result.fiber))),
               Effect.provideService(Dag.Service, dag),

--- a/packages/opencode/src/dag/runtime/spawn.ts
+++ b/packages/opencode/src/dag/runtime/spawn.ts
@@ -21,6 +21,7 @@ import { SessionID, MessageID } from "@/session/schema"
 import { deriveSubagentSessionPermission } from "@/agent/subagent-permissions"
 import { SessionPrompt } from "@/session/prompt"
 import { Dag } from "../dag"
+import { validateReviewResult } from "../review-lifecycle"
 import { InvalidTransitionError, TerminalViolationError } from "@opencode-ai/core/dag/core/types"
 import type { DagStore } from "@opencode-ai/core/dag/store"
 import { registerCaptureSlot, clearCaptureSlot } from "./capture"
@@ -39,6 +40,7 @@ export interface NodeSpawnInput {
   outputSchema?: Record<string, unknown>
   timeoutMs?: number
   reportToParent?: boolean
+  reviewImplementationFingerprint?: string
 }
 
 export interface NodeSpawnResult {
@@ -189,6 +191,26 @@ export function spawnNode(
             const updatedNode = yield* dag.store.getNode(input.dagID, input.nodeID).pipe(Effect.orDie)
             const captured = updatedNode?.capturedOutput
             if (captured !== undefined && captured !== null) {
+              if (input.reviewImplementationFingerprint) {
+                const reviewResult = validateReviewResult(
+                  captured,
+                  input.reviewImplementationFingerprint,
+                )
+                if (!reviewResult.valid) {
+                  yield* dag.nodeFailed(
+                    input.dagID,
+                    input.nodeID,
+                    `Review result contract failed: ${reviewResult.errors.join("; ")}`,
+                    "verdict_fail",
+                  ).pipe(
+                    Effect.catchIf(
+                      isTransitionRejection,
+                      () => Effect.logWarning("nodeFailed (review result contract) guard rejected — node already terminal"),
+                    ),
+                  )
+                  return
+                }
+              }
               yield* dag.nodeCompleted(input.dagID, input.nodeID, captured).pipe(
                 Effect.catchIf(
                   isTransitionRejection,

--- a/packages/opencode/src/tool/workflow.ts
+++ b/packages/opencode/src/tool/workflow.ts
@@ -5,6 +5,7 @@ import { Dag } from "@/dag/dag"
 import { Session } from "@/session/session"
 import { SessionID } from "@/session/schema"
 import type { NodeConfig, WorkflowConfig } from "@/dag/dag"
+import { AdmissionRecord, ExecutionMode } from "@/dag/admission"
 
 const id = "workflow"
 
@@ -45,6 +46,13 @@ const NodeSchema = Schema.Struct({
   restart: Schema.optional(Schema.Boolean).annotate({ description: "(replan only) Re-spawn this running node with new prompt" }),
   cancel: Schema.optional(Schema.Boolean).annotate({ description: "(replan only) Cancel this node" }),
   output_schema: Schema.optional(Schema.Record(Schema.String, Schema.Unknown)).annotate({ description: "JSON Schema; child agent must call submit_result to submit structured output" }),
+  review: Schema.optional(
+    Schema.Struct({
+      phase: Schema.Literals(["design", "diff"]),
+      implementation_node_id: Schema.optional(Schema.String),
+      verification_node_id: Schema.optional(Schema.String),
+    }),
+  ).annotate({ description: '(deep review workers) design reviews pre-implementation artifacts; diff reviews require implementation_node_id and verification_node_id' }),
 })
 
 const WorkflowGraphSchema = Schema.Struct({
@@ -77,6 +85,8 @@ const WorkflowGraphSchema = Schema.Struct({
 export const Parameters = Schema.Struct({
   action: Schema.Literals(["start", "extend", "control", "status"]).annotate({ description: "start: create workflow; extend: add nodes; control: pause/resume/cancel/replan/step/complete; status: inspect durable workflow and node state" }),
   config: Schema.optional(WorkflowGraphSchema).annotate({ description: "(start) Workflow graph definition" }),
+  mode: Schema.optional(ExecutionMode).annotate({ description: "(start) standard by default; deep requires completed parent-session admission QA" }),
+  admission: Schema.optional(AdmissionRecord).annotate({ description: "(start deep) Structured Requirement Brief and READY/WAIVED verdict" }),
   session_id: Schema.optional(Schema.String).annotate({ description: "(start) Parent session ID" }),
   project_id: Schema.optional(Schema.String).annotate({ description: "(start) Optional Project ID; must match the parent session project" }),
   title: Schema.optional(Schema.String).annotate({ description: "(start) Workflow title" }),
@@ -109,6 +119,7 @@ export const WorkflowTool = Tool.define<typeof Parameters, Metadata, Dag.Service
               const workflow = yield* dag.store.getWorkflow(params.workflow_id).pipe(Effect.orDie)
               if (!workflow) return yield* Effect.die(new Error(`Workflow not found: ${params.workflow_id}`))
               const nodes = yield* dag.store.getNodes(params.workflow_id).pipe(Effect.orDie)
+              const config = Dag.parseWorkflowConfig(workflow.config)
               return {
                 title: `Workflow status: ${workflow.title}`,
                 output: JSON.stringify(
@@ -117,6 +128,24 @@ export const WorkflowTool = Tool.define<typeof Parameters, Metadata, Dag.Service
                     title: workflow.title,
                     status: workflow.status,
                     session_id: workflow.sessionId,
+                    mode: config?.mode ?? "standard",
+                    ...(config?.admission
+                      ? {
+                          admission: {
+                            verdict: config.admission.verdict,
+                            state: config.admission.state,
+                            qa_mode: config.admission.qa_mode,
+                            brief_revision: config.admission.brief_revision,
+                            fingerprint: config.admission.fingerprint,
+                            ...(config.admission.waiver_reason
+                              ? { waiver_reason: config.admission.waiver_reason }
+                              : {}),
+                            ...(config.admission.acknowledged_risks
+                              ? { acknowledged_risks: config.admission.acknowledged_risks }
+                              : {}),
+                          },
+                        }
+                      : {}),
                     nodes: nodes.map((node) => ({
                       id: node.id,
                       name: node.name,
@@ -144,11 +173,16 @@ export const WorkflowTool = Tool.define<typeof Parameters, Metadata, Dag.Service
                 projectID: session.projectID,
                 sessionID,
                 title: params.title ?? params.config.name,
-                config: params.config as WorkflowConfig,
+                config: {
+                  ...params.config,
+                  mode: params.mode ?? "standard",
+                  ...(params.admission ? { admission: params.admission } : {}),
+                } as WorkflowConfig,
               }).pipe(Effect.orDie)
+              const mode = params.mode ?? "standard"
               return {
                 title: `Workflow started: ${params.config.name}`,
-                output: `<workflow id="${dagID}" state="running">\n${params.config.nodes.length} nodes registered.\nDo not poll this workflow. It runs asynchronously and will wake the parent session when attention is required.\n</workflow>`,
+                output: `<workflow id="${dagID}" state="running" mode="${mode}">\n${params.config.nodes.length} nodes registered.\nDo not poll this workflow. It runs asynchronously and will wake the parent session when attention is required.\n</workflow>`,
                 metadata: { workflowId: dagID } as Metadata,
               }
             }

--- a/packages/opencode/test/dag/dag-admission.test.ts
+++ b/packages/opencode/test/dag/dag-admission.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it } from "bun:test"
+import { Schema } from "effect"
+import {
+  AdmissionRecord,
+  AdmissionTransitionError,
+  evaluateQa,
+  fingerprintBrief,
+  Modes,
+  QaPolicies,
+  projectBriefForNode,
+  States,
+  transitionAdmission,
+  validateAdmission,
+  Verdicts,
+} from "@/dag/admission"
+
+const readyBrief = {
+  goal: "Add durable deep-workflow admission",
+  scope: {
+    in: ["workflow start", "DAG validation"],
+    out: ["admission management UI"],
+  },
+  constraints: ["standard workflows remain compatible"],
+  assumptions: ["the parent session can ask questions"],
+  acceptance_criteria: ["deep start rejects unresolved blockers"],
+  evidence_required: ["unit tests", "integration tests"],
+  risks: ["users may overuse waivers"],
+  review_plan: ["verify implementation", "review the actual diff"],
+  open_questions: [],
+  blocking_questions: [],
+}
+
+function recordFor(verdict: (typeof Verdicts)[number], qaMode: (typeof Modes)[number]) {
+  const brief = verdict === "READY"
+    ? readyBrief
+    : {
+        ...readyBrief,
+        blocking_questions: ["Which deployment environments are required?"],
+      }
+  return {
+    protocol_version: 1,
+    brief_revision: 1,
+    qa_mode: qaMode,
+    verdict,
+    state: verdict,
+    fingerprint: fingerprintBrief(brief),
+    brief,
+    ...(verdict === "WAIVED"
+      ? {
+          waiver_reason: "Proceed with preview-only deployment",
+          acknowledged_risks: ["Production deployment remains unspecified"],
+        }
+      : {}),
+  }
+}
+
+describe("DAG admission", () => {
+  it("accepts exactly the specified admission state transitions", () => {
+    const allowed = new Set([
+      "UNASSESSED:QUESTIONING",
+      "UNASSESSED:WAIVED",
+      "QUESTIONING:READY",
+      "QUESTIONING:NOT_READY",
+      "QUESTIONING:WAIVED",
+      "NOT_READY:QUESTIONING",
+      "NOT_READY:WAIVED",
+      "NOT_READY:INVALIDATED",
+      "READY:INVALIDATED",
+      "READY:CONSUMED",
+      "WAIVED:INVALIDATED",
+      "WAIVED:CONSUMED",
+      "INVALIDATED:QUESTIONING",
+    ])
+
+    for (const current of States) {
+      for (const target of States) {
+        const key = `${current}:${target}`
+        if (allowed.has(key)) {
+          expect(transitionAdmission(current, target)).toBe(target)
+          continue
+        }
+        expect(() => transitionAdmission(current, target)).toThrow(AdmissionTransitionError)
+        expect(() => transitionAdmission(current, target)).toThrow(`${current} -> ${target}`)
+      }
+    }
+  })
+
+  it("decodes every QA mode and final verdict fixture", () => {
+    const decode = Schema.decodeUnknownSync(AdmissionRecord)
+    for (const qaMode of Modes) {
+      for (const verdict of Verdicts) {
+        expect(decode(recordFor(verdict, qaMode))).toEqual(recordFor(verdict, qaMode))
+      }
+    }
+  })
+
+  it("rejects records missing required Requirement Brief fields", () => {
+    const decode = Schema.decodeUnknownSync(AdmissionRecord)
+    const input = recordFor("READY", "STANDARD")
+    expect(() => decode({
+      ...input,
+      brief: {
+        ...input.brief,
+        acceptance_criteria: undefined,
+      },
+    })).toThrow()
+  })
+
+  it("rejects READY when required content is blank or blockers remain", () => {
+    const input = recordFor("READY", "STANDARD")
+    expect(validateAdmission({
+      ...input,
+      brief: {
+        ...input.brief,
+        goal: " ",
+        blocking_questions: ["Define the rollout target"],
+      },
+    })).toEqual({
+      valid: false,
+      errors: [
+        "brief.goal must not be blank",
+        "READY admission must not contain blocking_questions",
+        "fingerprint does not match the canonical Requirement Brief",
+      ],
+    })
+  })
+
+  it("rejects an uninformed WAIVED verdict", () => {
+    const input = recordFor("WAIVED", "GRILL")
+    expect(validateAdmission({
+      ...input,
+      waiver_reason: " ",
+      acknowledged_risks: [],
+    })).toEqual({
+      valid: false,
+      errors: [
+        "WAIVED admission requires waiver_reason",
+        "WAIVED admission requires acknowledged_risks",
+      ],
+    })
+  })
+
+  it("fingerprints canonical briefs deterministically and tracks revisions", () => {
+    const reordered = {
+      ...readyBrief,
+      scope: {
+        in: ["DAG validation", "workflow start"],
+        out: ["admission management UI"],
+      },
+      evidence_required: ["integration tests", "unit tests"],
+    }
+    expect(fingerprintBrief(reordered)).toBe(fingerprintBrief(readyBrief))
+    expect(fingerprintBrief({
+      ...readyBrief,
+      acceptance_criteria: ["deep start accepts unresolved blockers"],
+    })).not.toBe(fingerprintBrief(readyBrief))
+    expect(fingerprintBrief(readyBrief)).toMatch(/^[a-f0-9]{64}$/)
+  })
+
+  it("stops questioning early when the brief is ready", () => {
+    for (const qaMode of Modes) {
+      expect(evaluateQa({
+        qa_mode: qaMode,
+        rounds_completed: 0,
+        brief: readyBrief,
+      })).toEqual({
+        state: "READY",
+        blockers: [],
+        rounds_remaining: QaPolicies[qaMode].max_rounds,
+      })
+    }
+  })
+
+  it("uses one, three, and five round budgets before NOT_READY", () => {
+    expect(QaPolicies).toEqual({
+      LIGHT: { max_rounds: 1 },
+      STANDARD: { max_rounds: 3 },
+      GRILL: { max_rounds: 5 },
+    })
+    const brief = {
+      ...readyBrief,
+      acceptance_criteria: [],
+      blocking_questions: ["Define the acceptance criteria"],
+    }
+
+    for (const qaMode of Modes) {
+      const max = QaPolicies[qaMode].max_rounds
+      expect(evaluateQa({
+        qa_mode: qaMode,
+        rounds_completed: max - 1,
+        brief,
+      })).toEqual({
+        state: "QUESTIONING",
+        blockers: [
+          "brief.acceptance_criteria must contain at least one item",
+          "Define the acceptance criteria",
+        ],
+        rounds_remaining: 1,
+      })
+      expect(evaluateQa({
+        qa_mode: qaMode,
+        rounds_completed: max,
+        brief,
+      })).toEqual({
+        state: "NOT_READY",
+        blockers: [
+          "brief.acceptance_criteria must contain at least one item",
+          "Define the acceptance criteria",
+        ],
+        rounds_remaining: 0,
+      })
+    }
+  })
+
+  it("projects bounded execution context without QA transcript chatter", () => {
+    const projection = projectBriefForNode({
+      ...readyBrief,
+      constraints: Array.from({ length: 25 }, (_, index) => `constraint-${index}-${"x".repeat(600)}`),
+      open_questions: ["raw QA transcript: maybe later"],
+      blocking_questions: ["raw QA transcript: unanswered"],
+    })
+
+    expect(projection).toEqual({
+      goal: readyBrief.goal,
+      scope: readyBrief.scope,
+      constraints: expect.any(Array),
+      assumptions: readyBrief.assumptions,
+      acceptance_criteria: readyBrief.acceptance_criteria,
+      evidence_required: readyBrief.evidence_required,
+      risks: readyBrief.risks,
+      review_plan: readyBrief.review_plan,
+    })
+    expect(projection.constraints).toHaveLength(20)
+    expect(projection.constraints.every((value) => value.length <= 500)).toBe(true)
+    expect(JSON.stringify(projection)).not.toContain("raw QA transcript")
+    expect(projection).not.toHaveProperty("open_questions")
+    expect(projection).not.toHaveProperty("blocking_questions")
+  })
+})

--- a/packages/opencode/test/dag/dag-loop-recovery-integration.test.ts
+++ b/packages/opencode/test/dag/dag-loop-recovery-integration.test.ts
@@ -8,8 +8,9 @@ import { ProjectTable } from "@opencode-ai/core/project/sql"
 import { SessionTable } from "@opencode-ai/core/session/sql"
 import { DagEvent } from "@opencode-ai/schema/dag-event"
 import { Agent } from "@/agent/agent"
-import { Dag, type NodeConfig } from "@/dag/dag"
+import { Dag, type NodeConfig, type WorkflowConfig } from "@/dag/dag"
 import { DagLoop } from "@/dag/runtime/loop"
+import { fingerprintBrief } from "@/dag/admission"
 import { InstanceRef } from "@/effect/instance-ref"
 import { EventV2Bridge } from "@/event-v2-bridge"
 import { SessionPrompt } from "@/session/prompt"
@@ -124,6 +125,7 @@ function createRunningNode(
   config: NodeConfig[],
   deadlineMs?: number,
   wakeEligible?: boolean,
+  configOverrides: Partial<WorkflowConfig> = {},
 ) {
   return Effect.gen(function* () {
     yield* database.db.insert(ProjectTable).values({
@@ -143,7 +145,7 @@ function createRunningNode(
       projectID: "project-1",
       sessionID: "ses_parent1",
       title: "Recovery",
-      config: { name: "recovery", nodes: config },
+      config: { name: "recovery", nodes: config, ...configOverrides },
     })
     yield* dag.nodeStarted(dagID, "n1", "ses_child1", deadlineMs, wakeEligible)
     return dagID
@@ -151,6 +153,64 @@ function createRunningNode(
 }
 
 describe("DagLoop crash recovery integration", () => {
+  it("retains consumed deep admission across recovery without replaying QA", async () => {
+    const brief = {
+      goal: "Recover a qualified deep workflow",
+      scope: { in: ["DAG recovery"], out: ["admission UI"] },
+      constraints: ["keep the original brief"],
+      assumptions: ["the durable config is available"],
+      acceptance_criteria: ["recovery retains the consumed admission"],
+      evidence_required: ["integration test"],
+      risks: ["production rollout is unspecified"],
+      review_plan: ["verify the recovered config"],
+      open_questions: [],
+      blocking_questions: ["Confirm production rollout"],
+    }
+    await Effect.runPromise(
+      runRecovery("active", ({ dag, database, loop, store, created }) =>
+        Effect.gen(function* () {
+          const dagID = yield* createRunningNode(
+            dag,
+            database,
+            [node()],
+            undefined,
+            undefined,
+            {
+              mode: "deep",
+              admission: {
+                protocol_version: 1,
+                brief_revision: 2,
+                qa_mode: "GRILL",
+                verdict: "WAIVED",
+                state: "WAIVED",
+                fingerprint: fingerprintBrief(brief),
+                brief,
+                waiver_reason: "Preview recovery coverage only",
+                acknowledged_risks: ["Production rollout is unspecified"],
+              },
+            },
+          )
+
+          yield* loop.init()
+
+          const workflow = yield* store.getWorkflow(dagID)
+          expect(Dag.parseWorkflowConfig(workflow?.config ?? "")).toEqual(expect.objectContaining({
+            mode: "deep",
+            admission: expect.objectContaining({
+              state: "CONSUMED",
+              verdict: "WAIVED",
+              brief_revision: 2,
+              brief,
+              waiver_reason: "Preview recovery coverage only",
+              acknowledged_risks: ["Production rollout is unspecified"],
+            }),
+          }))
+          expect(created).toEqual([])
+        }),
+      ),
+    )
+  })
+
   it("cancels active children with future or absent deadlines without spawning replacements", async () => {
     for (const deadline of [Date.now() + 60_000, undefined]) {
       await Effect.runPromise(

--- a/packages/opencode/test/dag/dag-review-lifecycle.test.ts
+++ b/packages/opencode/test/dag/dag-review-lifecycle.test.ts
@@ -1,0 +1,346 @@
+import { describe, expect, it } from "bun:test"
+import type { NodeConfig, WorkflowConfig } from "@/dag/dag"
+import {
+  reviewContractForNode,
+  validateReviewExecutionInput,
+  validateReviewLifecycle,
+  validateReviewResult,
+} from "@/dag/review-lifecycle"
+
+function node(id: string, overrides: Partial<NodeConfig> = {}): NodeConfig {
+  return {
+    id,
+    name: id,
+    worker_type: "build",
+    depends_on: [],
+    required: true,
+    prompt_template: { inline: `Run ${id}` },
+    ...overrides,
+  }
+}
+
+function workflow(mode: "standard" | "deep", nodes: NodeConfig[]): WorkflowConfig {
+  return { name: "review-lifecycle", mode, nodes }
+}
+
+function validDiffFlow() {
+  return [
+    node("implement", {
+      output_schema: {
+        type: "object",
+        properties: {
+          diff: { type: "string" },
+          fingerprint: { type: "string" },
+        },
+        required: ["diff", "fingerprint"],
+      },
+    }),
+    node("verify", {
+      depends_on: ["implement"],
+      output_schema: {
+        type: "object",
+        properties: { verdict: { enum: ["PASS", "FAIL"] } },
+        required: ["verdict"],
+      },
+    }),
+    node("review-diff", {
+      worker_type: "review",
+      depends_on: ["verify"],
+      review: {
+        phase: "diff",
+        implementation_node_id: "implement",
+        verification_node_id: "verify",
+      },
+      input_mapping: {
+        diff: "implement.output.diff",
+        implementation_fingerprint: "implement.output.fingerprint",
+        verification: "verify.output",
+      },
+      condition: 'verify.output.verdict == "PASS"',
+      output_schema: {
+        type: "object",
+        properties: {
+          verdict: { enum: ["ACCEPT", "REJECT"] },
+          implementation_fingerprint: { type: "string" },
+        },
+        required: ["verdict", "implementation_fingerprint"],
+      },
+    }),
+  ]
+}
+
+describe("DAG review lifecycle", () => {
+  it("accepts a pre-implementation design review in a deep workflow", () => {
+    const result = validateReviewLifecycle(workflow("deep", [
+      node("spec", { worker_type: "plan" }),
+      node("review-design", {
+        worker_type: "review",
+        depends_on: ["spec"],
+        review: { phase: "design" },
+      }),
+      node("implement", { depends_on: ["review-design"] }),
+    ]))
+
+    expect(result).toEqual({ valid: true, errors: [], warnings: [] })
+  })
+
+  it("rejects an unclassified review in a deep workflow", () => {
+    const result = validateReviewLifecycle(workflow("deep", [
+      node("explore", { worker_type: "explore" }),
+      node("review-security", {
+        worker_type: "review",
+        depends_on: ["explore"],
+      }),
+    ]))
+
+    expect(result.valid).toBe(false)
+    expect(result.errors).toEqual([
+      'review-security: deep review worker must declare review.phase as "design" or "diff"',
+    ])
+  })
+
+  it("preserves an unclassified legacy review in a standard workflow", () => {
+    expect(validateReviewLifecycle(workflow("standard", [
+      node("review-legacy", { worker_type: "review" }),
+    ]))).toEqual({ valid: true, errors: [], warnings: [] })
+  })
+
+  it("accepts implementation to verification PASS to diff review", () => {
+    expect(validateReviewLifecycle(workflow("deep", validDiffFlow()))).toEqual({
+      valid: true,
+      errors: [],
+      warnings: [],
+    })
+  })
+
+  it("reports every missing diff-review evidence edge and mapping", () => {
+    const nodes = validDiffFlow()
+    const review = nodes[2]
+    if (!review) throw new Error("fixture is incomplete")
+    review.depends_on = []
+    review.input_mapping = {
+      plan: "implement.output",
+    }
+    review.condition = 'verify.output.verdict == "FAIL"'
+
+    const result = validateReviewLifecycle(workflow("deep", nodes))
+    expect(result.valid).toBe(false)
+    expect(result.errors).toEqual([
+      "review-diff: diff review must depend transitively on verification node verify",
+      "review-diff: input_mapping must map an actual diff or changed-file artifact from implement",
+      "review-diff: input_mapping must map implementation fingerprint from implement",
+      "review-diff: input_mapping must map verification output from verify",
+      "review-diff: condition must require PASS from verification node verify",
+    ])
+  })
+
+  it("requires a mapped implementation fingerprint and bound review result schema", () => {
+    const nodes = validDiffFlow()
+    const review = nodes[2]
+    if (!review) throw new Error("fixture is incomplete")
+    review.input_mapping = {
+      diff: "implement.output.diff",
+      verification: "verify.output",
+    }
+    review.output_schema = {
+      type: "object",
+      properties: {
+        verdict: { enum: ["ACCEPT", "REJECT"] },
+      },
+      required: ["verdict"],
+    }
+
+    expect(validateReviewLifecycle(workflow("deep", nodes)).errors).toEqual([
+      "review-diff: input_mapping must map implementation fingerprint from implement",
+      "review-diff: output_schema must require verdict and implementation_fingerprint",
+    ])
+  })
+
+  it("rejects missing and reversed implementation verification dependencies", () => {
+    const missing = validDiffFlow()
+    const verify = missing[1]
+    if (!verify) throw new Error("fixture is incomplete")
+    verify.depends_on = []
+    expect(validateReviewLifecycle(workflow("deep", missing)).errors).toEqual([
+      "review-diff: verification node verify must depend transitively on implementation node implement",
+    ])
+
+    const absent = validDiffFlow()
+    const review = absent[2]
+    if (!review?.review) throw new Error("fixture is incomplete")
+    review.review.implementation_node_id = "missing-implementation"
+    review.review.verification_node_id = "missing-verification"
+    expect(validateReviewLifecycle(workflow("deep", absent)).errors).toEqual([
+      "review-diff: implementation node missing-implementation does not exist",
+      "review-diff: verification node missing-verification does not exist",
+    ])
+  })
+
+  it("warns rather than rejects explicit invalid diff metadata in standard mode", () => {
+    const result = validateReviewLifecycle(workflow("standard", [
+      node("review-standard", {
+        worker_type: "review",
+        review: {
+          phase: "diff",
+          implementation_node_id: "implement",
+          verification_node_id: "verify",
+        },
+      }),
+    ]))
+
+    expect(result).toEqual({
+      valid: true,
+      errors: [],
+      warnings: [
+        "review-standard: implementation node implement does not exist",
+        "review-standard: verification node verify does not exist",
+      ],
+    })
+  })
+
+  it("accepts actual diff evidence only after verification PASS", () => {
+    const review = validDiffFlow()[2]
+    if (!review) throw new Error("fixture is incomplete")
+    expect(validateReviewExecutionInput(review, {
+      diff: "diff --git a/file.ts b/file.ts\n+added",
+      implementation_fingerprint: "sha256:implementation-1",
+      verification: { verdict: "PASS", tests: 42 },
+    })).toEqual({
+      valid: true,
+      phase: "diff",
+      satisfies_diff_gate: true,
+      errors: [],
+    })
+  })
+
+  it("blocks failed verification and missing diff before execution", () => {
+    const review = validDiffFlow()[2]
+    if (!review) throw new Error("fixture is incomplete")
+    expect(validateReviewExecutionInput(review, {
+      diff: "",
+      implementation_fingerprint: "sha256:implementation-1",
+      verification: { verdict: "FAIL" },
+    })).toEqual({
+      valid: false,
+      phase: "diff",
+      satisfies_diff_gate: false,
+      errors: [
+        "review-diff: implementation evidence is empty or unresolved",
+        "review-diff: verification evidence must contain verdict PASS",
+      ],
+    })
+    expect(validateReviewExecutionInput(review, {
+      diff: "{{implementation-diff}}",
+      verification: { verdict: "PASS" },
+    }).errors).toEqual([
+      "review-diff: implementation evidence is empty or unresolved",
+      "review-diff: implementation fingerprint is empty or unresolved",
+    ])
+  })
+
+  it("keeps design review out of diff gates and emits a phase-specific contract", () => {
+    const design = node("review-design", {
+      worker_type: "review",
+      review: { phase: "design" },
+    })
+    expect(validateReviewExecutionInput(design, {
+      diff: "diff --git a/file.ts b/file.ts",
+      verification: { verdict: "PASS" },
+    })).toEqual({
+      valid: true,
+      phase: "design",
+      satisfies_diff_gate: false,
+      errors: [],
+    })
+    expect(reviewContractForNode(design)).toContain("design/specification review")
+    expect(reviewContractForNode(design)).toContain("MUST NOT claim")
+  })
+
+  it("binds ACCEPT and REJECT results to the current implementation fingerprint", () => {
+    expect(validateReviewResult({
+      verdict: "ACCEPT",
+      implementation_fingerprint: "sha256:revision-2",
+    }, "sha256:revision-2")).toEqual({
+      valid: true,
+      action: "proceed",
+      reviewed_fingerprint: "sha256:revision-2",
+      errors: [],
+    })
+    expect(validateReviewResult({
+      verdict: "REJECT",
+      implementation_fingerprint: "sha256:revision-2",
+      findings: ["Missing timeout test"],
+    }, "sha256:revision-2")).toEqual({
+      valid: true,
+      action: "correct",
+      reviewed_fingerprint: "sha256:revision-2",
+      errors: [],
+    })
+    expect(validateReviewResult({
+      verdict: "ACCEPT",
+      implementation_fingerprint: "sha256:revision-1",
+    }, "sha256:revision-2")).toEqual({
+      valid: false,
+      action: "invalidate",
+      reviewed_fingerprint: "sha256:revision-1",
+      errors: [
+        "review result fingerprint sha256:revision-1 does not match current implementation sha256:revision-2",
+      ],
+    })
+  })
+
+  it("accepts a rejected-review correction wave only after reimplementation and verification", () => {
+    const first = validDiffFlow()
+    const correction = [
+      node("implement-fix", {
+        depends_on: ["review-diff"],
+        condition: 'review-diff.output.verdict == "REJECT"',
+        output_schema: {
+          type: "object",
+          properties: {
+            diff: { type: "string" },
+            fingerprint: { type: "string" },
+          },
+          required: ["diff", "fingerprint"],
+        },
+      }),
+      node("verify-fix", {
+        depends_on: ["implement-fix"],
+        output_schema: {
+          type: "object",
+          properties: { verdict: { enum: ["PASS", "FAIL"] } },
+          required: ["verdict"],
+        },
+      }),
+      node("review-diff-2", {
+        worker_type: "review",
+        depends_on: ["verify-fix"],
+        review: {
+          phase: "diff",
+          implementation_node_id: "implement-fix",
+          verification_node_id: "verify-fix",
+        },
+        input_mapping: {
+          diff: "implement-fix.output.diff",
+          implementation_fingerprint: "implement-fix.output.fingerprint",
+          verification: "verify-fix.output",
+        },
+        condition: 'verify-fix.output.verdict == "PASS"',
+        output_schema: {
+          type: "object",
+          properties: {
+            verdict: { enum: ["ACCEPT", "REJECT"] },
+            implementation_fingerprint: { type: "string" },
+          },
+          required: ["verdict", "implementation_fingerprint"],
+        },
+      }),
+    ]
+
+    expect(validateReviewLifecycle(workflow("deep", [...first, ...correction]))).toEqual({
+      valid: true,
+      errors: [],
+      warnings: [],
+    })
+  })
+})

--- a/packages/opencode/test/dag/dag-structured-output.test.ts
+++ b/packages/opencode/test/dag/dag-structured-output.test.ts
@@ -88,22 +88,31 @@ function makePromptLayerWithCapture(result: SessionV1.WithParts, payloads: unkno
   })
 }
 
-function makeSpawnInput(outputSchema?: Record<string, unknown>): NodeSpawnInput {
+function makeSpawnInput(
+  outputSchema?: Record<string, unknown>,
+  overrides: Partial<NodeSpawnInput> = {},
+): NodeSpawnInput {
   return {
     dagID: "wf-1", nodeID: "node-1", node: makeNodeRow(),
     parentSessionID: "ses_parent",
     promptParts: [{ type: "text", text: "do the thing" }],
     outputSchema,
+    ...overrides,
   }
 }
 
-async function runSpawn(dagLayer: Layer.Layer<never>, promptLayer: Layer.Layer<never>, outputSchema?: Record<string, unknown>) {
+async function runSpawn(
+  dagLayer: Layer.Layer<never>,
+  promptLayer: Layer.Layer<never>,
+  outputSchema?: Record<string, unknown>,
+  overrides: Partial<NodeSpawnInput> = {},
+) {
   const semaphore = Semaphore.makeUnsafe(1)
   const fullLayer = Layer.mergeAll(dagLayer, agentLayer, sessionLayer, promptLayer)
   await Effect.runPromise(
     Effect.scoped(
       Effect.gen(function* () {
-        const result = yield* spawnNode(semaphore, makeSpawnInput(outputSchema))
+        const result = yield* spawnNode(semaphore, makeSpawnInput(outputSchema, overrides))
         yield* Fiber.await(result.fiber)
       }),
     ).pipe(Effect.provide(fullLayer)) as Effect.Effect<never>,
@@ -257,5 +266,34 @@ describe("spawnNode submit_result capture", () => {
     const completed = events.find((e) => e.type === "nodeCompleted")
     expect(completed).toBeDefined()
     expect(completed!.output).toBe("Task completed")
+  })
+
+  it("fails a diff review whose result targets a stale implementation fingerprint", async () => {
+    const { events, dagLayer } = makeEventTracker()
+    const schema = {
+      type: "object",
+      properties: {
+        verdict: { enum: ["ACCEPT", "REJECT"] },
+        implementation_fingerprint: { type: "string" },
+      },
+      required: ["verdict", "implementation_fingerprint"],
+    }
+    await runSpawn(
+      dagLayer,
+      makePromptLayerWithCapture(reply("ignored text"), [{
+        verdict: "ACCEPT",
+        implementation_fingerprint: "sha256:revision-1",
+      }], schema),
+      schema,
+      { reviewImplementationFingerprint: "sha256:revision-2" },
+    )
+
+    expect(events.find((event) => event.type === "nodeCompleted")).toBeUndefined()
+    expect(events.find((event) => event.type === "nodeFailed")).toEqual({
+      type: "nodeFailed",
+      nodeID: "node-1",
+      reason: "Review result contract failed: review result fingerprint sha256:revision-1 does not match current implementation sha256:revision-2",
+      trigger: "verdict_fail",
+    })
   })
 })

--- a/packages/opencode/test/dag/dag-wake-integration.test.ts
+++ b/packages/opencode/test/dag/dag-wake-integration.test.ts
@@ -10,6 +10,7 @@ import { EventV2 } from "@opencode-ai/core/event"
 import { ProjectTable } from "@opencode-ai/core/project/sql"
 import { SessionTable } from "@opencode-ai/core/session/sql"
 import { Agent } from "@/agent/agent"
+import { fingerprintBrief } from "@/dag/admission"
 import { Dag, type NodeConfig } from "@/dag/dag"
 import { DagLoop } from "@/dag/runtime/loop"
 import { InstanceRef } from "@/effect/instance-ref"
@@ -214,6 +215,65 @@ function runWakeTest<A>(
 }
 
 describe("DagLoop atomic wake integration", () => {
+  it("injects a bounded Requirement Brief without raw QA questions", async () => {
+    await Effect.runPromise(
+      runWakeTest(({ dag, store, childPrompts }) =>
+        Effect.gen(function* () {
+          const brief = {
+            goal: "Implement and verify durable deep admission",
+            scope: {
+              in: ["workflow start", "recovery"],
+              out: ["new user interface"],
+            },
+            constraints: ["standard mode remains compatible"],
+            assumptions: ["parent-session questions are available"],
+            acceptance_criteria: ["deep work starts only when admitted"],
+            evidence_required: ["typecheck", "unit tests"],
+            risks: ["stale admission"],
+            review_plan: ["verify the implementation diff"],
+            open_questions: ["raw QA transcript must not reach child prompts"],
+            blocking_questions: [],
+          }
+          const dagID = yield* dag.create({
+            projectID: "project-1",
+            sessionID: "ses_parent",
+            title: "Deep prompt context",
+            config: {
+              name: "deep-prompt-context",
+              mode: "deep",
+              admission: {
+                protocol_version: 1,
+                brief_revision: 1,
+                qa_mode: "STANDARD",
+                verdict: "READY",
+                state: "READY",
+                fingerprint: fingerprintBrief(brief),
+                brief,
+              },
+              nodes: [node("implement")],
+            },
+          })
+
+          const implement = yield* takeWithin(childPrompts, "implement did not start")
+          const prompt = promptText(implement.input)
+          expect(prompt).toContain("Requirement Brief")
+          expect(prompt).toContain("Implement and verify durable deep admission")
+          expect(prompt).toContain("standard mode remains compatible")
+          expect(prompt).not.toContain("open_questions")
+          expect(prompt).not.toContain("raw QA transcript must not reach child prompts")
+          yield* Deferred.succeed(implement.release, "Implemented")
+
+          yield* pollWithTimeout(
+            store.getWorkflow(dagID).pipe(
+              Effect.map((workflow) => workflow?.status === "completed" ? workflow : undefined),
+            ),
+            "deep prompt workflow did not complete",
+          )
+        }),
+      ),
+    )
+  })
+
   it("preserves documented template variables inside static template input", async () => {
     await Effect.runPromise(
       runWakeTest(({ dag, childPrompts }) =>

--- a/packages/opencode/test/dag/workflow-tool.test.ts
+++ b/packages/opencode/test/dag/workflow-tool.test.ts
@@ -11,8 +11,52 @@ import type { Tool } from "@/tool/tool"
 import { Truncate } from "@/tool/truncate"
 import { Parameters, WorkflowTool } from "@/tool/workflow"
 import { testEffect } from "../lib/effect"
+import { fingerprintBrief, type State } from "@/dag/admission"
 
 const projectID = "project_test"
+const admissionBrief = {
+  goal: "Qualify and execute a deep workflow",
+  scope: {
+    in: ["workflow start", "review lifecycle"],
+    out: ["new admission UI"],
+  },
+  constraints: ["standard workflows stay compatible"],
+  assumptions: ["the parent session can ask questions"],
+  acceptance_criteria: ["deep start requires READY or WAIVED"],
+  evidence_required: ["unit tests", "integration tests"],
+  risks: ["waiver misuse"],
+  review_plan: ["verify", "review the implementation diff"],
+  open_questions: [],
+  blocking_questions: [],
+}
+
+function admissionFor(
+  verdict: "READY" | "NOT_READY" | "WAIVED",
+  state: State = verdict,
+) {
+  const brief = verdict === "READY"
+    ? admissionBrief
+    : {
+        ...admissionBrief,
+        blocking_questions: ["Confirm the production rollout target"],
+      }
+  return {
+    protocol_version: 1,
+    brief_revision: 1,
+    qa_mode: "STANDARD" as const,
+    verdict,
+    state,
+    fingerprint: fingerprintBrief(brief),
+    brief,
+    ...(verdict === "WAIVED"
+      ? {
+          waiver_reason: "Preview release only",
+          acknowledged_risks: ["Production rollout is unresolved"],
+        }
+      : {}),
+  }
+}
+
 const published: Array<{ type: string; data: unknown }> = []
 const store = Layer.mock(DagStore.Service, {
   getWorkflow: (id: string) =>
@@ -32,6 +76,29 @@ const store = Layer.mock(DagStore.Service, {
             timeCreated: 1,
             timeUpdated: 2,
           }
+        : id === "dag_deep_status"
+          ? {
+              id,
+              projectId: projectID,
+              sessionId: "ses_workflow_parent",
+              title: "Deep status workflow",
+              status: "running",
+              config: JSON.stringify({
+                name: "deep-status",
+                mode: "deep",
+                admission: {
+                  ...admissionFor("WAIVED"),
+                  state: "CONSUMED",
+                },
+                nodes: [],
+              }),
+              seq: 1,
+              wakeReported: false,
+              startedAt: 1,
+              completedAt: null,
+              timeCreated: 1,
+              timeUpdated: 2,
+            }
         : id === "dag_defaults"
           ? {
               id,
@@ -201,6 +268,22 @@ describe("workflow tool schema (negative tests)", () => {
       model: { providerID: "configured", modelID: "configured/model" },
     })
   })
+
+  it("decodes deep mode and structured admission", () => {
+    const decode = Schema.decodeUnknownSync(Parameters)
+    expect(decode({
+      action: "start",
+      mode: "deep",
+      admission: admissionFor("READY"),
+      config: {
+        name: "deep-schema",
+        nodes: [],
+      },
+    })).toEqual(expect.objectContaining({
+      mode: "deep",
+      admission: expect.objectContaining({ verdict: "READY" }),
+    }))
+  })
 })
 
 describe("workflow tool execution", () => {
@@ -240,6 +323,44 @@ describe("workflow tool execution", () => {
       expect(result.output).toContain('"status": "running"')
       expect(result.output).toContain('"id": "node_running"')
       expect(result.output).toContain('"child_session_id": "ses_child"')
+      expect(result.output).toContain('"mode": "standard"')
+    }),
+  )
+
+  runtime.effect("status and recovery reads retain consumed deep admission audit fields", () =>
+    Effect.gen(function* () {
+      const info = yield* WorkflowTool
+      const workflow = yield* info.init()
+      const result = yield* workflow.execute(
+        {
+          action: "status",
+          workflow_id: "dag_deep_status",
+        },
+        {
+          sessionID: SessionID.make("ses_workflow_parent"),
+          messageID: MessageID.ascending(),
+          agent: "build",
+          abort: new AbortController().signal,
+          messages: [],
+          metadata: () => Effect.void,
+          ask: () => Effect.void,
+        } satisfies Tool.Context,
+      )
+
+      const output = JSON.parse(result.output)
+      expect(output).toEqual(expect.objectContaining({
+        mode: "deep",
+        admission: {
+          verdict: "WAIVED",
+          state: "CONSUMED",
+          qa_mode: "STANDARD",
+          brief_revision: 1,
+          fingerprint: admissionFor("WAIVED").fingerprint,
+          waiver_reason: "Preview release only",
+          acknowledged_risks: ["Production rollout is unresolved"],
+        },
+      }))
+      expect(output.admission).not.toHaveProperty("qa_transcript")
     }),
   )
 
@@ -275,6 +396,135 @@ describe("workflow tool execution", () => {
       expect(published.find((event) => event.type === DagEvent.WorkflowCreated.type)?.data).toEqual(
         expect.objectContaining({ projectID, sessionID: parentID }),
       )
+      const created = published.find((event) => event.type === DagEvent.WorkflowCreated.type)?.data as {
+        config?: string
+      }
+      expect(JSON.parse(created.config ?? "{}").mode).toBe("standard")
+    }),
+  )
+
+  runtime.effect("deep start consumes and persists a READY admission", () =>
+    Effect.gen(function* () {
+      published.length = 0
+      const info = yield* WorkflowTool
+      const workflow = yield* info.init()
+      const result = yield* workflow.execute(
+        {
+          action: "start",
+          mode: "deep",
+          admission: admissionFor("READY"),
+          config: {
+            name: "deep-ready",
+            nodes: [],
+          },
+        },
+        {
+          sessionID: SessionID.make("ses_workflow_parent"),
+          messageID: MessageID.ascending(),
+          agent: "build",
+          abort: new AbortController().signal,
+          messages: [],
+          metadata: () => Effect.void,
+          ask: () => Effect.void,
+        } satisfies Tool.Context,
+      )
+
+      expect(result.output).toContain('mode="deep"')
+      const created = published.find((event) => event.type === DagEvent.WorkflowCreated.type)?.data as {
+        config?: string
+      }
+      expect(JSON.parse(created.config ?? "{}")).toEqual(expect.objectContaining({
+        mode: "deep",
+        admission: expect.objectContaining({
+          verdict: "READY",
+          state: "CONSUMED",
+          fingerprint: admissionFor("READY").fingerprint,
+        }),
+      }))
+    }),
+  )
+
+  runtime.effect("deep start consumes and retains an informed WAIVED admission", () =>
+    Effect.gen(function* () {
+      published.length = 0
+      const info = yield* WorkflowTool
+      const workflow = yield* info.init()
+      yield* workflow.execute(
+        {
+          action: "start",
+          mode: "deep",
+          admission: admissionFor("WAIVED"),
+          config: {
+            name: "deep-waived",
+            nodes: [],
+          },
+        },
+        {
+          sessionID: SessionID.make("ses_workflow_parent"),
+          messageID: MessageID.ascending(),
+          agent: "build",
+          abort: new AbortController().signal,
+          messages: [],
+          metadata: () => Effect.void,
+          ask: () => Effect.void,
+        } satisfies Tool.Context,
+      )
+
+      const created = published.find((event) => event.type === DagEvent.WorkflowCreated.type)?.data as {
+        config?: string
+      }
+      expect(JSON.parse(created.config ?? "{}").admission).toEqual(expect.objectContaining({
+        verdict: "WAIVED",
+        state: "CONSUMED",
+        waiver_reason: "Preview release only",
+        acknowledged_risks: ["Production rollout is unresolved"],
+      }))
+    }),
+  )
+
+  runtime.effect("deep start blocks every non-admitted state without side effects", () =>
+    Effect.gen(function* () {
+      const info = yield* WorkflowTool
+      const workflow = yield* info.init()
+      const cases = [
+        { name: "missing", admission: undefined },
+        { name: "not-ready", admission: admissionFor("NOT_READY") },
+        { name: "invalidated", admission: admissionFor("NOT_READY", "INVALIDATED") },
+        {
+          name: "bad-fingerprint",
+          admission: {
+            ...admissionFor("READY"),
+            fingerprint: "0".repeat(64),
+          },
+        },
+      ]
+
+      for (const item of cases) {
+        published.length = 0
+        const exit = yield* workflow.execute(
+          {
+            action: "start",
+            mode: "deep",
+            admission: item.admission,
+            config: {
+              name: `deep-${item.name}`,
+              nodes: [],
+            },
+          },
+          {
+            sessionID: SessionID.make("ses_workflow_parent"),
+            messageID: MessageID.ascending(),
+            agent: "build",
+            abort: new AbortController().signal,
+            messages: [],
+            metadata: () => Effect.void,
+            ask: () => Effect.void,
+          } satisfies Tool.Context,
+        ).pipe(Effect.exit)
+
+        expect(Exit.isFailure(exit)).toBe(true)
+        expect(published).toHaveLength(0)
+      }
     }),
   )
 


### PR DESCRIPTION
## 概要
- 内化 LIGHT / STANDARD / GRILL admission QA 与 Requirement Brief
- deep 工作流启动前强制 READY 或知情 WAIVED，并持久化审计状态
- 强化 design review 与真实 diff review 生命周期，要求 implementation → verification(PASS) → diff review
- 修复模板数据中的花括号字面量被误判为内部占位符的风险路径，并保持 optional 节点失败不取消同层/下游

## TDD / 回归
- DAG：210 passed
- 编排提示词契约：11 passed
- App E2E：21 passed
- 受影响包 typecheck：通过
- pre-commit / pre-push Turbo typecheck：29/29 包通过
- OpenSpec strict validate：通过
- lint：0 errors

## 全量本地说明
- opencode：3434 pass；唯一 PTY 负载超时单测单独重跑通过
- core：1113 pass；唯一 macOS FSEvents add/change 差异为平台基线，交由 Linux CI 权威验证

目标分支 dev 合并后将监听 push 触发的完整 Unit + E2E 回归，绿色后再触发 prerelease。