### PR TITLE
fix(dag): scheduling semantics, validation, and recovery-pause

### DIFF
--- a/docs/dag-bug-condition-skip-as-satisfied.md
+++ b/docs/dag-bug-condition-skip-as-satisfied.md
@@ -1,0 +1,485 @@
+# DAG 模组缺陷与改进清单（P0–P2）
+
+> **来源**：DAG 模组全盘审计（性能 / 运行闭环 / 场景覆盖 / TUI）+ 压测工作流 `dag_067ef539cffe6fbuucCw7L5nko` 实证
+> **报告日期**：2026-07-25（P0-1 实证）/ 2026-07-27（全量审计整合）
+> **分级标准**：P0 = 语义正确性破坏或核心链路死路；P1 = 静默行为偏差、性能热点、契约自相矛盾；P2 = 语义弱化、死代码、UX 缺口
+
+---
+
+## 总览
+
+| 编号 | 级别 | 标题 | 类型 |
+|------|------|------|------|
+| [P0-1](#p0-1) | P0 | condition_false 被当作 satisfied，门禁拒绝被下游完全无视 | 正确性（已实证） |
+| [P0-2](#p0-2) | P0 | max_concurrency 只限流 LLM 调用，子会话被急切创建，QUEUED 是死状态 | 正确性 + 性能 |
+| [P0-3](#p0-3) | P0 | 连续单步（step）是状态机死路 | 正确性 |
+| [P1-1](#p1-1) | P1 | create 不校验 depends_on 引用 / 重复节点 ID / max_total_nodes | 正确性 |
+| [P1-2](#p1-2) | P1 | sanitizer 破坏性替换损坏 diff/代码产出物，与 diff-review 契约矛盾 | 正确性 |
+| [P1-3](#p1-3) | P1 | spawnReady 每节点重复全量读，O(ready × nodes) 查询 | 性能 |
+| [P1-4](#p1-4) | P1 | getWorkflowSummaries JS 聚合 + 事件热路径前置查询 | 性能 |
+| [P1-5](#p1-5) | P1 | 失败节点无法通过 replan restart 重跑（必须换新 ID），工具描述未告知 | 使用陷阱 |
+| [P2-1](#p2-1) | P2 | required 节点失败 → 工作流终态是 cancelled 而非 failed | 语义 |
+| [P2-2](#p2-2) | P2 | 崩溃恢复对 running 节点一律判失败，required 级联即整流程报废 | 语义（**已修复：recovery-pause**） |
+| [P2-3](#p2-3) | P2 | orchestrator_unresponsive 兜底的触发时机依赖未钉死的 promptIfIdle 语义 | 风险（**已验证关闭+契约测试**） |
+| [P2-4](#p2-4) | P2 | 死代码/死状态：ViolationTable、ARCHIVED、NodeStatus.PAUSED/ABORTED | 清理 |
+| [P2-5](#p2-5) | P2 | inline 模板走临时文件写读删，spawn 热路径纯多余 I/O | 性能 |
+| [P2-6](#p2-6) | P2 | condition DSL 表达力不足，且只能引用直接依赖 | 场景 |
+| [P2-7](#p2-7) | P2 | HTTP API 不对称：无 start / extend | 场景 |
+| [P2-8](#p2-8) | P2 | TUI：Inspector 无滚动、列表截断与导航不一致、无 step 控制、配色两套 | UX |
+| [P2-9](#p2-9) | P2 | summary 进度不计 skipped，工作流"跑完了但分子不满" | UX |
+| [P2-10](#p2-10) | P2 | pause 语义（不停止在跑节点）无任何文档/UI 提示 | UX |
+
+---
+
+<a id="p0-1"></a>
+## P0-1：condition_false 被当作 satisfied，门禁拒绝被下游完全无视
+
+> **状态**：已确认（经工作流 `dag_067ef539cffe6fbuucCw7L5nko` 终态验证）
+> **严重度**：Critical — 语义正确性缺陷，门禁形同虚设
+
+### 摘要
+
+当一个节点的 `condition` 求值为 false 时，节点发布 `NodeSkipped(condition_false)`，但调度层把 **skipped 与 completed 等价处理为 `satisfied`**。由于调度器把 `satisfied` 集合视为"依赖已满足"，**所有依赖该节点的下游节点会照常调度执行**——即使该节点是一个质量门禁且刚刚拒绝了放行。
+
+结果是：门禁返回 `REVISE`/`REJECT` → 实现节点被 condition 跳过 → 但实现节点的下游（集成、验证、审计）仍然全部执行，最终审计甚至返回 `ACCEPT`。**整个质量门控链路形同虚设。**
+
+### 复现
+
+#### 工作流信息
+
+| 字段 | 值 |
+|------|-----|
+| Workflow ID | `dag_067ef539cffe6fbuucCw7L5nko` |
+| Title | engine-stress-review-pipeline |
+| Parent Session | `ses_067f06f1bffeAmDFfH51NmNBl5` |
+| 模式 | standard |
+| 终态 | completed |
+
+#### 图结构（相关部分）
+
+```
+quality-gate (required, output_schema: verdict)
+  ├── implement-core   (condition: quality-gate.output.verdict == "ACCEPT")
+  ├── implement-docs   (condition: quality-gate.output.verdict == "ACCEPT")
+  │
+  implement-cli        (condition: quality-gate.output.verdict == "ACCEPT", depends_on: implement-core)
+       │
+    integrate          (depends_on: implement-cli, implement-docs)  ← 无 condition
+       ├── verify-unit   (depends_on: integrate)
+       └── verify-e2e    (depends_on: integrate)
+            │
+       diff-review      (depends_on: verify-unit, verify-e2e, output_schema: verdict)
+            │
+       final-audit      (required, depends_on: diff-review, output_schema: verdict)
+            │
+       tail-telemetry   (depends_on: final-audit)
+```
+
+#### 预期行为
+
+quality-gate 返回 `REVISE` → condition 求值 false → implement-* 被跳过 → **整条下游链不应执行**（无实现产物可集成/验证/审计）。
+
+#### 实际行为（终态快照）
+
+| 节点 | 状态 | 说明 |
+|------|------|------|
+| quality-gate | completed, verdict=**REVISE** | 子 agent 合法分析仲裁结果后拒绝放行 |
+| implement-core | **skipped** (condition_false) | 正确跳过 |
+| implement-docs | **skipped** (condition_false) | 正确跳过 |
+| implement-cli | **skipped** (condition_false) | 正确跳过 |
+| integrate | **completed** | ❌ 依赖的两个节点都被 skip，却仍然执行 |
+| verify-unit | **completed** | ❌ 不应该运行 |
+| verify-e2e | **completed** | ❌ 不应该运行 |
+| diff-review | **completed**, verdict=ACCEPT | ❌ 不应该运行 |
+| final-audit | **completed**, verdict=**ACCEPT** | ❌ 门禁拒绝了，审计却通过了 |
+| tail-telemetry | **completed** | ❌ 不应该运行 |
+
+**工作流整体 completed**——门禁拒绝被完全无视，整条链跑完并"通过"。
+
+### 根因分析（已修正定位）
+
+> 早期版本将根因定位在 `loop.ts` condition 分支内联 `markSatisfied`——**不准确**。当前源码中 condition 分支只发布 NodeSkipped 事件；skip≡satisfied 的合流发生在下述 **三个独立位置**，修复必须同时覆盖，否则任一遗漏路径都会在重建/单步时复现该缺陷。
+
+**位置 ①：NodeSkipped 事件处理器（活跃路径）** — `packages/opencode/src/dag/runtime/loop.ts:318-353`
+
+```ts
+for (const def of [DagEvent.NodeCompleted, DagEvent.NodeSkipped]) {   // ← skip 与 complete 共用一个处理器
+  yield* events.subscribe(def).pipe(
+    ...
+    if (entry.runtime.isActive(evt.data.nodeID as string)) {
+      entry.runtime.markSatisfied(evt.data.nodeID as string)          // ← skip 被当作 satisfied
+      if (!entry.runtime.isStepMode()) yield* spawnReady(dagID)       // ← 随即放行下游
+    }
+```
+
+**位置 ②：`toSchedulingNodes` 重建映射（恢复/replan 重建路径）** — `loop.ts:36-51`
+
+```ts
+export const SUCCESS_TERMINAL = new Set(["completed", "skipped", "aborted"])  // ← skip 归入成功终态
+
+export function toSchedulingNodes(nodes) {
+  return nodes.map((n) => ({
+    ...
+    status: SUCCESS_TERMINAL.has(n.status)
+      ? ("satisfied" as const)     // ← 从 DB 重建 WorkflowRuntime 时 skip 再次变 satisfied
+      : ...
+```
+
+**位置 ③：`Dag.step` 的同款内联映射** — `packages/opencode/src/dag/dag.ts:356-385`（单步计算 ready 集合时复制了同一映射）
+
+**调度器侧的放大机制** — `packages/core/src/dag/core/scheduling.ts:50-109`
+
+```ts
+markSatisfied(nodeID: string): void {
+  this.satisfied.add(nodeID)       // ← skip 的节点进了这里
+  ...
+}
+
+getReadyNodes(): string[] {
+  const ready = this.graph
+    .getExecutableNodes(new Set([
+      ...this.satisfied,           // ← 下游据此判定依赖"已满足"
+      ...[...this.unsatisfied].filter((id) => !this.required.has(id)),
+    ]))
+    ...
+}
+```
+
+`satisfied` 集合同时承载"成功完成"与"被 condition 跳过"两种语义，调度器无法区分。**WorkflowRuntime 只有 satisfied/unsatisfied/running/pending 四态，没有 skipped**——节点 STATUS 层有 `SKIPPED`（`types.ts:37`）和 `SkipReason.CONDITION_FALSE`（`types.ts:49-56`），但调度态丢失了这一信息。
+
+#### 语义断裂链
+
+```
+condition == false
+  → NodeSkipped(condition_false) 发布
+    → 事件处理器 markSatisfied（skip 当 success）      [位置①]
+    → 重建时 SUCCESS_TERMINAL 映射为 satisfied          [位置②③]
+      → 下游 getExecutableNodes 判定依赖已满足
+        → resolveInputMapping 注入 "Dependency skipped: no output" 文本作为下游输入
+          → 下游带着占位文本照常执行
+            → 整条链跑完，门禁形同虚设
+```
+
+注意最后一环：下游并非"拿不到输入而失败"，而是 `resolveInputMapping`（`loop.ts:112-125`）会把 skip 依赖降级为一段说明文本注入 prompt——这是为"可选分支降级"设计的机制，但在门禁场景下变成了"用占位文本继续跑完全链"。
+
+#### 设计张力：为什么不能简单地把 skip 全部级联
+
+| 场景 | 当前行为（skip≡satisfied） | 期望行为 |
+|------|---------------------------|----------|
+| 门禁拒绝 → 实现链跳过 | 下游照常执行 ❌ | 下游级联 skip |
+| 可选分支跳过 → 主链继续（fan-in 有其他 satisfied 依赖） | 下游执行 ✅ | 下游执行 ✅（合法场景，必须保留） |
+| condition 跳过 → fan-in 汇总 | fan-in 收到占位文本仍执行 | 至少让 fan-in 可区分 skip 与 success |
+
+关键区分点：**下游是否"纯依赖" skipped 节点**。有任一 satisfied 依赖的 fan-in 继续执行是合法降级；全部依赖都 skip 的子树继续执行则是缺陷。
+
+### 修复建议
+
+#### 方案 A：引入 skipped 调度态 + 纯依赖级联（推荐）
+
+1. `WorkflowRuntime` 增加 `private readonly skipped: Set<string>` 与 `markSkipped(nodeID)`
+2. `getReadyNodes` 判定依赖满足时，`{satisfied ∪ skipped}` 仍可解锁下游，**但**一个节点若其依赖全部 ∈ skipped（无任何 satisfied），则该节点自动级联 skip（发布 `NodeSkipped(orphan_cascade)` 复用现有 SkipReason）
+3. `isComplete()` 将 skipped 计入终态集合（保持现有完成判定不回归）
+4. **三处合流点同步修改**：位置① NodeSkipped 处理器改调 `markSkipped`；位置② `SUCCESS_TERMINAL` 拆分为 `{completed, aborted} → satisfied`、`{skipped} → skipped`；位置③ `Dag.step` 内联映射同步（建议顺手消除该重复，复用 `toSchedulingNodes`）
+5. 可选：节点级 `skip_propagation: cascade | allow_downstream` 配置覆盖默认级联策略
+
+#### 方案 B：condition_false → markUnsatisfied（最小改动，不推荐）
+
+`markUnsatisfied` 仅对 required 节点级联（`scheduling.ts:60-75`），非必需节点的下游会永远卡 pending 导致 `isComplete()` 永假、工作流悬挂；补非必需级联变体后实质上等于方案 A 的劣化版，且把 skip 混入 unsatisfied 又制造新的语义合流。
+
+#### 方案 C：编排层声明传播策略
+
+`condition_propagation: skip_subtree` 类声明。可作为方案 A 第 5 步的配置面，不建议单独作为修复（默认行为仍是坏的）。
+
+**推荐方案 A**——级联只影响纯依赖 skipped 的子树，保留"可选分支跳过→主链继续"合法场景；且三处合流点一次收敛，重建/单步路径不留后门。
+
+#### 回归测试清单
+
+- 门禁拒绝 → 全下游级联 skip、工作流 completed（非 cancelled）
+- fan-in 一个依赖 skip 一个 completed → fan-in 照常执行且输入含 skip 说明文本
+- 级联 skip 后进程重启（走 `toSchedulingNodes` 重建）→ 不复活下游
+- stepping 模式下 condition_false → 级联 skip 不触发 auto-advance
+
+---
+
+<a id="p0-2"></a>
+## P0-2：max_concurrency 只限流 LLM 调用，子会话被急切创建，QUEUED 是死状态
+
+**位置**：`packages/opencode/src/dag/runtime/spawn.ts:97-156`、`loop.ts:79-230`
+
+`spawnReady` 对每个 ready 节点立即执行 `spawnNode`，而 `sessions.create`（L97）与 `NodeStarted` 事件发布（L119）都发生在 **semaphore 取许可之前**（L156 才 `take(1)`）。后果链：
+
+- 100 个 ready 节点 → 瞬间创建 100 个子会话、发布 100 条 `NodeStarted`、100 个节点在 DB 中全部变为 `running`
+- `NodeStatus.QUEUED` 全代码库**无任何发布点**（`transitionToNodeEvent` 对 QUEUED 返回 null）——状态机死状态
+- UI（sidebar `▶N running`、Inspector spinner）显示全部"运行中"，用户无法分辨真实并发是 5
+- 排队等待计入 deadline 是有意设计（正确），但大扇出下队尾节点"未执行先超时"，且全程显示 running
+
+**修复**：会话创建与 `NodeStarted` 移入 permit 内；取 permit 前发布 queued 语义（新增 NodeQueued 事件或延迟 NodeStarted）。注意联动：`recovery.ts` 对 running 节点的收敛逻辑、deadline 计算起点（保持 spawn 时刻不变）都要复核。
+
+---
+
+<a id="p0-3"></a>
+## P0-3：连续单步（step）是状态机死路
+
+**位置**：`packages/core/src/dag/core/types.ts:187-188`、`dag.ts:356-385`、`loop.ts:446-463`
+
+`dag.step` 的守卫要求 `当前状态 → STEPPING` 是合法迁移，而 `getValidNextWorkflowStatuses(STEPPING) = [RUNNING, PAUSED, COMPLETED, FAILED, CANCELLED]`——**不含 STEPPING**。完整时序推演：
+
+1. `running` 下 step → 状态 `stepping`，运行 1 个节点 ✓
+2. 节点完成，stepMode 阻止 auto-advance（正确）✓
+3. 再次 step → `InvalidTransitionError(stepping → stepping)` ✗
+4. 唯一出路 `resume` → 但 `WorkflowResumed` 处理器清 stepMode 并 `spawnReady` **全量并发放行** ✗
+
+即"逐节点调试"只能走一步；第二步要么报错要么失控全放。`dag-step-semantics.test.ts` 只测了第一步，无连续 step 用例，故未暴露。
+
+**修复**：迁移表允许 `STEPPING → STEPPING`（幂等 re-step，projector 的 `WorkflowStepped` 投影 from 列表同步加 `"stepping"`），或 stepped 节点完成后自动回落 running。TUI 侧同步补 step 命令（见 P2-8）。
+
+---
+
+<a id="p1-1"></a>
+## P1-1：create 不校验 depends_on 引用 / 重复节点 ID / max_total_nodes
+
+**位置**：`dag.ts:296-317`（create 校验段）、`scheduling.ts:12-21`（buildGraph）
+
+- **悬空依赖静默丢边**：`buildGraph` 对不存在的依赖 `if (graph.hasNode(dep))` 静默跳过 → **依赖 ID 打错字的节点变成根节点立即执行**。replan 路径有完整引用校验（`planReplan` 第 2 步），create 没有——不对称。
+- **重复节点 ID 静默合并**：`addNode` 去重、projector `onConflictDoUpdate` 覆盖；`ErrorCode.DUPLICATE_NODE_NAME` 定义了但无人使用。
+- **max_total_nodes 只在 replan 检查**（`dag.ts:462`）：初始 config 500 节点直接放行，与 P0-2 叠加 = 瞬间 500 个子会话。
+
+**修复**：create 增加三项校验，全部拒绝式（fail fast），错误信息对齐 replan 的措辞。
+
+---
+
+<a id="p1-2"></a>
+## P1-2：sanitizer 破坏性替换损坏 diff/代码产出物，与 diff-review 契约矛盾
+
+**位置**：`packages/opencode/src/dag/templates/sanitize.ts:16-28`、`loop.ts:130`
+
+`sanitize` 把所有 <code>```</code> 替换为 <code>``</code>、行首 `system:` 替换为 `[REDACTED]:`、`you are now a` 替换为 `[REDACTED]`，并作用于**所有上游节点输出**（`resolvedMapping = sanitizeInput(...)`）。而 `review-lifecycle.ts` 的 diff-review 契约**要求**下游收到真实的 diff/patch 工件——任何含 code fence 的 diff、含 "system:" 的日志都会被静默改写，**审查者审的是被篡改的补丁**。防注入与工件保真当前不可兼得。
+
+**修复方向**（按侵入度递增）：
+1. 对 `review.phase == "diff"` 声明的 implementation 工件字段豁免 sanitize
+2. 改破坏性替换为包裹式中和（如 `<untrusted-output>` 定界 + 转义），保留原文
+3. 按 worker_type / 字段级 sanitize 策略配置
+
+---
+
+<a id="p1-3"></a>
+## P1-3：spawnReady 每节点重复全量读，O(ready × nodes) 查询
+
+**位置**：`loop.ts:89`（condition 分支）、`loop.ts:111`（input_mapping 分支）
+
+每个 ready 节点最多两次 `store.getNodes(dagID)` 全表读，一轮调度 N 个 ready 节点 = 最多 2N 次全量查询。**修复**：每轮 `spawnReady` 开头读一次 nodes 快照并复用（condition 求值与 mapping 解析都只需要终态依赖的 output，快照一致性足够）。
+
+---
+
+<a id="p1-4"></a>
+## P1-4：getWorkflowSummaries JS 聚合 + 事件热路径前置查询
+
+**位置**：`packages/core/src/dag/store.ts:226-257`、`summary-publisher.ts:104-120`
+
+- `getWorkflowSummaries` 拉取 session 下**所有**节点行到内存计数；每个 `dag.*` 事件后触发（50ms 去抖动缓解突发）。长会话累积多个 100 节点工作流后，每次事件突发 = 数千行读取。改 `GROUP BY workflow_id, status` 一行等价。
+- 节点事件不带 sessionID，publisher 在**去抖动之前**每事件做一次 `getWorkflow` 查询（L109-112）。100 节点事件突发 = 100 次前置查询。可加 dagID→sessionID 短 TTL 缓存，或把去抖动窗口提到查询之前。
+
+---
+
+<a id="p1-5"></a>
+## P1-5：失败节点无法 replan restart 重跑，必须换新 ID——工具描述未告知
+
+**位置**：`packages/core/src/dag/core/replan.ts:108-110`、`replan.ts:133`（终态 ignore）
+
+`planReplan` 规定 `restart` 仅对 **running** 节点合法；failed 等终态节点出现在 fragment 中直接进 ignore 桶。即**失败节点想重试必须换一个新节点 ID 重新添加**。这是符合"终态不可逆"铁律的有意设计，但 `workflow.ts` 工具 schema 的 restart 描述（"Re-spawn this running node"）没有把这个陷阱讲透——父 agent 大概率先试 restart 失败节点、收到 ignore 静默结果后困惑。
+
+**修复**：restart 非 running 节点时返回**显式错误提示**（"failed 节点请以新 ID 添加替代节点"），而非静默 ignore；工具描述补一句陷阱说明。
+
+---
+
+<a id="p2-1"></a>
+## P2-1：required 节点失败 → 工作流终态 cancelled 而非 failed
+
+**位置**：`loop.ts:238`（`checkCompletion`：`hasRequiredFailure() → dag.cancel`）
+
+必需节点失败的工作流终态是 `cancelled`，与用户主动取消不可区分；TUI 把 failed 标红、cancelled 置灰——**必需节点炸了显示为灰色**，归因被弱化。wake 消息同样只说 "Workflow cancelled"。建议改走 `dag.fail(dagID, "required node failed: <ids>")`，同时更新依赖该语义的测试与工具描述（当前描述"If true and this node fails, the workflow is cancelled"需同步）。
+
+---
+
+<a id="p2-2"></a>
+## P2-2：崩溃恢复对 running 节点一律判失败
+
+> **状态**：已修复（recovery-pause，分支 `fix/dag-recovery-pause`）
+
+**位置**：`recovery.ts:93-99`（判罚保留）+ `loop.ts` `recoverWorkflow`（处置改变）
+
+**原病理**：ownership lost 的 running 节点一律 `nodeFailed("execution ownership lost")`，不重试——有意的保守设计。但叠加 required 级联（P2-1）后：**重启一次进程 = required 链上任何在跑节点失败 = 整个工作流终态报废**，且终态节点不可变、终态工作流不可 replan，父 agent 收到的是无可修复的死亡通知。
+
+**否决的方案**（本文档旧版建议）：ownership lost 且 deadline 未到的节点回落 `pending` 由 spawnReady 自动重拾取。**自动重拾取就是未经显式控制的新 execution attempt**，正面违反模块自身契约（`loop.ts` 恢复注释："a new execution attempt must come from explicit workflow control"，与 `core/session/runner/llm.ts` 的恢复铁律同源；该铁律经 07-27 实证为有效——双代码锚点、AGENTS.md 更新后 47 提交零漂移；其解除路径是完成显式恢复设计而非删除条款），且有崩溃循环与子会话副作用重放风险。
+
+**实施的修复（recovery-pause）**：崩溃判罚保留（发明性失败照旧 `failed`，铁律无损），但当恢复过程**发明**了失败（ownership lost / 无子会话 / deadline 离线到期）且工作流原为 running 时，转 `paused` 而非放任 spawnReady+checkCompletion 立即级联 skip 并焊死终态：
+
+- **关键洞察**：暂停发生在级联之前，下游节点保持 `pending`——pending 可被 replan 改线，failed/skipped 终态不可。旧行为下 n2 已 skipped、工作流已 failed，同一 replan 根本无法提交。
+- 父 agent 收到 durable NodeFailed wake（paused 工作流本就处于投递边界）+ actionable 指令，三选一：`replan`（新 id 替换节点 + 下游改线）→ `resume` 复活；直接 `resume`（接受失败语义，走 P2-1 归因终态）；`cancel`。
+- 再次崩溃时已 paused、无 running 节点，恢复幂等——无崩溃循环。
+- 配套修复一个被此设计暴露的既有缺陷：`WorkflowResumed` 处理器只调 `spawnReady` 不调 `checkCompletion`，全节点已终态的 paused 工作流 resume 后永久悬挂。
+- 回归测试：`dag-loop-recovery-integration.test.ts` 新增三组契约（pause-then-resume 终态归因 / 下游可 replan / 全终态 resume 不悬挂）。
+
+---
+
+<a id="p2-3"></a>
+## P2-3：orchestrator_unresponsive 兜底的触发时机假设未钉死
+
+> **状态**：已验证关闭（07-27 源码实证）+ 契约测试钉死
+
+**位置**：`loop.ts`（`tryDeliverWake`）
+
+投递 wake 后循环立即重读批次，无未上报行且工作流停摆即 `dag.fail(dagID, "orchestrator_unresponsive")`。该逻辑隐含假设 `promptIfIdle` 等到父 turn 完整结束才 resolve。
+
+**实证结果**（`prompt.ts` `promptIfIdle` 实现）：`state.startIfIdle` 返回 wait handle，末尾 `yield* wait.value` 阻塞至完整 `runLoop`（父 turn）完成——**误杀窗口不存在**，假设成立。
+
+**回归防护**：该假设是 session 层契约而非 DAG 层可控行为，因此防护落在 `test/session/prompt.test.ts`（"idle-only prompt resolves only after the full provider turn completes"）：provider 流未完成时 promptIfIdle 必未 resolve，流完成后才 resolve Some。若未来有人把 promptIfIdle 改成 admission 即返回，此测试会先于线上误杀暴露。
+
+---
+
+<a id="p2-4"></a>
+## P2-4：死代码 / 死状态清理
+
+| 项 | 证据 | 处置建议 |
+|---|---|---|
+| `WorkflowViolationTable` | 只有读方法（listViolations/queryViolations/countBySeverity），全库无写入点，HTTP/TUI 不暴露 | 接上（sanitizer 命中、ceiling 命中、unresponsive 判罚天然是 violation）或删除 |
+| `WorkflowStatus.ARCHIVED` | 迁移表允许终态→ARCHIVED，但无 archive 事件定义、无发布点 | 删除或补 archive API |
+| `NodeStatus.PAUSED` / `ABORTED` | 无节点级暂停 API；aborted 无发布点 | 从迁移表移除或明确 roadmap |
+| `NodeStatus.QUEUED` | 见 P0-2，随 P0-2 修复激活 | 激活 |
+
+---
+
+<a id="p2-5"></a>
+## P2-5：inline 模板走临时文件写读删
+
+**位置**：`templates/resolve.ts:68-82`。注释自认"simulating the template-file read path"——spawn 热路径上 3 次纯多余磁盘 I/O + 无谓的失败面（tmpdir 权限/磁盘满）。直接用字符串。
+
+---
+
+<a id="p2-6"></a>
+## P2-6：condition DSL 表达力不足，且只能引用直接依赖
+
+**位置**：`runtime/eval.ts:32-54`、`loop.ts:89-104`
+
+- 仅支持单个二元比较（`a.output.x == v`），无 `&&`/`||`、无存在性判断、无 contains
+- condition 的 outputs map 只装 **direct dependsOn**（`loop.ts:91-94`），引用间接上游会静默 undefined → 比较恒 false → 静默 skip（叠加 P0-1 后下游还照跑）
+- 字符串与数字比较 `>` 会得到 NaN 比较恒 false，无告警
+
+**建议**：至少补 `&&`/`||` 与 `exists()`；对引用了非直接依赖的 condition 在 create/replan 校验期报错（静默 false 是最坏的失败模式）。
+
+---
+
+<a id="p2-7"></a>
+## P2-7：HTTP API 不对称——无 start / extend
+
+**位置**：`server/routes/instance/httpapi/handlers/dag.ts`
+
+control 支持 pause/resume/cancel/complete/step/replan，但**无 extend、无 start**——外部系统无法通过 HTTP 发起或追加工作流，只能由 agent 工具面发起。若 HTTP 面定位为完整控制面，需补齐并同步 SDK 再生成（`./packages/sdk/js/script/build.ts`）与 `test/server/httpapi-exercise` 场景。
+
+---
+
+<a id="p2-8"></a>
+## P2-8：TUI Inspector / 面板缺陷合集
+
+**位置**：`packages/tui/src/feature-plugins/system/dag-inspector.tsx`、`sidebar/dag-panel.tsx`
+
+| 问题 | 位置 | 说明 |
+|---|---|---|
+| 无滚动容器 | inspector L379-501 | 节点树 `<For>` 平铺，40+ 节点溢出屏幕；键盘选中可移动到不可见区域（无 scroll-into-view） |
+| 列表截断与导航不一致 | L341 `slice(0, 10)` vs L153-159 moveWorkflow 全量列表 | 第 11 个工作流可被选中但列表看不到 |
+| 无 step 控制 | — | 后端有 stepping 状态、面板显示黄色 stepping，TUI 无法触发/继续单步（受 P0-3 制约） |
+| replan/extend 不可见 | — | `replanAttempts`、节点取消/替换/重启历史、`WorkflowReplanned` 计数均不呈现 |
+| 节点详情缺失 | — | 无输出预览、无耗时（started_at/completed_at 有数据不渲染）、无模型标注、无 deadline 倒计时 |
+| footer 快捷键硬编码 | L505-517 | `p/r/x/↑↓/←→` 写死，命令实际走 `keybinds.gather("dag", ...)` 可重绑；close/enter 用了动态 `useCommandShortcut`，同文件内不一致 |
+| 两套状态配色 | inspector L295-302 vs dag-panel L13-21 | inspector 缺 paused/stepping 分支（落默认色），panel 里是 warning 黄；running/pending/skipped/cancelled 在 inspector 全是 textMuted | 
+
+**建议**：提取共享 status→color 映射；补 scrollbox + scroll-into-view；节点行加耗时/模型/输出摘要；footer 全部走 `useCommandShortcut`。
+
+---
+
+<a id="p2-9"></a>
+## P2-9：summary 进度不计 skipped
+
+**位置**：`store.ts:242-250`（只计 completed/running/failed）
+
+进度显示 `completed/total`，条件跳过的节点永远不进分子——"3/5 · completed" 的工作流看起来像没跑完。skipped 应并入完成侧或单独列出（`⊘N`），schema `DagWorkflowSummary` 加 `skippedNodes` 字段后需再生成 SDK。
+
+---
+
+<a id="p2-10"></a>
+## P2-10：pause 语义无提示
+
+pause 只停新 spawn，运行中的子会话继续跑（合理设计），但工具描述、HTTP 文档、TUI toast 均无一处说明"暂停 ≠ 停止正在跑的节点"。补一句话成本极低。
+
+---
+
+## 附带观察（非缺陷，交接留档）
+
+### 观察 1：final-audit 输出引用了错误的工作流 ID
+
+final-audit 的结构化输出为：
+```json
+{"verdict":"ACCEPT","summary":"...工作流 dag_0679ada90ffeAHIyYfUv8WlxE0 已完成执行，4 节点（discover → {migrate-a, migrate-b condition:false} → assemble fan-in）..."}
+```
+
+- 引用的 `dag_0679ada90ffeAHIyYfUv8WlxE0` **不是**本工作流（`dag_067ef539cffe6fbuucCw7L5nko`）
+- 描述的节点（discover/migrate-a/migrate-b/assemble）**不存在于本图**
+- 可能原因：(a) 子 agent 在测试场景下幻觉编造；(b) 跨工作流上下文污染
+
+**建议**：若是 (b)，排查子会话上下文是否混入其他工作流数据；若是 (a)，压测应使用更具约束性的 prompt。
+
+### 观察 2：此前"永久卡死"诊断已被推翻
+
+工作流执行中途查询 status 时 7 个节点显示 pending，当时诊断为"永久卡死"，但工作流最终 completed——这些节点随后被正常调度。**中途 status 快照不能判定卡死**，需配合 `isComplete()` / `hasRunning()` 等运行时方法。（另见 P0-2：大扇出下 pending/running 的显示语义本身有失真。）
+
+---
+
+## 修复优先级路线
+
+```
+第一批（正确性，可并行）：
+  P0-1 skipped 调度态 + 级联       ← 三处合流点一次收敛
+  P0-3 STEPPING→STEPPING 迁移      ← 一行迁移表 + projector from 列表
+  P1-1 create 三项校验             ← 对齐 replan 已有逻辑
+
+第二批（需要设计推演）：
+  P0-2 permit 内建会话             ← 联动 deadline/recovery/QUEUED 语义
+  P1-2 sanitize 豁免策略           ← 联动 review 契约
+  P1-5 restart 显式报错
+
+第三批（性能 + 清理 + UX）：
+  P1-3 / P1-4 / P2-*
+
+已完成：P0-1 / P0-3 / P1-1 / P1-5（报错面）/ P2-1 / P2-2（recovery-pause）/ P2-3（验证关闭+契约测试）/ P2-4（violation 读面清理）/ P2-5 / P2-6（引用校验）/ P2-8（TUI 对齐）/ P2-10（文案）
+```
+
+---
+
+## 相关文件
+
+| 文件 | 关键行 | 内容 |
+|------|--------|------|
+| `packages/opencode/src/dag/runtime/loop.ts` | 36-51, 318-353 | SUCCESS_TERMINAL 映射 / NodeSkipped→markSatisfied（**P0-1 根因**） |
+| `packages/opencode/src/dag/runtime/loop.ts` | 88-104, 112-130 | condition 求值分支 / resolveInputMapping + sanitize 注入点 |
+| `packages/opencode/src/dag/runtime/spawn.ts` | 97-156 | 会话急切创建（**P0-2 根因**） |
+| `packages/opencode/src/dag/dag.ts` | 296-317, 356-385 | create 校验段（P1-1）/ step 守卫与内联映射（P0-3） |
+| `packages/core/src/dag/core/scheduling.ts` | 50-113 | markSatisfied / getReadyNodes / isComplete |
+| `packages/core/src/dag/core/types.ts` | 37-56, 156-200 | NodeStatus.SKIPPED / SkipReason / 迁移表 |
+| `packages/core/src/dag/core/replan.ts` | 108-133 | restart 仅限 running / 终态 ignore（P1-5） |
+| `packages/opencode/src/dag/templates/sanitize.ts` | 16-28 | 破坏性替换（P1-2） |
+| `packages/core/src/dag/store.ts` | 226-257 | JS 聚合（P1-4）/ skipped 不计数（P2-9） |
+| `packages/opencode/src/dag/runtime/eval.ts` | 32-54, 92-107 | evaluateCondition / resolvePath（求值逻辑本身正确，DSL 弱见 P2-6） |
+| `packages/opencode/src/dag/runtime/recovery.ts` | 93-99 | ownership lost 判罚（P2-2，处置已改 recovery-pause） |
+| `packages/tui/src/feature-plugins/system/dag-inspector.tsx` | 295-302, 341, 505-517 | 配色 / 截断 / footer（P2-8） |
+
+---
+
+## 关键会话 ID（交接用）
+
+| 角色 | Session ID |
+|------|-----------|
+| 工作流父会话 | `ses_067f06f1bffeAmDFfH51NmNBl5` |
+| quality-gate 子会话（返回 REVISE） | `ses_067ee102bffeQVj8nS1Jti7eet` |
+| arbitrate 子会话 | `ses_067eebfe6ffe7tpZPn5m2EiV2U` |
+| final-audit 子会话（返回 ACCEPT，引用错误 workflow ID） | `ses_06799fb9fffer5U2WPoyRYo3Jx` |
+| integrate 子会话（skip 后仍执行） | `ses_0679b57baffexlZR1vLYr7VOwa` |

--- a/docs/dag-orchestration-constraints.md
+++ b/docs/dag-orchestration-constraints.md
@@ -1,0 +1,116 @@
+# DAG 编排约束提示词（condition / skip / 恢复语义）
+
+> **用途**：交给编写 DAG 工作流的 agent（编排者）作为硬约束规则。
+> **背景**：`condition_false → markSatisfied` 缺陷（P0-1）已修复：skipped 现在是独立调度态，纯 skip 依赖会级联跳过下游。本文档描述**修复后**的引擎语义。历史缺陷分析见 `dag-bug-condition-skip-as-satisfied.md`。
+
+---
+
+## 规则 1：condition 门禁会级联——纯 skip 依赖的下游自动跳过
+
+### 引擎语义（修复后）
+
+`condition` 求值为 false 时节点被标记 `skipped`（终态，`condition_false`）。下游处置取决于依赖构成：
+
+- **下游的依赖全部为 skipped** → 级联跳过（`orphan_cascade`），一波一波传播到整条子链。门禁拒绝会真正阻断纯门禁子图。
+- **下游是混合 fan-in**（至少一个依赖 satisfied 或可降级的 failed-optional）→ 照常执行，skip 的上游以占位文本注入（见规则 3）。
+
+```
+gate (verdict=REVISE)
+  └─ implement-A (condition: gate.verdict == "ACCEPT")  → skipped (condition_false)
+       └─ integrate (仅依赖 implement-A)                  → skipped (orphan_cascade) ✅
+            └─ audit (仅依赖 integrate)                    → skipped (orphan_cascade) ✅
+```
+
+### 约束
+
+- 单点 condition 即可门控其**纯依赖**子链，不再需要给子图每个节点重复相同 condition。
+- 若下游是混合 fan-in 且你希望它也被门控，仍需给该 fan-in 自己加 condition——混合 fan-in 的"继续执行"是有意的降级语义，不是缺陷。
+- skip 是终态：级联一旦发生不可逆。若门禁拒绝后还想走修复路径，用 `report_to_parent: true` 唤醒父会话决策 replan，而不是依赖已 skip 的子链复活。
+
+---
+
+## 规则 2：condition 只能引用 depends_on 中的节点（现在 create 会直接拒绝）
+
+### 引擎语义（修复后）
+
+condition 求值时只收集 `node.depends_on` 直接依赖的输出。**`dag.create` 与 `replan` 现在校验 condition 引用**：可解析的 condition 若引用了不在 `depends_on` 中的节点，提交直接报错（fail-fast），不再静默得到 `condition_false`。
+
+### 约束
+
+- condition 中出现的每个 nodeID 都必须存在于该节点的 `depends_on` 数组中。
+- 不可解析的表达式仍留给运行时 fail-loud，不要依赖格式错误的 condition"恰好为 false"。
+
+```yaml
+# ❌ create 时报错：condition 引用了 gate，但 depends_on 里没有 gate
+- id: implement-core
+  depends_on: [some-other-node]
+  condition: 'gate.output.verdict == "ACCEPT"'
+
+# ✅ 正确
+- id: implement-core
+  depends_on: [gate]
+  condition: 'gate.output.verdict == "ACCEPT"'
+```
+
+---
+
+## 规则 3：混合 fan-in 节点必须容忍上游 skip
+
+### 引擎语义（修复后）
+
+纯 skip 依赖的 fan-in 会被级联跳过（规则 1），**不再需要防护**。仍会执行的是混合 fan-in：部分上游 skipped、至少一个上游有真实产出。skip 的上游以 `"Dependency X skipped: condition_false"` 占位文本注入 input_mapping / prompt interpolation。
+
+### 要求
+
+- 混合 fan-in 的 prompt 必须显式说明如何处理 skip 的上游（如"如果某条输入标注为 skipped，在汇总中注明并跳过该项"）。
+- 若混合 fan-in 在部分上游 skip 时不应执行，给它加 condition 显式门控。
+
+---
+
+## 规则 4：崩溃恢复会暂停工作流——父会话必须处置
+
+### 引擎语义（recovery-pause）
+
+进程崩溃重启后，恢复流程对无法从子会话持久状态证明结果的 running 节点**判失败**（`execution ownership lost on recovery` 等），这一保守判罚不会重试（恢复永不隐式重跑 provider 工作）。判罚后工作流**不会直接终态报废**，而是转 `paused`：
+
+- 失败节点的下游保持 `pending`（可 replan 改线）。
+- 父会话会收到 NodeFailed wake 消息（含 `execution ownership lost on recovery` 等原因）。
+
+### 处置（父会话三选一）
+
+1. **replan + resume（推荐）**：失败节点是终态不可变的，用**新 id** 提交替换节点，并把下游节点的 `depends_on` 改线到新 id，然后 `resume`。
+2. **直接 resume**：接受失败语义。required 节点失败会把工作流归因为 `failed`（原因含具体节点 id）；optional 失败则降级继续。
+3. **cancel**：放弃整个工作流。
+
+### 约束
+
+- **禁止**假设崩溃后工作流会自动继续或自动重跑丢失的节点。不会。
+- 收到 ownership-lost wake 后必须在当轮处置（replan / resume / cancel），不要留着 paused 工作流不管。
+
+---
+
+## 规则 5：不要用中途 status 快照判定"卡死"
+
+工作流执行中查询 status 时可能看到部分节点 pending——不一定是卡死，可能是调度器尚未拾取。判定卡死需要：`hasRunning()` 为 false、无 ready 节点、且 `!isComplete()`。
+
+- **禁止**仅凭"有 pending 节点 + status=running"就判定卡死。
+- 引擎自带 `orchestrator_unresponsive` 兜底：wake 投递后父会话当轮未对停摆工作流采取动作，工作流会被判 fail。收到 wake 里的 actionable 指令必须当轮响应。
+
+---
+
+## 规则 6：测试场景下占位 prompt 会导致子 agent 产出不可靠
+
+压测中使用极简占位 prompt（如"输出一句话后结束"）时，部分子 agent 会产出幻觉内容（引用不存在的工作流 ID / 节点名）。
+
+- 压测图若要验证 fan-in / 结构化输出的正确性，prompt 必须包含足够约束（如"只基于上游输入汇总，不要编造工作流 ID 或节点名"）。
+- 否则子 agent 的幻觉输出会干扰对引擎行为的判断。
+
+---
+
+## 自检清单（编排者提交图之前过一遍）
+
+- [ ] 每个 condition 引用的 nodeID 都在对应节点的 `depends_on` 中？（规则 2，create 会拒绝但别浪费一轮）
+- [ ] 门禁 condition 的下游是纯依赖链还是混合 fan-in？混合 fan-in 需要自己的 condition 或 skip 容忍 prompt？（规则 1/3）
+- [ ] 父会话的编排 prompt 是否涵盖崩溃恢复处置（ownership-lost wake → replan/resume/cancel）？（规则 4）
+- [ ] 是否避免了对中途 status 快照的过度解读？（规则 5）
+- [ ] 压测 prompt 是否足够约束，避免子 agent 幻觉？（规则 6）

--- a/packages/core/src/dag/core/replan.ts
+++ b/packages/core/src/dag/core/replan.ts
@@ -91,9 +91,17 @@ export function planReplan(
   const fragmentNodeById = new Map(fragment.nodes.map((n) => [n.id, n]))
   const fragmentIds = new Set(fragment.nodes.map((n) => n.id))
 
-  // 1. Validate fragment-internal consistency: restart/cancel mutual exclusion,
-  //    and restart/cancel on ids that don't exist in the current graph (those
-  //    are nonsensical — a new id can't be restarted/cancelled, only added).
+  // 1. Validate fragment-internal consistency: duplicate ids, restart/cancel
+  //    mutual exclusion, and restart/cancel on ids that don't exist in the
+  //    current graph (those are nonsensical — a new id can't be restarted or
+  //    cancelled, only added).
+  const fragmentSeen = new Set<string>()
+  for (const fragNode of fragment.nodes) {
+    if (fragmentSeen.has(fragNode.id)) {
+      errors.push(`Fragment contains duplicate node id "${fragNode.id}"`)
+    }
+    fragmentSeen.add(fragNode.id)
+  }
   for (const fragNode of fragment.nodes) {
     if (fragNode.restart && fragNode.cancel) {
       errors.push(`Node "${fragNode.id}" declares both restart and cancel — pick one`)
@@ -106,7 +114,11 @@ export function planReplan(
       errors.push(`Node "${fragNode.id}" declares cancel but is not in the current graph (new nodes are added, not cancelled)`)
     }
     if (existing && fragNode.restart && existing.status !== NodeStatus.RUNNING) {
-      errors.push(`Node "${fragNode.id}" declares restart but is ${existing.status} (restart is only valid on running nodes)`)
+      errors.push(
+        isNodeTerminalStatus(existing.status)
+          ? `Node "${fragNode.id}" declares restart but is terminal (${existing.status}) — terminal nodes are immutable; add a replacement node under a new id instead`
+          : `Node "${fragNode.id}" declares restart but is ${existing.status} (restart is only valid on running nodes; include a ${existing.status} node without restart to replace its definition)`,
+      )
     }
     if (existing && fragNode.cancel && isNodeTerminalStatus(existing.status)) {
       errors.push(`Node "${fragNode.id}" declares cancel but is already terminal (${existing.status})`)

--- a/packages/core/src/dag/core/scheduling.ts
+++ b/packages/core/src/dag/core/scheduling.ts
@@ -1,12 +1,42 @@
 import { DependencyGraph } from "./graph"
 
-export type SchedulingNodeStatus = "pending" | "running" | "satisfied" | "unsatisfied"
+export type SchedulingNodeStatus = "pending" | "running" | "satisfied" | "unsatisfied" | "skipped"
 
 export interface SchedulingNode {
   readonly id: string
   readonly dependsOn: readonly string[]
   readonly status: SchedulingNodeStatus
   readonly required: boolean
+}
+
+/** Durable node statuses that count as output-producing success for scheduling. */
+const SATISFIED_TERMINAL = new Set(["completed", "aborted"])
+
+/**
+ * Map durable read-model node rows into scheduling states. Shared by the live
+ * loop, crash recovery, and Dag.step so every ready-set computation uses the
+ * same mapping. `skipped` is deliberately NOT folded into `satisfied`: a
+ * skipped dependency still unlocks mixed fan-ins, but descendants that depend
+ * on skipped nodes only must cascade-skip instead of running on placeholder
+ * inputs (D13 — condition gates).
+ */
+export function toSchedulingNodes(
+  nodes: readonly { id: string; status: string; dependsOn: readonly string[]; required: boolean }[],
+): SchedulingNode[] {
+  return nodes.map((n) => ({
+    id: n.id,
+    dependsOn: n.dependsOn,
+    required: n.required,
+    status: SATISFIED_TERMINAL.has(n.status)
+      ? ("satisfied" as const)
+      : n.status === "skipped"
+        ? ("skipped" as const)
+        : n.status === "failed"
+          ? ("unsatisfied" as const)
+          : n.status === "running"
+            ? ("running" as const)
+            : ("pending" as const),
+  }))
 }
 
 export function buildGraph(nodes: SchedulingNode[]): DependencyGraph {
@@ -24,6 +54,7 @@ export class WorkflowRuntime {
   private graph: DependencyGraph
   private readonly satisfied: Set<string> = new Set()
   private readonly unsatisfied: Set<string> = new Set()
+  private readonly skipped: Set<string> = new Set()
   private readonly running: Set<string> = new Set()
   private readonly required: Set<string>
   private paused = false
@@ -42,6 +73,7 @@ export class WorkflowRuntime {
     nodes.forEach((node) => {
       if (node.status === "satisfied") this.satisfied.add(node.id)
       else if (node.status === "unsatisfied") this.unsatisfied.add(node.id)
+      else if (node.status === "skipped") this.skipped.add(node.id)
       else if (node.status === "running") this.running.add(node.id)
     })
     unsatisfiedIDs.filter((id) => this.required.has(id)).forEach((id) => this.cascadeUnsatisfied(id))
@@ -51,13 +83,24 @@ export class WorkflowRuntime {
     this.satisfied.add(nodeID)
     this.running.delete(nodeID)
     this.unsatisfied.delete(nodeID)
+    this.skipped.delete(nodeID)
   }
 
   markUnsatisfied(nodeID: string): void {
     this.unsatisfied.add(nodeID)
     this.running.delete(nodeID)
     this.satisfied.delete(nodeID)
+    this.skipped.delete(nodeID)
     if (this.required.has(nodeID)) this.cascadeUnsatisfied(nodeID)
+  }
+
+  /** Terminal no-output state (D13): unlocks mixed fan-ins like satisfied, but
+   * descendants that depend on skipped nodes only are cascade-skipped. */
+  markSkipped(nodeID: string): void {
+    this.skipped.add(nodeID)
+    this.running.delete(nodeID)
+    this.satisfied.delete(nodeID)
+    this.unsatisfied.delete(nodeID)
   }
 
   private cascadeUnsatisfied(nodeID: string): void {
@@ -93,7 +136,10 @@ export class WorkflowRuntime {
 
   /** Returns true if the node is in running or pending (not yet terminal) state. */
   isActive(nodeID: string): boolean {
-    return this.running.has(nodeID) || (!this.satisfied.has(nodeID) && !this.unsatisfied.has(nodeID))
+    return (
+      this.running.has(nodeID)
+      || (!this.satisfied.has(nodeID) && !this.unsatisfied.has(nodeID) && !this.skipped.has(nodeID))
+    )
   }
 
   getReadyNodes(): string[] {
@@ -101,15 +147,53 @@ export class WorkflowRuntime {
     const ready = this.graph
       .getExecutableNodes(new Set([
         ...this.satisfied,
+        ...this.skipped,
         ...[...this.unsatisfied].filter((id) => !this.required.has(id)),
       ]))
-      .filter((id) => !this.satisfied.has(id) && !this.unsatisfied.has(id) && !this.running.has(id))
+      .filter((id) =>
+        !this.satisfied.has(id)
+        && !this.unsatisfied.has(id)
+        && !this.skipped.has(id)
+        && !this.running.has(id)
+        && !this.dependsOnSkippedOnly(id),
+      )
     if (this.stepMode && ready.length > 0) return [ready.slice().sort()[0]]
     return ready
   }
 
+  /**
+   * Pending nodes whose dependencies are ALL skipped: they can never receive a
+   * real input, so they must cascade-skip instead of spawning (D13). Returns
+   * one wave per call — callers loop to a fixpoint, publishing a durable
+   * NodeSkipped(orphan_cascade) per node so the cascade is crash-recoverable.
+   * Nodes with at least one satisfied (or degradable failed-optional)
+   * dependency are NOT cascaded — mixed fan-ins keep running with placeholder
+   * inputs. Respects pause like getReadyNodes: skip is terminal and must not
+   * fire while a paused workflow may still be replanned.
+   */
+  getCascadeSkipNodes(): string[] {
+    if (this.paused) return []
+    return this.graph
+      .getAllNodes()
+      .filter((id) =>
+        !this.satisfied.has(id)
+        && !this.unsatisfied.has(id)
+        && !this.skipped.has(id)
+        && !this.running.has(id)
+        && this.dependsOnSkippedOnly(id),
+      )
+      .sort()
+  }
+
+  private dependsOnSkippedOnly(nodeID: string): boolean {
+    const deps = this.graph.getDependencies(nodeID)
+    return deps.length > 0 && deps.every((dep) => this.skipped.has(dep))
+  }
+
   isComplete(): boolean {
-    return this.graph.getAllNodes().every((id) => this.satisfied.has(id) || this.unsatisfied.has(id))
+    return this.graph
+      .getAllNodes()
+      .every((id) => this.satisfied.has(id) || this.unsatisfied.has(id) || this.skipped.has(id))
   }
 
   hasRequiredFailure(): boolean {
@@ -119,10 +203,17 @@ export class WorkflowRuntime {
     return false
   }
 
+  /** Required nodes currently unsatisfied — used to attribute a workflow
+   * failure to the specific nodes that caused it. */
+  getRequiredFailures(): string[] {
+    return [...this.unsatisfied].filter((id) => this.required.has(id)).sort()
+  }
+
   rebuildGraph(nodes: SchedulingNode[]): void {
     this.graph = buildGraph(nodes)
     this.satisfied.clear()
     this.unsatisfied.clear()
+    this.skipped.clear()
     this.running.clear()
     this.required.clear()
     nodes.filter((n) => n.required).forEach((n) => this.required.add(n.id))

--- a/packages/core/src/dag/core/types.ts
+++ b/packages/core/src/dag/core/types.ts
@@ -185,7 +185,9 @@ export function getValidNextWorkflowStatuses(currentStatus: WorkflowStatus): Wor
     case WorkflowStatus.RUNNING:
       return [WorkflowStatus.PAUSED, WorkflowStatus.STEPPING, WorkflowStatus.COMPLETED, WorkflowStatus.FAILED, WorkflowStatus.CANCELLED]
     case WorkflowStatus.STEPPING:
-      return [WorkflowStatus.RUNNING, WorkflowStatus.PAUSED, WorkflowStatus.COMPLETED, WorkflowStatus.FAILED, WorkflowStatus.CANCELLED]
+      // STEPPING -> STEPPING is the consecutive single-step path: each step
+      // command re-enters stepping to run exactly one more node.
+      return [WorkflowStatus.RUNNING, WorkflowStatus.PAUSED, WorkflowStatus.STEPPING, WorkflowStatus.COMPLETED, WorkflowStatus.FAILED, WorkflowStatus.CANCELLED]
     case WorkflowStatus.PAUSED:
       return [WorkflowStatus.RUNNING, WorkflowStatus.CANCELLED]
     case WorkflowStatus.COMPLETED:

--- a/packages/core/src/dag/projector.ts
+++ b/packages/core/src/dag/projector.ts
@@ -74,7 +74,7 @@ export const layer = Layer.effectDiscard(
 
     yield* events.project(DagEvent.WorkflowPaused, setWorkflowStatus(ws("paused"), [ws("running"), ws("stepping")]))
     yield* events.project(DagEvent.WorkflowResumed, setWorkflowStatus(ws("running"), [ws("paused"), ws("stepping")]))
-    yield* events.project(DagEvent.WorkflowStepped, setWorkflowStatus(ws("stepping"), [ws("running")]))
+    yield* events.project(DagEvent.WorkflowStepped, setWorkflowStatus(ws("stepping"), [ws("running"), ws("stepping")]))
 
     const setWorkflowTerminal = (status: WorkflowStatus, from: WorkflowStatus[]) => (event: { data: { dagID: DagEvent.DagID; timestamp: DateTime.Utc }; durable?: { seq: number } }) =>
       db

--- a/packages/core/src/dag/sql.ts
+++ b/packages/core/src/dag/sql.ts
@@ -80,6 +80,13 @@ export const WorkflowNodeTable = sqliteTable(
   ],
 )
 
+/**
+ * Reserved audit table. The physical table exists via the 20260702 migration
+ * but NOTHING writes or reads it yet — the read surface was removed from
+ * DagStore as dead code. Keep the definition so the drizzle schema matches
+ * the database; wire producers (sanitizer hits, ceiling rejections,
+ * orchestrator_unresponsive verdicts) before adding any query surface back.
+ */
 export const WorkflowViolationTable = sqliteTable(
   "workflow_violation",
   {

--- a/packages/core/src/dag/store.ts
+++ b/packages/core/src/dag/store.ts
@@ -1,10 +1,10 @@
 export * as DagStore from "./store"
 
-import { and, asc, desc, eq, gte, lte, inArray } from "drizzle-orm"
+import { and, asc, desc, eq, inArray } from "drizzle-orm"
 import { Context, Effect, Layer } from "effect"
 import { Database } from "../database/database"
 import { LayerNode } from "../effect/layer-node"
-import { WorkflowNodeTable, WorkflowTable, WorkflowViolationTable } from "./sql"
+import { WorkflowNodeTable, WorkflowTable } from "./sql"
 
 // ============================================================================
 // Row → domain types
@@ -58,17 +58,6 @@ export interface WakeSnapshot {
   readonly workflows: readonly WorkflowRow[]
 }
 
-export interface ViolationRow {
-  id: string
-  workflowId: string
-  nodeId: string | null
-  type: string
-  severity: string
-  message: string
-  details: Record<string, unknown> | null
-  timeCreated: number
-}
-
 /** Aggregated per-workflow progress for UI display. Shape matches the TUI's DagWorkflowSummary. */
 export interface WorkflowSummary {
   id: string
@@ -118,29 +107,6 @@ const mapNode = (r: typeof WorkflowNodeTable.$inferSelect): NodeRow => ({
   completedAt: r.completed_at,
 })
 
-const mapViolation = (r: typeof WorkflowViolationTable.$inferSelect): ViolationRow => ({
-  id: r.id,
-  workflowId: r.workflow_id,
-  nodeId: r.node_id,
-  type: r.type,
-  severity: r.severity,
-  message: r.message,
-  details: r.details,
-  timeCreated: r.time_created,
-})
-
-// ============================================================================
-// Query filters
-// ============================================================================
-
-export interface ViolationQuery {
-  workflowId?: string
-  severity?: string
-  type?: string
-  since?: number
-  until?: number
-}
-
 // ============================================================================
 // Service interface
 // ============================================================================
@@ -166,10 +132,6 @@ export interface Interface {
   readonly getUnreportedWakeWorkflows: (sessionID: string) => Effect.Effect<WorkflowRow[]>
   readonly getSessionsWithUnreportedWakes: () => Effect.Effect<string[]>
   readonly hasReportedWakeNodes: (sessionID: string) => Effect.Effect<boolean>
-
-  readonly listViolations: (workflowId: string) => Effect.Effect<ViolationRow[]>
-  readonly countBySeverity: (workflowId: string) => Effect.Effect<Record<string, number>>
-  readonly queryViolations: (query: ViolationQuery) => Effect.Effect<ViolationRow[]>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/v2/DagStore") {}
@@ -463,46 +425,6 @@ export const layer = Layer.effect(
           .all()
           .pipe(Effect.orDie)
         return rows.length > 0
-      }),
-
-      listViolations: Effect.fn("DagStore.listViolations")(function* (workflowId) {
-        const rows = yield* db
-          .select()
-          .from(WorkflowViolationTable)
-          .where(eq(WorkflowViolationTable.workflow_id, workflowId))
-          .orderBy(desc(WorkflowViolationTable.time_created))
-          .all()
-          .pipe(Effect.orDie)
-        return rows.map(mapViolation)
-      }),
-
-      countBySeverity: Effect.fn("DagStore.countBySeverity")(function* (workflowId) {
-        const rows = yield* db
-          .select()
-          .from(WorkflowViolationTable)
-          .where(eq(WorkflowViolationTable.workflow_id, workflowId))
-          .all()
-          .pipe(Effect.orDie)
-        const counts: Record<string, number> = {}
-        for (const r of rows) counts[r.severity] = (counts[r.severity] ?? 0) + 1
-        return counts
-      }),
-
-      queryViolations: Effect.fn("DagStore.queryViolations")(function* (query) {
-        const conditions = []
-        if (query.workflowId) conditions.push(eq(WorkflowViolationTable.workflow_id, query.workflowId))
-        if (query.severity) conditions.push(eq(WorkflowViolationTable.severity, query.severity))
-        if (query.type) conditions.push(eq(WorkflowViolationTable.type, query.type))
-        if (query.since) conditions.push(gte(WorkflowViolationTable.time_created, query.since))
-        if (query.until) conditions.push(lte(WorkflowViolationTable.time_created, query.until))
-        const rows = yield* db
-          .select()
-          .from(WorkflowViolationTable)
-          .where(conditions.length > 0 ? and(...conditions) : undefined)
-          .orderBy(desc(WorkflowViolationTable.time_created))
-          .all()
-          .pipe(Effect.orDie)
-        return rows.map(mapViolation)
       }),
     })
   }),

--- a/packages/core/src/plugin/command/workflow.md
+++ b/packages/core/src/plugin/command/workflow.md
@@ -130,7 +130,7 @@ config:
         inline: "Review this design and submit a structured verdict: {{design}}"
 ```
 
-`required: true` cancels the workflow only when the gate node fails to execute
+`required: true` fails the workflow only when the gate node fails to execute
 or satisfy its output contract. A successful `REVISE` or `REJECT` result is a
 business verdict, not an execution failure. Use a downstream `condition` for a
 static ACCEPT path, or let the reported checkpoint wake the parent to perform a
@@ -486,6 +486,21 @@ rather than letting the original graph run to completion.
 
 When the same node or workflow keeps failing — via `orchestrator_unresponsive` (the woken agent took no action), a replan-attempt ceiling rejection, or repeated review failures — **change your approach** rather than retrying the identical plan. Try a different decomposition, a different model, a simpler prompt, or break the node into smaller steps. Repeating the same failing plan wastes budget without progress.
 
+### Crash recovery: a recovered workflow arrives paused
+
+After a process restart, nodes that were mid-flight are failed conservatively
+(`execution ownership lost on recovery`) — recovery never re-runs provider work
+implicitly. The workflow then PAUSES instead of terminalizing, and you receive
+the failed-node wake. Downstream nodes stay `pending`, so the graph is still
+replannable. Dispose of it in the same turn:
+
+- **Replan + resume (preferred)**: the failed node is terminal and immutable — add a replacement under a NEW id, rewire its pending dependents' `depends_on` to the new id, then `control(resume)`.
+- **Resume as-is**: accept the failure. A required-node failure terminalizes the workflow as `failed` (attributed to the node ids); optional failures degrade and continue.
+- **Cancel**: abandon the workflow.
+
+Never assume a crashed workflow resumes or retries on its own — it will wait,
+paused, until you act.
+
 ## Model Assignment Strategy
 
 Each node MAY specify `model: { modelID, providerID }` to pin a specific model.
@@ -541,7 +556,7 @@ All nodes share the same workspace. Write conflicts are an orchestration concern
 ## Design Principles
 
 - Each node is a real child session with its own message history, tools, and context window. There is no shared memory between nodes — data flows only through `depends_on` and `input_mapping`.
-- `required: true` means failure cancels the entire workflow. Use it for nodes whose output is indispensable (gates, core implementation). Omit it for nodes whose failure is recoverable.
+- `required: true` means failure fails the entire workflow (terminal status `failed`, attributed to the node ids; `cancelled` is reserved for explicit cancels). Use it for nodes whose output is indispensable (gates, core implementation). Omit it for nodes whose failure is recoverable.
 - A successful fan-in node must actually contain the requested comparison,
   synthesis, or final decision. Unresolved placeholders, missing dependency
   outputs, or a claim that inputs were aggregated are not successful
@@ -568,7 +583,7 @@ checkpoint naturally completed the current graph; an early
 **status** — Read the durable state of one workflow and all of its nodes. Pass `workflow_id`. Use it when the user explicitly asks for current state or once before a decision that requires fresh state, such as replan/control. Do not poll a running workflow merely to wait: node reports and terminal outcomes wake the parent session automatically.
 
 **control** — Control a running workflow:
-- `pause` — let running nodes finish, don't spawn new ones
+- `pause` — let running nodes finish, don't spawn new ones (pause does NOT stop nodes that are already running)
 - `resume` — resume scheduling
 - `cancel` — cancel the entire workflow
 - `replan` — submit a YAML fragment; running nodes can be `restart: true` or `cancel: true`; pending nodes absent from the fragment are cancelled
@@ -583,7 +598,7 @@ checkpoint naturally completed the current graph; an early
 | `name` | yes | Human-readable name |
 | `worker_type` | yes | Agent type (`explore`, `build`, `general`, `plan`, or custom) |
 | `depends_on` | yes | Array of node IDs this node waits for (`[]` for root) |
-| `required` | no | If true and this node fails, the workflow is cancelled. Default: false |
+| `required` | no | If true and this node fails, the workflow terminalizes as failed. Default: false |
 | `prompt_template` | yes | `{ id: "..." }` or `{ inline: "...", input: {...} }` |
 | `model` | no | `{ modelID, providerID }` override |
 | `condition` | no | Expression evaluated before spawn; node is skipped if false |

--- a/packages/core/test/dag-core.test.ts
+++ b/packages/core/test/dag-core.test.ts
@@ -23,6 +23,7 @@ import { FallbackTrigger } from "@opencode-ai/core/dag/core/types"
 import { validateRequiredNodes } from "@opencode-ai/core/dag/core/required-validator"
 import {
   buildGraph,
+  toSchedulingNodes,
   type SchedulingNode,
   WorkflowRuntime,
 } from "@opencode-ai/core/dag/core/scheduling"
@@ -183,7 +184,7 @@ describe("iron laws (transition tables)", () => {
     const transitions = [
       [WorkflowStatus.PENDING, [WorkflowStatus.RUNNING]],
       [WorkflowStatus.RUNNING, [WorkflowStatus.PAUSED, WorkflowStatus.STEPPING, WorkflowStatus.COMPLETED, WorkflowStatus.FAILED, WorkflowStatus.CANCELLED]],
-      [WorkflowStatus.STEPPING, [WorkflowStatus.RUNNING, WorkflowStatus.PAUSED, WorkflowStatus.COMPLETED, WorkflowStatus.FAILED, WorkflowStatus.CANCELLED]],
+      [WorkflowStatus.STEPPING, [WorkflowStatus.RUNNING, WorkflowStatus.PAUSED, WorkflowStatus.STEPPING, WorkflowStatus.COMPLETED, WorkflowStatus.FAILED, WorkflowStatus.CANCELLED]],
       [WorkflowStatus.PAUSED, [WorkflowStatus.RUNNING, WorkflowStatus.CANCELLED]],
       [WorkflowStatus.COMPLETED, [WorkflowStatus.ARCHIVED]],
       [WorkflowStatus.FAILED, [WorkflowStatus.ARCHIVED]],
@@ -692,5 +693,125 @@ describe("WorkflowRuntime", () => {
     rt.markSatisfied("c")
     rt.markUnsatisfied("a")
     expect(rt.isComplete()).toBe(true)
+  })
+})
+
+describe("WorkflowRuntime skipped semantics (D13)", () => {
+  it("markSkipped excludes pure-skip dependents from ready and flags them for cascade", () => {
+    const nodes: SchedulingNode[] = [
+      { id: "gate", dependsOn: [], status: "pending", required: true },
+      { id: "impl", dependsOn: ["gate"], status: "pending", required: true },
+      { id: "audit", dependsOn: ["impl"], status: "pending", required: true },
+    ]
+    const rt = new WorkflowRuntime(nodes, 4)
+    rt.markSatisfied("gate")
+    rt.markSkipped("impl")
+    // impl is the only dependency of audit and it is skipped — audit must NOT
+    // become ready (the pre-fix bug: skip ≡ satisfied let audit run).
+    expect(rt.getReadyNodes()).toEqual([])
+    expect(rt.getCascadeSkipNodes()).toEqual(["audit"])
+  })
+
+  it("cascade waves reach a fixpoint transitively", () => {
+    const nodes: SchedulingNode[] = [
+      { id: "a", dependsOn: [], status: "pending", required: true },
+      { id: "b", dependsOn: ["a"], status: "pending", required: true },
+      { id: "c", dependsOn: ["b"], status: "pending", required: true },
+    ]
+    const rt = new WorkflowRuntime(nodes, 4)
+    rt.markSkipped("a")
+    expect(rt.getCascadeSkipNodes()).toEqual(["b"])
+    rt.markSkipped("b")
+    expect(rt.getCascadeSkipNodes()).toEqual(["c"])
+    rt.markSkipped("c")
+    expect(rt.getCascadeSkipNodes()).toEqual([])
+    expect(rt.isComplete()).toBe(true)
+  })
+
+  it("a mixed fan-in with at least one satisfied dependency still runs", () => {
+    const nodes: SchedulingNode[] = [
+      { id: "left", dependsOn: [], status: "pending", required: false },
+      { id: "right", dependsOn: [], status: "pending", required: false },
+      { id: "fanin", dependsOn: ["left", "right"], status: "pending", required: true },
+    ]
+    const rt = new WorkflowRuntime(nodes, 4)
+    rt.markSatisfied("left")
+    rt.markSkipped("right")
+    // Graceful degradation is preserved: the fan-in sees the skip as a
+    // placeholder input instead of cascading.
+    expect(rt.getReadyNodes()).toEqual(["fanin"])
+    expect(rt.getCascadeSkipNodes()).toEqual([])
+  })
+
+  it("isComplete counts skipped as terminal and skip of a required node is not a required failure", () => {
+    const nodes: SchedulingNode[] = [
+      { id: "a", dependsOn: [], status: "pending", required: true },
+      { id: "b", dependsOn: ["a"], status: "pending", required: true },
+    ]
+    const rt = new WorkflowRuntime(nodes, 4)
+    rt.markSkipped("a")
+    rt.markSkipped("b")
+    expect(rt.isComplete()).toBe(true)
+    expect(rt.hasRequiredFailure()).toBe(false)
+  })
+
+  it("constructor seeds skipped nodes from durable statuses", () => {
+    const nodes: SchedulingNode[] = [
+      { id: "a", dependsOn: [], status: "skipped", required: true },
+      { id: "b", dependsOn: ["a"], status: "pending", required: true },
+    ]
+    const rt = new WorkflowRuntime(nodes, 4)
+    expect(rt.getReadyNodes()).toEqual([])
+    expect(rt.getCascadeSkipNodes()).toEqual(["b"])
+    expect(rt.isActive("a")).toBe(false)
+  })
+
+  it("cascade respects pause — a paused workflow must stay replannable", () => {
+    const nodes: SchedulingNode[] = [
+      { id: "a", dependsOn: [], status: "skipped", required: true },
+      { id: "b", dependsOn: ["a"], status: "pending", required: true },
+    ]
+    const rt = new WorkflowRuntime(nodes, 4)
+    rt.setPaused(true)
+    expect(rt.getCascadeSkipNodes()).toEqual([])
+    rt.setPaused(false)
+    expect(rt.getCascadeSkipNodes()).toEqual(["b"])
+  })
+})
+
+describe("toSchedulingNodes mapping", () => {
+  it("keeps skipped distinguishable from satisfied", () => {
+    const rows = [
+      { id: "done", status: "completed", dependsOn: [], required: true },
+      { id: "gone", status: "skipped", dependsOn: [], required: true },
+      { id: "dead", status: "failed", dependsOn: [], required: true },
+      { id: "live", status: "running", dependsOn: [], required: true },
+      { id: "wait", status: "queued", dependsOn: [], required: true },
+    ]
+    expect(toSchedulingNodes(rows).map((n) => n.status)).toEqual([
+      "satisfied",
+      "skipped",
+      "unsatisfied",
+      "running",
+      "pending",
+    ])
+  })
+})
+
+describe("planReplan fragment validation additions", () => {
+  it("rejects duplicate ids within the fragment", () => {
+    const plan = planReplan(
+      { nodes: [] },
+      { nodes: [{ id: "x", depends_on: [] }, { id: "x", depends_on: [] }] },
+    )
+    expect(plan.errors.join(" ")).toContain('duplicate node id "x"')
+  })
+
+  it("restart on a terminal node explains the replacement path", () => {
+    const plan = planReplan(
+      { nodes: [{ id: "f", status: NodeStatus.FAILED, depends_on: [] }] },
+      { nodes: [{ id: "f", depends_on: [], restart: true }] },
+    )
+    expect(plan.errors.join(" ")).toContain("add a replacement node under a new id")
   })
 })

--- a/packages/opencode/src/dag/dag.ts
+++ b/packages/opencode/src/dag/dag.ts
@@ -9,7 +9,7 @@ import { EventV2Bridge } from "@/event-v2-bridge"
 import { Database } from "@opencode-ai/core/database/database"
 import { KeyedMutex } from "@opencode-ai/core/effect/keyed-mutex"
 import { validateRequiredNodes } from "@opencode-ai/core/dag/core/required-validator"
-import { buildGraph, WorkflowRuntime } from "@opencode-ai/core/dag/core/scheduling"
+import { buildGraph, WorkflowRuntime, toSchedulingNodes } from "@opencode-ai/core/dag/core/scheduling"
 import { CycleError } from "@opencode-ai/core/dag/core/graph"
 import { planReplan } from "@opencode-ai/core/dag/core/replan"
 import {
@@ -29,6 +29,7 @@ import {
   validateAdmission,
 } from "./admission"
 import { validateReviewLifecycle } from "./review-lifecycle"
+import { conditionReference } from "./runtime/eval"
 
 // Re-export domain types
 export const ID = DagEvent.DagID
@@ -176,6 +177,21 @@ export function parseWorkflowConfig(raw: string): WorkflowConfig | undefined {
   return parsed.value as WorkflowConfig
 }
 
+/**
+ * A parseable condition may only reference the node's direct dependencies —
+ * anything else silently resolves to undefined and evaluates false at spawn
+ * time. Shared by create (all nodes) and replan (fragment nodes).
+ */
+function conditionReferenceErrors(nodes: readonly NodeConfig[]): string[] {
+  return nodes.flatMap((node) => {
+    const ref = conditionReference(node.condition)
+    if (!ref || node.depends_on.includes(ref)) return []
+    return [
+      `node "${node.id}" condition references "${ref}" which is not in its depends_on (condition inputs come from direct dependencies only; this would silently evaluate false)`,
+    ]
+  })
+}
+
 export interface Interface {
   readonly create: (input: {
     projectID: string
@@ -254,6 +270,33 @@ export const layer = Layer.effect(
       config: WorkflowConfig
     }) {
       const config = normalizeWorkflowConfig(input.config)
+      // Structural validation first (mirrors planReplan's fragment checks so
+      // create and replan reject the same malformed shapes): duplicate ids
+      // would silently merge via the projector's upsert, and a dangling
+      // depends_on reference would silently drop the edge in buildGraph —
+      // turning a typo'd dependency into an immediately-runnable root node.
+      const ids = config.nodes.map((n) => n.id)
+      const idSet = new Set(ids)
+      if (idSet.size !== ids.length) {
+        const duplicates = [...new Set(ids.filter((id, index) => ids.indexOf(id) !== index))]
+        return yield* Effect.fail(new Error(`Invalid workflow config: duplicate node ids: ${duplicates.join(", ")}`))
+      }
+      const danglingDeps = config.nodes.flatMap((n) =>
+        n.depends_on.filter((dep) => !idSet.has(dep)).map((dep) => `node "${n.id}" depends on unknown node "${dep}"`),
+      )
+      if (danglingDeps.length > 0) {
+        return yield* Effect.fail(new Error(`Invalid workflow config: ${danglingDeps.join("; ")}`))
+      }
+      const conditionErrors = conditionReferenceErrors(config.nodes)
+      if (conditionErrors.length > 0) {
+        return yield* Effect.fail(new Error(`Invalid workflow config: ${conditionErrors.join("; ")}`))
+      }
+      // Enforce the total node ceiling at creation, not only on replan — the
+      // ceiling is a lifetime cap and the initial graph counts toward it.
+      const maxTotalNodes = config.max_total_nodes ?? DEFAULT_WORKFLOW_CONFIG.maxTotalNodes
+      if (config.nodes.length > maxTotalNodes) {
+        return yield* Effect.fail(new Error(`Total node ceiling exceeded: ${config.nodes.length} nodes > ${maxTotalNodes} max`))
+      }
       if (config.mode === "deep") {
         if (!config.admission) {
           return yield* Effect.fail(new Error(
@@ -361,19 +404,7 @@ export const layer = Layer.effect(
       const hasInFlight = nodes.some((n) => n.status === "running")
       if (hasInFlight) return yield* Effect.fail(new Error(`Node still in-flight: cannot step ${dagID}`))
       // Compute ready nodes using a transient WorkflowRuntime.
-      const SUCCESS_TERMINAL = new Set(["completed", "skipped", "aborted"])
-      const schedulingNodes = nodes.map((n) => ({
-        id: n.id,
-        dependsOn: n.dependsOn,
-        required: n.required,
-        status: SUCCESS_TERMINAL.has(n.status)
-          ? ("satisfied" as const)
-          : n.status === "failed"
-            ? ("unsatisfied" as const)
-            : n.status === "running"
-              ? ("running" as const)
-              : ("pending" as const),
-      }))
+      const schedulingNodes = toSchedulingNodes(nodes)
       const config = parseWorkflowConfig((yield* store.getWorkflow(dagID))?.config ?? "")
       const maxConcurrency = Math.max(1, config?.max_concurrency ?? DEFAULT_WORKFLOW_CONFIG.maxConcurrency)
       const runtime = new WorkflowRuntime(schedulingNodes, maxConcurrency)
@@ -452,6 +483,22 @@ export const layer = Layer.effect(
         { nodes: normalizedFragment.nodes.map((n) => ({ id: n.id, depends_on: n.depends_on, restart: n.restart, cancel: n.cancel })) },
       )
       if (plan.errors.length > 0) return yield* Effect.fail(new Error(`Replan rejected: ${plan.errors.join("; ")}`))
+
+      // Fragment nodes that will actually (re)run must satisfy the same
+      // condition-reference rule as create. Terminal nodes in the fragment are
+      // ignored by the plan and keep their immutable definitions; cancelled
+      // nodes never evaluate a condition again.
+      const nodeStatusById = new Map(nodes.map((n) => [n.id, n.status]))
+      const conditionErrors = conditionReferenceErrors(
+        normalizedFragment.nodes.filter((n) => {
+          if (n.cancel) return false
+          const status = nodeStatusById.get(n.id)
+          return status === undefined || !isNodeTerminalStatus(status as NodeStatus)
+        }),
+      )
+      if (conditionErrors.length > 0) {
+        return yield* Effect.fail(new Error(`Replan rejected: ${conditionErrors.join("; ")}`))
+      }
 
       const maxReplanAttempts = wfConfig?.max_node_replan_attempts ?? DEFAULT_WORKFLOW_CONFIG.maxNodeReplanAttempts
       const maxTotalNodes = wfConfig?.max_total_nodes ?? DEFAULT_WORKFLOW_CONFIG.maxTotalNodes

--- a/packages/opencode/src/dag/runtime/eval.ts
+++ b/packages/opencode/src/dag/runtime/eval.ts
@@ -11,6 +11,8 @@
 
 import type { DagStore } from "@opencode-ai/core/dag/store"
 
+const CONDITION_RE = /^(.+?)\s*(==|!=|>=|<=|>|<)\s*(.+)$/
+
 /**
  * Evaluate a node's `condition` expression.
  *
@@ -35,7 +37,7 @@ export function evaluateCondition(
 ): { ok: true; value: boolean } | { ok: false; error: string } {
   if (!condition || condition.trim() === "") return { ok: true, value: true }
 
-  const match = condition.match(/^(.+?)\s*(==|!=|>=|<=|>|<)\s*(.+)$/)
+  const match = condition.match(CONDITION_RE)
   if (!match) return { ok: false, error: `condition unparseable: ${condition}` }
 
   const [, lhsRaw, op, rhsRaw] = match
@@ -51,6 +53,21 @@ export function evaluateCondition(
     case "<=": return { ok: true, value: (lhs as number) <= (rhs as number) }
     default: return { ok: true, value: true }
   }
+}
+
+/**
+ * NodeID referenced by a parseable condition's left-hand side, or null when
+ * the condition is empty or unparseable. Used at create/replan time to reject
+ * conditions referencing nodes outside `depends_on` — those would silently
+ * resolve to undefined and evaluate false at spawn time (the worst failure
+ * mode). Unparseable conditions are left to the runtime, which fails the node
+ * loudly instead.
+ */
+export function conditionReference(condition: string | undefined): string | null {
+  if (!condition || condition.trim() === "") return null
+  const match = condition.match(CONDITION_RE)
+  if (!match) return null
+  return match[1]!.trim().split(".")[0] || null
 }
 
 /**

--- a/packages/opencode/src/dag/runtime/loop.ts
+++ b/packages/opencode/src/dag/runtime/loop.ts
@@ -7,7 +7,7 @@ import { EventV2Bridge } from "@/event-v2-bridge"
 import { DagEvent } from "@opencode-ai/schema/dag-event"
 import { SessionStatusEvent } from "@opencode-ai/schema/session-status-event"
 import { DagStore } from "@opencode-ai/core/dag/store"
-import { WorkflowRuntime, type SchedulingNode } from "@opencode-ai/core/dag/core/scheduling"
+import { WorkflowRuntime, toSchedulingNodes } from "@opencode-ai/core/dag/core/scheduling"
 import { isWorkflowTerminalStatus } from "@opencode-ai/core/dag/core/types"
 import { Dag, type WorkflowConfig, parseWorkflowConfig } from "../dag"
 import { projectBriefForNode } from "../admission"
@@ -32,23 +32,6 @@ export interface Interface {
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/DagLoop") {}
-
-export const SUCCESS_TERMINAL = new Set(["completed", "skipped", "aborted"])
-
-export function toSchedulingNodes(nodes: readonly DagStore.NodeRow[]): SchedulingNode[] {
-  return nodes.map((n) => ({
-    id: n.id,
-    dependsOn: n.dependsOn,
-    required: n.required,
-    status: SUCCESS_TERMINAL.has(n.status)
-      ? ("satisfied" as const)
-      : n.status === "failed"
-        ? ("unsatisfied" as const)
-        : n.status === "running"
-          ? ("running" as const)
-          : ("pending" as const),
-  }))
-}
 
 interface WorkflowEntry {
   runtime: WorkflowRuntime
@@ -79,6 +62,20 @@ export const layer = Layer.effect(
         const spawnReady = Effect.fn("DagLoop.spawnReady")(function* (dagID: string) {
           const entry = runtimes.get(dagID)
           if (!entry) return
+          // D13: settle cascade-skips before spawning. A node whose dependencies
+          // are all skipped can never receive a real input; publish a durable
+          // NodeSkipped(orphan_cascade) wave by wave until a fixpoint so gated
+          // subtrees terminalize instead of running on placeholder inputs.
+          // Eagerly markSkipped so the fixpoint advances synchronously; the
+          // NodeSkipped handler's isActive guard then no-ops on these events.
+          for (;;) {
+            const cascade = entry.runtime.getCascadeSkipNodes()
+            if (cascade.length === 0) break
+            for (const nodeID of cascade) {
+              entry.runtime.markSkipped(nodeID)
+              yield* dag.nodeSkipped(dagID, nodeID, "orphan_cascade").pipe(Effect.ignore)
+            }
+          }
           const ready = entry.runtime.getReadyNodes()
           for (const nodeID of ready) {
             const node = yield* store.getNode(dagID, nodeID)
@@ -235,8 +232,14 @@ export const layer = Layer.effect(
           if (!entry.runtime.isComplete()) return
           const wf = yield* store.getWorkflow(dagID).pipe(Effect.orDie)
           if (wf && isWorkflowTerminalStatus(wf.status as never)) return
-          if (entry.runtime.hasRequiredFailure()) yield* dag.cancel(dagID)
-          else yield* dag.complete(dagID)
+          // A required-node failure is a workflow FAILURE, not a cancellation —
+          // "cancelled" is reserved for explicit user/agent cancels so the
+          // terminal status attributes the outcome correctly (P2-1).
+          if (entry.runtime.hasRequiredFailure()) {
+            yield* dag.fail(dagID, `required node(s) failed: ${entry.runtime.getRequiredFailures().join(", ")}`)
+            return
+          }
+          yield* dag.complete(dagID)
         })
 
         const checkSessionStatus = makeSessionStatusChecker(sessionSvc)
@@ -260,7 +263,26 @@ export const layer = Layer.effect(
           ).pipe(
             Effect.provideService(Dag.Service, dag),
           )
-          if (recovery.ownershipLost > 0) {
+          // P2-2 recovery-pause: reconciliation invented failures (ownership
+          // lost / no child session / deadline enforced offline) without any
+          // durable proof of the child's outcome. Letting spawnReady cascade
+          // skips and checkCompletion terminalize now would weld the workflow
+          // into a terminal status the parent never sanctioned — and terminal
+          // nodes are immutable, so replan could no longer rewire downstream.
+          // Pause instead: pending nodes stay replannable, the durable
+          // NodeFailed wake rows reach the parent at the paused delivery
+          // boundary, and disposition (replan / resume / cancel) stays under
+          // explicit workflow control.
+          const pausedForRecovery = recovery.ownershipLost > 0 && wf.status === "running"
+          if (pausedForRecovery) {
+            yield* dag.pause(dagID)
+            yield* Effect.logWarning("DagLoop paused workflow after recovery invented node failures", {
+              dagID,
+              reconciled: recovery.reconciled,
+              ownershipLost: recovery.ownershipLost,
+            })
+          }
+          if (recovery.ownershipLost > 0 && !pausedForRecovery) {
             yield* Effect.logWarning("DagLoop terminalized recovered nodes after execution ownership loss", {
               dagID,
               reconciled: recovery.reconciled,
@@ -271,7 +293,7 @@ export const layer = Layer.effect(
           const maxConcurrency = Math.max(1, config?.max_concurrency ?? Dag.DEFAULT_WORKFLOW_CONFIG.maxConcurrency)
           const runtime = new WorkflowRuntime(toSchedulingNodes(nodes), maxConcurrency)
           const semaphore = Semaphore.makeUnsafe(maxConcurrency)
-          const isPaused = wf.status === "paused"
+          const isPaused = wf.status === "paused" || pausedForRecovery
           const isStepping = wf.status === "stepping"
           if (isPaused) runtime.setPaused(true)
           if (isStepping) runtime.setStepMode(true)
@@ -287,6 +309,12 @@ export const layer = Layer.effect(
                 yield* checkCompletion(dagID)
               }),
             )
+          }
+          // Deliver the invented-failure wake rows now instead of waiting for
+          // the next idle event — the workflow just paused itself and the
+          // parent is the only actor that can dispose of it.
+          if (pausedForRecovery) {
+            yield* tryDeliverWake(wf.sessionId).pipe(Effect.ignore, Effect.forkScoped)
           }
         })
 
@@ -316,6 +344,12 @@ export const layer = Layer.effect(
         )
 
         for (const def of [DagEvent.NodeCompleted, DagEvent.NodeSkipped]) {
+          // A completed node is an output-producing success; a skipped node is a
+          // terminal no-output state that must stay distinguishable so pure-skip
+          // descendants cascade instead of running (D13).
+          const settle = def === DagEvent.NodeSkipped
+            ? (entry: WorkflowEntry, nodeID: string) => entry.runtime.markSkipped(nodeID)
+            : (entry: WorkflowEntry, nodeID: string) => entry.runtime.markSatisfied(nodeID)
           yield* events.subscribe(def).pipe(
             Stream.filter((e) => runtimes.has(e.data.dagID as string)),
             Stream.runForEach((evt) =>
@@ -333,7 +367,7 @@ export const layer = Layer.effect(
                     // (markUnsatisfied) or already satisfied must not be flipped
                     // back. Mirrors the NodeFailed handler's isActive guard.
                     if (entry.runtime.isActive(evt.data.nodeID as string)) {
-                      entry.runtime.markSatisfied(evt.data.nodeID as string)
+                      settle(entry, evt.data.nodeID as string)
                       // In stepMode, do NOT auto-advance — wait for the next
                       // explicit step command. checkCompletion still runs so
                       // required-node failure / early completion is detected.
@@ -455,6 +489,11 @@ export const layer = Layer.effect(
                   entry.runtime.setPaused(false)
                   entry.runtime.setStepMode(false)
                   yield* spawnReady(dagID)
+                  // A workflow can be resumed with every node already settled
+                  // (e.g. recovery-pause on a single lost node). Without this,
+                  // nothing else re-runs completion and the workflow hangs in
+                  // running forever.
+                  yield* checkCompletion(dagID)
                 }),
               )
             }).pipe(Effect.ignore),
@@ -546,7 +585,13 @@ export const layer = Layer.effect(
             if (workflow.status === "paused" || workflow.status === "stepping") return true
             if (entry?.runtime.isPaused() || entry?.runtime.isStepMode()) return true
             if (workflow.status !== "running" || !entry) return false
-            if (entry.runtime.hasRunningMatching((id) => entry.fibers.has(id))) return false
+            // Delivery boundary uses the runtime's own running set, NOT fiber
+            // ownership: between markRunning and fibers.set the spawn path has
+            // async yield points, and a wake reading that window would misjudge
+            // "running, no fiber, nothing ready" as a stalled boundary and
+            // deliver a mid-flight batch. The orchestrator-unresponsive net
+            // below keeps the stricter fiber-ownership check.
+            if (entry.runtime.hasRunning()) return false
             return entry.runtime.getReadyNodes().length === 0
           })
           const atBoundary = new Set(boundaryWorkflows.map((workflow) => workflow.id))

--- a/packages/opencode/src/dag/runtime/recovery.ts
+++ b/packages/opencode/src/dag/runtime/recovery.ts
@@ -9,6 +9,12 @@
  * This is NOT a startup-blocking scan (unlike the old recoverOrphanedWorkflows).
  * It runs lazily when a workflow is first accessed, and only touches workflows
  * that have running nodes.
+ *
+ * `ownershipLost` counts nodes whose failure was INVENTED by reconciliation
+ * (no durable proof of the child's outcome: session missing, still active, or
+ * unknown), as opposed to failures read from durable child state. The caller
+ * uses it to pause the workflow instead of letting the scheduler cascade skips
+ * and terminalize on fabricated evidence (P2-2 recovery-pause).
  */
 
 import { Effect, Clock } from "effect"
@@ -44,6 +50,9 @@ export function reconcileWorkflow(
       }
       if (node.status !== "running") continue
       if (!node.childSessionId) {
+        // Crash landed between admission and session creation — no durable
+        // outcome exists, so this is an invented failure like ownership loss.
+        ownershipLost++
         yield* dag.nodeFailed(dagID, node.id, "node was running but had no child session on recovery", "exec_failed")
         reconciled++
         continue

--- a/packages/opencode/src/dag/templates/resolve.ts
+++ b/packages/opencode/src/dag/templates/resolve.ts
@@ -4,8 +4,7 @@
  * Resolves a node's `prompt_template` declaration into a final prompt string:
  * - `id` reference → reads the `.md` file from project (`.opencode/dag-prompts/`)
  *   or global (`~/.config/opencode/dag-prompts/`) directory
- * - `inline` → writes the string to a temp file under `os.tmpdir()`, reads it,
- *   then deletes it after resolution
+ * - `inline` → used directly as the template source (no filesystem round-trip)
  *
  * Both paths go through `{{var}}` interpolation and `sanitize()`.
  *
@@ -57,28 +56,14 @@ export function renderTemplate(
 
 function readTemplateSource(ref: TemplateRef, projectDir: string): Effect.Effect<string, Error> {
   if (ref.inline !== undefined) {
-    return readInline(ref.inline)
+    // Inline content IS the template source — a temp-file write/read/delete
+    // round-trip adds spawn-path I/O and failure surface for no benefit.
+    return Effect.succeed(ref.inline)
   }
   if (ref.id) {
     return readById(ref.id, projectDir)
   }
   return Effect.fail(new Error("prompt_template must have either 'id' or 'inline'"))
-}
-
-function readInline(content: string): Effect.Effect<string, Error> {
-  return Effect.gen(function* () {
-    // Write to temp file (os.tmpdir() — NEVER hardcoded /tmp/)
-    const dir = yield* Effect.promise(() => fs.mkdtemp(path.join(os.tmpdir(), "dag-inline-")))
-    const filePath = path.join(dir, "prompt.md")
-    yield* Effect.promise(() => fs.writeFile(filePath, content, "utf-8"))
-    // Read it back (simulating the template-file read path)
-    const raw = yield* Effect.promise(() => fs.readFile(filePath, "utf-8"))
-    // Delete temp file (use-once-and-discard)
-    yield* Effect.promise(() => fs.rm(dir, { recursive: true, force: true })).pipe(
-      Effect.catch(() => Effect.void),
-    )
-    return raw
-  })
 }
 
 function readById(id: string, projectDir: string): Effect.Effect<string, Error> {

--- a/packages/opencode/src/tool/workflow.ts
+++ b/packages/opencode/src/tool/workflow.ts
@@ -19,7 +19,7 @@ const NodeSchema = Schema.Struct({
   worker_type: Schema.String.annotate({ description: "Agent type (explore, build, general, plan, or custom)" }),
   depends_on: Schema.Array(Schema.String).annotate({ description: "Node IDs this node waits for ([] for root)" }),
   required: Schema.optional(Schema.Boolean).annotate({
-    description: "If true and this node fails, the workflow is cancelled. Inherits config.node_defaults.required",
+    description: "If true and this node fails, the workflow terminalizes as failed. Inherits config.node_defaults.required",
   }),
   prompt_template: Schema.Struct({
     id: Schema.optional(Schema.String),
@@ -43,7 +43,7 @@ const NodeSchema = Schema.Struct({
   model: Schema.optional(Schema.Struct({ modelID: Schema.String, providerID: Schema.String })).annotate({
     description: 'Optional node override. modelID is provider-local, e.g. { providerID: "local-proxy-compatible", modelID: "glm-5.2" }, never repeat providerID inside modelID. Omit to inherit config.node_defaults.model, then the agent or parent-session model',
   }),
-  restart: Schema.optional(Schema.Boolean).annotate({ description: "(replan only) Re-spawn this running node with new prompt" }),
+  restart: Schema.optional(Schema.Boolean).annotate({ description: "(replan only) Re-spawn this running node with new prompt. Running nodes only — terminal (completed/failed/skipped) nodes are immutable; to retry a failed node, add a replacement node under a new id" }),
   cancel: Schema.optional(Schema.Boolean).annotate({ description: "(replan only) Cancel this node" }),
   output_schema: Schema.optional(Schema.Record(Schema.String, Schema.Unknown)).annotate({ description: "JSON Schema; child agent must call submit_result to submit structured output" }),
   review: Schema.optional(
@@ -201,7 +201,7 @@ export const WorkflowTool = Tool.define<typeof Parameters, Metadata, Dag.Service
               switch (params.operation) {
                 case "pause":
                   yield* dag.pause(wfId).pipe(Effect.orDie)
-                  return { title: "Workflow paused", output: `<workflow id="${wfId}" state="paused"/>`, metadata: { workflowId: wfId } as Metadata }
+                  return { title: "Workflow paused", output: `<workflow id="${wfId}" state="paused"/>\nNote: pause stops new node spawns only — nodes already running continue to completion.`, metadata: { workflowId: wfId } as Metadata }
                 case "resume":
                   yield* dag.resume(wfId).pipe(Effect.orDie)
                   return { title: "Workflow resumed", output: `<workflow id="${wfId}" state="running"/>`, metadata: { workflowId: wfId } as Metadata }
@@ -214,9 +214,10 @@ export const WorkflowTool = Tool.define<typeof Parameters, Metadata, Dag.Service
                 case "replan": {
                   if (!params.fragment) return yield* Effect.die(new Error("replan operation requires 'fragment'"))
                   const r = yield* dag.replan(wfId, { nodes: params.fragment.nodes as NodeConfig[] }).pipe(Effect.orDie)
+                  const ignored = r.ignore.length > 0 ? `\nIgnored (terminal, immutable — add replacements under new ids to retry): ${r.ignore.join(", ")}` : ""
                   return {
                     title: `Workflow replanned: +${r.add.length} -${r.cancel.length} ↻${r.restart.length}`,
-                    output: `<workflow id="${wfId}" action="replan">\nAdded: ${r.add.join(", ")}\nCancelled: ${r.cancel.join(", ")}\nRestarted: ${r.restart.join(", ")}\nReplaced: ${r.replace.join(", ")}\n</workflow>`,
+                    output: `<workflow id="${wfId}" action="replan">\nAdded: ${r.add.join(", ")}\nCancelled: ${r.cancel.join(", ")}\nRestarted: ${r.restart.join(", ")}\nReplaced: ${r.replace.join(", ")}${ignored}\n</workflow>`,
                     metadata: { workflowId: wfId, ...r } as Metadata,
                   }
                 }

--- a/packages/opencode/test/dag/dag-create-validation.test.ts
+++ b/packages/opencode/test/dag/dag-create-validation.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "bun:test"
+import { Effect, Layer } from "effect"
+import { Database } from "@opencode-ai/core/database/database"
+import { EventV2 } from "@opencode-ai/core/event"
+import { DagProjector } from "@opencode-ai/core/dag/projector"
+import { DagStore } from "@opencode-ai/core/dag/store"
+import { Project } from "@opencode-ai/core/project"
+import { ProjectTable } from "@opencode-ai/core/project/sql"
+import { SessionTable } from "@opencode-ai/core/session/sql"
+import { AbsolutePath } from "@opencode-ai/core/schema"
+import { Dag, type NodeConfig, type WorkflowConfig } from "@/dag/dag"
+import { EventV2Bridge } from "@/event-v2-bridge"
+
+const testLayer = Layer.mergeAll(
+  Database.defaultLayer,
+  EventV2.defaultLayer,
+  DagProjector.defaultLayer,
+  DagStore.defaultLayer,
+  EventV2Bridge.defaultLayer,
+)
+
+const dagLayer = Layer.provideMerge(Dag.layer, testLayer)
+
+function node(id: string, dependsOn: string[] = []): NodeConfig {
+  return {
+    id,
+    name: id,
+    worker_type: "build",
+    depends_on: dependsOn,
+    required: true,
+    prompt_template: { inline: id },
+  }
+}
+
+// Structural validation fails BEFORE any event is published, so no
+// project/session FK rows are needed for the rejection paths.
+function createExpectingError(config: Partial<WorkflowConfig> & { nodes: NodeConfig[] }) {
+  return Effect.gen(function* () {
+    const dag = yield* Dag.Service
+    const error = yield* dag.create({
+      projectID: "project-1",
+      sessionID: "ses_create",
+      title: "create-validation",
+      config: { name: "create-validation", ...config },
+    }).pipe(Effect.catch((e: Error) => Effect.succeed(e)))
+    expect(error).toBeInstanceOf(Error)
+    return error as Error
+  })
+}
+
+function setupFKs() {
+  return Effect.gen(function* () {
+    const { db } = yield* Database.Service
+    yield* db.insert(ProjectTable).values({ id: Project.ID.global, worktree: AbsolutePath.make("/project"), sandboxes: [] }).run().pipe(Effect.orDie)
+    yield* db.insert(SessionTable).values({ id: "ses_create" as never, project_id: Project.ID.global, slug: "create", directory: "/project", title: "create", version: "test" }).run().pipe(Effect.orDie)
+  })
+}
+
+describe("Dag.create structural validation", () => {
+  it("rejects duplicate node ids instead of silently merging them", async () => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const error = yield* createExpectingError({ nodes: [node("a"), node("b"), node("a")] })
+        expect(error.message).toContain("duplicate node ids: a")
+      }).pipe(Effect.scoped, Effect.provide(dagLayer)) as Effect.Effect<never>,
+    )
+  })
+
+  it("rejects unknown depends_on references instead of silently dropping the edge", async () => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        // Pre-fix, buildGraph dropped the edge and a typo'd dependency turned
+        // the node into an immediately-runnable root.
+        const error = yield* createExpectingError({ nodes: [node("a"), node("b", ["ghost"])] })
+        expect(error.message).toContain('node "b" depends on unknown node "ghost"')
+      }).pipe(Effect.scoped, Effect.provide(dagLayer)) as Effect.Effect<never>,
+    )
+  })
+
+  it("enforces max_total_nodes at creation, not only on replan", async () => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const error = yield* createExpectingError({
+          max_total_nodes: 2,
+          nodes: [node("a"), node("b"), node("c")],
+        })
+        expect(error.message).toContain("Total node ceiling exceeded: 3 nodes > 2 max")
+      }).pipe(Effect.scoped, Effect.provide(dagLayer)) as Effect.Effect<never>,
+    )
+  })
+
+  it("rejects a condition referencing a node outside depends_on", async () => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        // Pre-fix, the condition would silently resolve to undefined at spawn
+        // time and evaluate false — a silent skip instead of a loud rejection.
+        const error = yield* createExpectingError({
+          nodes: [
+            node("gate"),
+            node("other"),
+            { ...node("impl", ["other"]), condition: 'gate.output.verdict == "ACCEPT"' },
+          ],
+        })
+        expect(error.message).toContain('node "impl" condition references "gate"')
+      }).pipe(Effect.scoped, Effect.provide(dagLayer)) as Effect.Effect<never>,
+    )
+  })
+
+  it("accepts a valid config (condition on a direct dependency)", async () => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* setupFKs()
+        const dag = yield* Dag.Service
+        const dagID = yield* dag.create({
+          projectID: Project.ID.global,
+          sessionID: "ses_create",
+          title: "create-validation",
+          config: {
+            name: "create-validation",
+            nodes: [node("gate"), { ...node("impl", ["gate"]), condition: 'gate.output.verdict == "ACCEPT"' }],
+          },
+        }).pipe(Effect.orDie)
+        expect(dagID.startsWith("dag")).toBe(true)
+      }).pipe(Effect.scoped, Effect.provide(dagLayer)) as Effect.Effect<never>,
+    )
+  })
+})

--- a/packages/opencode/test/dag/dag-loop-recovery-integration.test.ts
+++ b/packages/opencode/test/dag/dag-loop-recovery-integration.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test"
-import { DateTime, Effect, Layer } from "effect"
+import { DateTime, Effect, Layer, Option } from "effect"
 import { Database } from "@opencode-ai/core/database/database"
 import { DagProjector } from "@opencode-ai/core/dag/projector"
 import { DagStore } from "@opencode-ai/core/dag/store"
@@ -16,6 +16,7 @@ import { EventV2Bridge } from "@/event-v2-bridge"
 import { SessionPrompt } from "@/session/prompt"
 import { Session } from "@/session/session"
 import { SessionStatus } from "@/session/status"
+import { pollWithTimeout } from "../lib/effect"
 
 type ChildStatus = "active" | "completed" | "failed" | "unknown"
 
@@ -76,6 +77,7 @@ function recoveryLayer(input: {
     ),
     // Keep wake delivery pending so tests can inspect durable unreported rows.
     prompt: () => Effect.never,
+    promptIfIdle: () => Effect.succeed(Option.none()),
   })
   const loop = DagLoop.layer.pipe(
     Layer.provide(base),
@@ -274,7 +276,7 @@ describe("DagLoop crash recovery integration", () => {
     )
   })
 
-  it("cascades a required recovery failure through the standard workflow terminal path", async () => {
+  it("pauses on invented recovery failures and terminalizes only after explicit resume", async () => {
     await Effect.runPromise(
       runRecovery("active", ({ dag, database, loop, store }) =>
         Effect.gen(function* () {
@@ -285,9 +287,80 @@ describe("DagLoop crash recovery integration", () => {
 
           yield* loop.init()
 
+          // P2-2 recovery-pause: the ownership-lost failure is invented, so the
+          // workflow pauses instead of cascading skips — downstream stays
+          // pending (replannable), disposition belongs to the parent.
           expect((yield* store.getNode(dagID, "n1"))?.status).toBe("failed")
+          expect((yield* store.getNode(dagID, "n2"))?.status).toBe("pending")
+          expect((yield* store.getWorkflow(dagID))?.status).toBe("paused")
+
+          // Explicit resume accepts the failure semantics: the required-node
+          // failure terminalizes the workflow as FAILED (P2-1 attribution).
+          yield* dag.resume(dagID)
+          yield* pollWithTimeout(
+            Effect.gen(function* () {
+              const wf = yield* store.getWorkflow(dagID)
+              return wf?.status === "failed" ? wf : undefined
+            }),
+            "resumed workflow did not terminalize",
+          )
           expect((yield* store.getNode(dagID, "n2"))?.status).toBe("skipped")
-          expect((yield* store.getWorkflow(dagID))?.status).toBe("cancelled")
+        }),
+      ),
+    )
+  })
+
+  it("keeps downstream replannable after recovery-pause", async () => {
+    await Effect.runPromise(
+      runRecovery("active", ({ dag, database, loop, store }) =>
+        Effect.gen(function* () {
+          const dagID = yield* createRunningNode(dag, database, [
+            node(),
+            node({ id: "n2", name: "Node 2", depends_on: ["n1"] }),
+          ])
+
+          yield* loop.init()
+          expect((yield* store.getWorkflow(dagID))?.status).toBe("paused")
+
+          // The failed node is terminal-immutable, but its pending dependents
+          // are not — replan can rewire them onto a replacement node. Under the
+          // pre-P2-2 behavior n2 was already skipped (terminal) and the
+          // workflow already failed, so this exact replan was impossible.
+          yield* dag.replan(dagID, {
+            nodes: [
+              node({ id: "n1b", name: "Node 1 retry" }),
+              node({ id: "n2", name: "Node 2", depends_on: ["n1b"] }),
+            ],
+          })
+
+          expect((yield* store.getNode(dagID, "n1b"))?.status).toBe("pending")
+          expect((yield* store.getNode(dagID, "n2"))?.dependsOn).toEqual(["n1b"])
+          expect((yield* store.getWorkflow(dagID))?.status).toBe("paused")
+        }),
+      ),
+    )
+  })
+
+  it("terminalizes a fully-settled workflow on resume after recovery-pause", async () => {
+    await Effect.runPromise(
+      runRecovery("active", ({ dag, database, loop, store }) =>
+        Effect.gen(function* () {
+          const dagID = yield* createRunningNode(dag, database, [node()])
+
+          yield* loop.init()
+          expect((yield* store.getWorkflow(dagID))?.status).toBe("paused")
+
+          // Every node is already settled at resume time — the WorkflowResumed
+          // handler itself must re-run completion or the workflow would hang
+          // in running forever.
+          yield* dag.resume(dagID)
+          yield* pollWithTimeout(
+            Effect.gen(function* () {
+              const wf = yield* store.getWorkflow(dagID)
+              return wf?.status === "failed" ? wf : undefined
+            }),
+            "resumed settled workflow did not terminalize",
+          )
         }),
       ),
     )

--- a/packages/opencode/test/dag/dag-recovery.test.ts
+++ b/packages/opencode/test/dag/dag-recovery.test.ts
@@ -3,8 +3,7 @@ import { Effect, Layer } from "effect"
 import { reconcileWorkflow } from "@/dag/runtime/recovery"
 import { Dag } from "@/dag/dag"
 import type { DagStore } from "@opencode-ai/core/dag/store"
-import { WorkflowRuntime } from "@opencode-ai/core/dag/core/scheduling"
-import { SUCCESS_TERMINAL, toSchedulingNodes } from "@/dag/runtime/loop"
+import { WorkflowRuntime, toSchedulingNodes } from "@opencode-ai/core/dag/core/scheduling"
 import { makeNodeRow } from "./fixtures"
 
 type TrackedEvent = {
@@ -296,7 +295,9 @@ describe("rehydration via toSchedulingNodes", () => {
       ["completed", "satisfied"],
       ["failed", "unsatisfied"],
       ["aborted", "satisfied"],
-      ["skipped", "satisfied"],
+      // D13: skipped stays distinguishable from satisfied so pure-skip
+      // descendants cascade-skip after rehydration instead of running.
+      ["skipped", "skipped"],
     ])
   })
 

--- a/packages/opencode/test/dag/dag-runtime.test.ts
+++ b/packages/opencode/test/dag/dag-runtime.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test"
-import { evaluateCondition, resolveInputMapping } from "@/dag/runtime/eval"
+import { conditionReference, evaluateCondition, resolveInputMapping } from "@/dag/runtime/eval"
 import { planReplan } from "@opencode-ai/core/dag/core/replan"
 import { WorkflowRuntime, buildGraph } from "@opencode-ai/core/dag/core/scheduling"
 import { CycleError } from "@opencode-ai/core/dag/core/graph"
@@ -32,6 +32,21 @@ describe("evaluateCondition", () => {
 
   it("returns ok:true value:true when path resolves to undefined with != ", () => {
     expect(evaluateCondition('missing.path != "expected"', {})).toEqual({ ok: true, value: true })
+  })
+})
+
+describe("conditionReference", () => {
+  it("extracts the referenced nodeID from a parseable condition", () => {
+    expect(conditionReference('gate.output.verdict == "ACCEPT"')).toBe("gate")
+    expect(conditionReference("explore-src.output.count > 0")).toBe("explore-src")
+  })
+
+  it("returns null for empty or unparseable conditions (runtime fails those loudly)", () => {
+    expect(conditionReference(undefined)).toBeNull()
+    expect(conditionReference("")).toBeNull()
+    expect(conditionReference("   ")).toBeNull()
+    expect(conditionReference("analysis.output.verdict ==")).toBeNull()
+    expect(conditionReference("foo ??? bar")).toBeNull()
   })
 })
 

--- a/packages/opencode/test/dag/dag-step-semantics.test.ts
+++ b/packages/opencode/test/dag/dag-step-semantics.test.ts
@@ -62,10 +62,12 @@ describe("state machine: stepping status", () => {
     expect(getValidNextWorkflowStatuses(WorkflowStatus.RUNNING)).toContain(WorkflowStatus.STEPPING)
   })
 
-  it("stepping → running/paused/cancelled/failed/completed are valid", () => {
+  it("stepping → running/paused/stepping/cancelled/failed/completed are valid", () => {
     const valid = getValidNextWorkflowStatuses(WorkflowStatus.STEPPING)
     expect(valid).toContain(WorkflowStatus.RUNNING)
     expect(valid).toContain(WorkflowStatus.PAUSED)
+    // Consecutive single-step: each step command re-enters stepping.
+    expect(valid).toContain(WorkflowStatus.STEPPING)
     expect(valid).toContain(WorkflowStatus.CANCELLED)
     expect(valid).toContain(WorkflowStatus.FAILED)
     expect(valid).toContain(WorkflowStatus.COMPLETED)
@@ -175,6 +177,33 @@ describe("Dag.Service.step", () => {
         )
         expect(error).toBeInstanceOf(Error)
         expect((error as Error).message).toContain("in-flight")
+      }).pipe(Effect.scoped, Effect.provide(dagLayer)) as Effect.Effect<never>,
+    )
+  })
+
+  it("consecutive steps advance one node at a time (stepping → stepping)", async () => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* setupFKs()
+        yield* createRunningWorkflow(["b", "a"])
+        const dag = yield* Dag.Service
+        const events = yield* EventV2.Service
+
+        const first = yield* dag.step(dagID).pipe(Effect.orDie)
+        expect(first).toEqual({ status: "stepping", nodeID: "a" })
+
+        // Settle the stepped node so no node is in-flight for the next step.
+        yield* events.publish(DagEvent.NodeStarted, { dagID, nodeID: "a" as never, childSessionID: "ses_child_a" as never, timestamp: ts(3) })
+        yield* events.publish(DagEvent.NodeCompleted, { dagID, nodeID: "a" as never, output: "done", durationMs: 0 as never, timestamp: ts(4) })
+
+        // The workflow is still "stepping" — a second step must re-enter
+        // stepping and select the next node instead of dying on an
+        // InvalidTransitionError(stepping → stepping).
+        const second = yield* dag.step(dagID).pipe(Effect.orDie)
+        expect(second).toEqual({ status: "stepping", nodeID: "b" })
+
+        const store = yield* DagStore.Service
+        expect((yield* store.getWorkflow(dagID))?.status).toBe("stepping")
       }).pipe(Effect.scoped, Effect.provide(dagLayer)) as Effect.Effect<never>,
     )
   })

--- a/packages/opencode/test/dag/dag-wake-integration.test.ts
+++ b/packages/opencode/test/dag/dag-wake-integration.test.ts
@@ -819,9 +819,12 @@ describe("DagLoop atomic wake integration", () => {
             expect(
               (yield* store.getNode("dag_recovered_conditional", "conditional"))?.status,
             ).toBe("skipped")
-            expect(
-              (yield* store.getNode("dag_recovered_conditional", "after-conditional"))?.status,
-            ).toBe("completed")
+            // D13: after-conditional depends only on the skipped conditional
+            // node, so it cascade-skips instead of running on a placeholder
+            // input — the gate rejection blocks the whole downstream subtree.
+            const afterConditional = yield* store.getNode("dag_recovered_conditional", "after-conditional")
+            expect(afterConditional?.status).toBe("skipped")
+            expect(afterConditional?.errorReason).toBe("orphan_cascade")
             expect(promptText(parent.input)).toContain(
               'Node "quality-gate" completed: REJECT',
             )
@@ -936,6 +939,63 @@ describe("DagLoop atomic wake integration", () => {
 
           expect((yield* store.getWorkflow(dagID))?.status).toBe("stepping")
           expect((yield* store.getNode(dagID, "after"))?.status).toBe("pending")
+        }),
+      ),
+    )
+  })
+
+  it("cascade-skips the whole downstream subtree when a condition gate rejects", async () => {
+    await Effect.runPromise(
+      runWakeTest(({ dag, store, childPrompts, parentPrompts }) =>
+        Effect.gen(function* () {
+          const dagID = yield* dag.create({
+            projectID: "project-1",
+            sessionID: "ses_parent",
+            title: "Gated pipeline",
+            config: {
+              name: "gated-pipeline",
+              nodes: [
+                node("quality-gate"),
+                {
+                  ...node("implement", ["quality-gate"]),
+                  report_to_parent: false,
+                  condition: 'quality-gate.output.verdict == "ACCEPT"',
+                },
+                { ...node("integrate", ["implement"]), report_to_parent: false },
+                { ...node("final-audit", ["integrate"]), report_to_parent: false },
+              ],
+            },
+          })
+
+          const gate = yield* takeWithin(childPrompts, "quality-gate did not start")
+          yield* Deferred.succeed(gate.release, "REJECT")
+
+          // D13 regression: the gate rejection must terminalize the whole
+          // subtree without executing it — implement skips on condition_false
+          // and integrate / final-audit cascade-skip because their only
+          // dependency is skipped. Pre-fix, skip ≡ satisfied ran the full
+          // chain and the audit "passed" a rejected gate.
+          yield* pollWithTimeout(
+            store.getWorkflow(dagID).pipe(
+              Effect.map((workflow) => workflow?.status === "completed" ? workflow : undefined),
+            ),
+            "gated workflow did not complete after the gate rejection",
+          )
+          const implement = yield* store.getNode(dagID, "implement")
+          expect(implement?.status).toBe("skipped")
+          expect(implement?.errorReason).toBe("condition_false")
+          const integrate = yield* store.getNode(dagID, "integrate")
+          expect(integrate?.status).toBe("skipped")
+          expect(integrate?.errorReason).toBe("orphan_cascade")
+          const audit = yield* store.getNode(dagID, "final-audit")
+          expect(audit?.status).toBe("skipped")
+          expect(audit?.errorReason).toBe("orphan_cascade")
+          // No downstream child session was ever spawned.
+          expect(Option.isNone(yield* Queue.poll(childPrompts))).toBe(true)
+
+          const parent = yield* takeWithin(parentPrompts, "gate wake did not reach the parent")
+          expect(promptText(parent.input)).toContain('Node "quality-gate" completed: REJECT')
+          yield* Deferred.succeed(parent.release, "success")
         }),
       ),
     )

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -1791,6 +1791,46 @@ it.instance("interrupting idle-only admission releases the reserved runner", () 
   }),
 )
 
+it.instance("idle-only prompt resolves only after the full provider turn completes", () =>
+  Effect.gen(function* () {
+    const { llm } = yield* useServerConfig(providerCfg)
+    const prompt = yield* SessionPrompt.Service
+    const sessions = yield* Session.Service
+    const chat = yield* sessions.create({ title: "Pinned" })
+    let releaseTurn: (value: unknown) => void = () => {}
+    yield* llm.hold("wake handled", new Promise((resolve) => {
+      releaseTurn = resolve
+    }))
+
+    const wake = yield* prompt
+      .promptIfIdle({
+        sessionID: chat.id,
+        agent: "build",
+        model: ref,
+        parts: [{ type: "text", text: "synthetic DAG wake", synthetic: true }],
+      })
+      .pipe(Effect.forkChild({ startImmediately: true }))
+    yield* awaitWithTimeout(llm.wait(1), "idle-only prompt did not reach the provider")
+
+    // The DAG orchestrator-unresponsive net (DagLoop.tryDeliverWake) re-reads
+    // the wake batch as soon as promptIfIdle resolves and fails the workflow
+    // if it still looks stalled. That judgement is only sound while
+    // promptIfIdle waits for the FULL provider turn (runLoop) — resolving
+    // after admission alone would create a mis-kill window. Pin the contract.
+    const early = yield* Fiber.join(wake).pipe(
+      Effect.timeoutOrElse({ duration: "250 millis", orElse: () => Effect.succeed("still-running" as const) }),
+    )
+    expect(early).toBe("still-running")
+
+    releaseTurn(undefined)
+    const result = yield* awaitWithTimeout(
+      Fiber.join(wake),
+      "idle-only prompt did not resolve after turn completion",
+    )
+    expect(result._tag).toBe("Some")
+  }),
+)
+
 it.instance("prompt submitted during an active run is included in the next LLM input", () =>
   Effect.gen(function* () {
     const { llm } = yield* useServerConfig(providerCfg)


### PR DESCRIPTION
# fix(dag): scheduling semantics, validation, and recovery-pause

## 摘要

DAG 引擎正确性批次修复（审计文档 `docs/dag-bug-condition-skip-as-satisfied.md` 的 P0-1 / P0-3 / P1-1 / P1-5 / P2-1 / P2-2 / P2-3 / P2-4 / P2-5 / P2-6 / P2-10），以及配套文档与契约测试。

## 关键变更

### 调度语义（P0-1 核心）
- `skipped` 成为独立调度态，不再折叠进 `satisfied`：三处合流点（NodeSkipped 事件处理器 / `toSchedulingNodes` / `Dag.step` 内联映射）统一收敛到 core 的单一映射。
- 纯 skip 依赖的下游按波级联跳过（`orphan_cascade`，持久事件、崩溃可恢复）；混合 fan-in 保留降级语义。级联尊重 pause / stepMode。

### 崩溃恢复（P2-2 recovery-pause）
- 恢复"发明"的失败（ownership lost / 无子会话 / deadline 离线到期）不再放任级联 skip + 焊死终态：工作流转 `paused`，下游保持 `pending`（可 replan 改线），处置权交还父 agent（replan+resume / resume / cancel）。铁律无损：恢复永不隐式重跑 provider 工作。
- 配套修复 `WorkflowResumed` 处理器缺 `checkCompletion` 导致的全终态 resume 永久悬挂。

### 其余
- P2-1：required 失败终态改 `failed`（归因节点 id），`cancelled` 保留给显式取消。
- P1-1/P2-6：create/replan fail-fast 校验（重复 id / dangling deps / condition 引用 / max_total_nodes）。
- P0-3：`stepping` 状态迁移合法化，连续 step 不再死路。
- P2-4：violation 死读面清理；P2-5：inline 模板去临时文件 I/O；P2-10：pause 语义文案。
- P2-3：promptIfIdle 完整 turn 契约经源码实证关闭，回归防护落在 `test/session/prompt.test.ts`。
- 文档：审计清单状态更新；`dag-orchestration-constraints.md` 按修复后语义重写；`workflow.md` 新增崩溃恢复处置指引。

## 验证

- typecheck（tsgo --noEmit）：core / opencode 全绿
- `packages/opencode`：`bun test test/dag/ test/session/prompt.test.ts` → 289 pass / 1 skip / 0 fail
- `packages/core`：1122 pass / 1 fail（`Watcher > publishes .git/HEAD events`，已在干净基线实证为既有环境失败，与本 PR 无关）
