### PR TITLE
fix(dag): resume scheduling after recovery

### DIFF
--- a/packages/opencode/src/dag/runtime/loop.ts
+++ b/packages/opencode/src/dag/runtime/loop.ts
@@ -95,11 +95,9 @@ export const layer = Layer.effect(
               const condResult = evaluateCondition(nodeConfig.condition, outputs)
               if (!condResult.ok) {
                 yield* dag.nodeFailed(dagID, nodeID, condResult.error, "exec_failed").pipe(Effect.ignore)
-                entry.runtime.markUnsatisfied(nodeID)
                 continue
               }
               if (!condResult.value) {
-                entry.runtime.markSatisfied(nodeID)
                 yield* dag.nodeSkipped(dagID, nodeID, "condition_false").pipe(Effect.ignore)
                 continue
               }
@@ -140,7 +138,6 @@ export const layer = Layer.effect(
                   `Review input contract failed: ${reviewInput.errors.join("; ")}`,
                   "verdict_fail",
                 ).pipe(Effect.ignore)
-                entry.runtime.markUnsatisfied(nodeID)
                 continue
               }
             }
@@ -165,10 +162,7 @@ export const layer = Layer.effect(
                   text: node.name,
                   unresolvedPlaceholders: [],
                 }))
-            if (!resolved.ok) {
-              entry.runtime.markUnsatisfied(nodeID)
-              continue
-            }
+            if (!resolved.ok) continue
 
             if (resolved.unresolvedPlaceholders.length > 0) {
               yield* dag.nodeFailed(
@@ -177,7 +171,6 @@ export const layer = Layer.effect(
                 `Unresolved template placeholders: ${resolved.unresolvedPlaceholders.join(", ")}`,
                 "verdict_fail",
               ).pipe(Effect.ignore)
-              entry.runtime.markUnsatisfied(nodeID)
               continue
             }
 
@@ -406,6 +399,7 @@ export const layer = Layer.effect(
                       yield* abortChild(nid, node?.childSessionId ?? null).pipe(Effect.ignore)
                       if (fiber) yield* Fiber.interrupt(fiber).pipe(Effect.ignore)
                       entry.runtime.markUnsatisfied(nid)
+                      if (!entry.runtime.isStepMode()) yield* spawnReady(dagID)
                     }
                     // In stepMode, checkCompletion (which can trigger autonomous
                     // fail/complete) still runs, but spawnReady is skipped —

--- a/packages/opencode/test/dag/dag-wake-integration.test.ts
+++ b/packages/opencode/test/dag/dag-wake-integration.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test"
-import { Deferred, Effect, Layer, Option, Queue } from "effect"
+import { Deferred, Effect, Fiber, Layer, Option, Queue } from "effect"
 import type { SessionV1 } from "@opencode-ai/core/v1/session"
 import { Database } from "@opencode-ai/core/database/database"
 import { TerminalViolationError } from "@opencode-ai/core/dag/core/types"
@@ -797,6 +797,108 @@ describe("DagLoop atomic wake integration", () => {
           expect(promptText(parent.input)).toContain('Node "busy-node" completed: held result')
           yield* Deferred.succeed(parent.release, "success")
         }),
+      ),
+    )
+  })
+
+  it("recovers after a false conditional branch and eventually wakes the parent", async () => {
+    await Effect.runPromise(
+      runWakeTest(
+        ({ store, childPrompts, parentPrompts }) =>
+          Effect.gen(function* () {
+            const responder = yield* Effect.forever(
+              Queue.take(childPrompts).pipe(
+                Effect.flatMap((prompt) => Deferred.succeed(prompt.release, "done")),
+              ),
+            ).pipe(Effect.forkChild)
+
+            const parent = yield* takeWithin(
+              parentPrompts,
+              "parent agent did not receive the durable DAG status after recovery",
+            )
+            expect(
+              (yield* store.getNode("dag_recovered_conditional", "conditional"))?.status,
+            ).toBe("skipped")
+            expect(
+              (yield* store.getNode("dag_recovered_conditional", "after-conditional"))?.status,
+            ).toBe("completed")
+            expect(promptText(parent.input)).toContain(
+              'Node "quality-gate" completed: REJECT',
+            )
+            expect(promptText(parent.input)).toContain(
+              'Workflow "Recovered conditional workflow" has reached terminal status',
+            )
+            yield* Deferred.succeed(parent.release, "success")
+            yield* Fiber.interrupt(responder)
+          }),
+        ({ database }) =>
+          database.db.transaction((tx) =>
+            Effect.gen(function* () {
+              yield* tx.insert(WorkflowTable).values({
+                id: "dag_recovered_conditional",
+                project_id: "project-1" as never,
+                session_id: "ses_parent" as never,
+                title: "Recovered conditional workflow",
+                status: "running",
+                config: JSON.stringify({
+                  name: "dag_recovered_conditional",
+                  nodes: [
+                    node("quality-gate"),
+                    {
+                      ...node("conditional", ["quality-gate"]),
+                      report_to_parent: false,
+                      condition: 'quality-gate.output.verdict == "ACCEPT"',
+                    },
+                    {
+                      ...node("after-conditional", ["conditional"]),
+                      report_to_parent: false,
+                    },
+                  ],
+                }),
+                seq: 6,
+                wake_reported: false,
+              }).run()
+              yield* tx.insert(WorkflowNodeTable).values([
+                {
+                  id: "quality-gate",
+                  workflow_id: "dag_recovered_conditional",
+                  name: "quality-gate",
+                  worker_type: "build",
+                  status: "completed",
+                  required: true,
+                  depends_on: [],
+                  output: "REJECT",
+                  wake_eligible: true,
+                  wake_reported: false,
+                  seq: 4,
+                },
+                {
+                  id: "conditional",
+                  workflow_id: "dag_recovered_conditional",
+                  name: "conditional",
+                  worker_type: "build",
+                  status: "pending",
+                  required: true,
+                  depends_on: ["quality-gate"],
+                  wake_eligible: false,
+                  wake_reported: false,
+                  seq: 2,
+                },
+                {
+                  id: "after-conditional",
+                  workflow_id: "dag_recovered_conditional",
+                  name: "after-conditional",
+                  worker_type: "build",
+                  status: "pending",
+                  required: true,
+                  depends_on: ["conditional"],
+                  wake_eligible: false,
+                  wake_reported: false,
+                  seq: 1,
+                },
+              ]).run()
+            }),
+          ).pipe(Effect.orDie),
       ),
     )
   })


### PR DESCRIPTION
## Summary
- make DAG terminal events the single owner of runtime terminal state
- continue scheduling after node failures without weakening step mode
- cover recovered workflows with a false conditional branch and durable parent wake

## Validation
- 211 DAG tests passed
- package typecheck passed
- full package suite: 3437 passed; one unrelated PTY timeout passed on isolated rerun (4/4)
