### PR TITLE
fix(tui): align DAG surfaces with native opencode style

### DIFF
--- a/packages/tui/src/config/keybind.ts
+++ b/packages/tui/src/config/keybind.ts
@@ -83,6 +83,7 @@ export const Definitions = {
   dag_previous_workflow: keybind("h,left", "Select previous DAG workflow"),
   dag_pause: keybind("p", "Pause selected DAG workflow"),
   dag_resume: keybind("r", "Resume selected DAG workflow"),
+  dag_step: keybind("s", "Step selected DAG workflow (run one node)"),
   dag_cancel: keybind("x", "Cancel selected DAG workflow"),
 
   editor_open: keybind("<leader>e", "Open external editor"),
@@ -301,6 +302,7 @@ export const CommandMap = {
   dag_previous_workflow: "dag.previous_workflow",
   dag_pause: "dag.pause",
   dag_resume: "dag.resume",
+  dag_step: "dag.step",
   dag_cancel: "dag.cancel",
   editor_open: "prompt.editor",
   theme_list: "theme.switch",

--- a/packages/tui/src/feature-plugins/sidebar/dag-panel.tsx
+++ b/packages/tui/src/feature-plugins/sidebar/dag-panel.tsx
@@ -4,21 +4,12 @@ import type { DagNode, DagWorkflowSummary } from "@opencode-ai/sdk/v2"
 import type { BuiltinTuiPlugin } from "../builtins"
 import { createEffect, createMemo, createSignal, For, Show } from "solid-js"
 import { Spinner } from "../../component/spinner"
+import { dagNodeGlyph, dagStatusColor } from "../system/dag-inspector-utils"
 
 const id = "internal:sidebar-dag-panel"
 
 const ACTIVE_STATUSES = new Set(["running", "paused", "stepping"])
 const TERMINAL_STATUSES = new Set(["completed", "failed", "cancelled"])
-
-function statusColor(theme: TuiPluginApi["theme"]["current"], status: string) {
-  if (status === "completed") return theme.success
-  if (status === "failed") return theme.error
-  if (status === "cancelled") return theme.textMuted
-  if (status === "running") return theme.textMuted
-  if (status === "paused") return theme.warning
-  if (status === "stepping") return theme.warning
-  return theme.textMuted
-}
 
 function WorkflowRow(props: {
   api: TuiPluginApi
@@ -61,27 +52,19 @@ function WorkflowRow(props: {
     void fetchNodes(props.summary.id, sig)
   })
 
-  const bar = () => {
-    const width = 6
-    const t = total()
-    if (t <= 0) return ""
-    const filled = Math.round((completed() / t) * width)
-    return "▓".repeat(filled) + "░".repeat(width - filled)
-  }
-
   return (
     <box flexDirection="column">
       <box flexDirection="row" gap={1} onMouseDown={props.onToggle}>
-        <text flexShrink={0} style={{ fg: statusColor(theme(), props.summary.status) }}>
-          {props.expanded ? "▼" : "▶"}
+        <text flexShrink={0} style={{ fg: dagStatusColor(theme(), props.summary.status) }}>
+          •
         </text>
-        <text fg={theme().text} wrapMode="char">
-          {props.summary.title}
-        </text>
-        <text flexShrink={0} fg={theme().textMuted}>
-          {bar()} {completed()}/{total()}
-          {running() > 0 ? ` ▶${running()}` : ""}
-          {failed() > 0 ? ` ✗${failed()}` : ""}
+        <text fg={theme().text} wrapMode="word">
+          {props.summary.title}{" "}
+          <span style={{ fg: theme().textMuted }}>
+            ({completed()}/{total()}
+            {running() > 0 ? `, ${running()} running` : ""}
+            {failed() > 0 ? `, ${failed()} failed` : ""})
+          </span>
         </text>
       </box>
       <Show when={props.expanded}>
@@ -89,21 +72,12 @@ function WorkflowRow(props: {
           <For each={nodes()}>
             {(node) => (
               <box flexDirection="row" gap={1}>
-                <Show
-                  when={node.status !== "running"}
-                  fallback={<Spinner color={theme().textMuted} />}
-                >
-                  <text flexShrink={0} style={{ fg: statusColor(theme(), node.status) }}>
-                    {node.status === "completed"
-                      ? "✓"
-                      : node.status === "failed"
-                        ? "✗"
-                        : node.status === "skipped" || node.status === "cancelled"
-                          ? "⊘"
-                          : "○"}
+                <Show when={node.status !== "running"} fallback={<Spinner color={theme().textMuted} />}>
+                  <text flexShrink={0} style={{ fg: dagStatusColor(theme(), node.status) }}>
+                    {dagNodeGlyph(node.status)}
                   </text>
                 </Show>
-                <text fg={theme().text} wrapMode="char">
+                <text fg={theme().textMuted} wrapMode="word">
                   {node.name}
                 </text>
               </box>
@@ -116,6 +90,7 @@ function WorkflowRow(props: {
 }
 
 function DagPanel(props: { api: TuiPluginApi; session_id: string }) {
+  const [open, setOpen] = createSignal(true)
   const theme = () => props.api.theme.current
   const dags = createMemo(() => props.api.state.session.dag(props.session_id))
   const active = createMemo(() => dags().filter((d) => ACTIVE_STATUSES.has(d.status)))
@@ -146,29 +121,40 @@ function DagPanel(props: { api: TuiPluginApi; session_id: string }) {
 
   return (
     <Show when={dags().length > 0}>
-      <box flexDirection="column" gap={1}>
-        <text fg={theme().text}>
-          <b>DAG</b>
-        </text>
-        <For each={active()}>
-          {(summary) => (
-            <WorkflowRow
-              api={props.api}
-              summary={summary}
-              expanded={isExpanded(summary.id)}
-              onToggle={() => toggle(summary.id)}
-            />
-          )}
-        </For>
-        <Show when={terminal().length > 0}>
-          <box flexDirection="column">
-            <box flexDirection="row" gap={1} onMouseDown={() => setShowTerminal((x) => !x)}>
-              <text fg={theme().textMuted}>
-                {showTerminal() ? "▼" : "▶"} done ({terminal().length})
-              </text>
-            </box>
-            <Show when={showTerminal()}>
-              <box flexDirection="column" paddingLeft={1}>
+      <box>
+        <box flexDirection="row" gap={1} onMouseDown={() => dags().length > 2 && setOpen((x) => !x)}>
+          <Show when={dags().length > 2}>
+            <text fg={theme().text}>{open() ? "▼" : "▶"}</text>
+          </Show>
+          <text fg={theme().text}>
+            <b>DAG</b>
+            <Show when={!open() && dags().length > 2}>
+              <span style={{ fg: theme().textMuted }}>
+                {" "}
+                ({active().length} active{terminal().length > 0 ? `, ${terminal().length} done` : ""})
+              </span>
+            </Show>
+          </text>
+        </box>
+        <Show when={dags().length <= 2 || open()}>
+          <For each={active()}>
+            {(summary) => (
+              <WorkflowRow
+                api={props.api}
+                summary={summary}
+                expanded={isExpanded(summary.id)}
+                onToggle={() => toggle(summary.id)}
+              />
+            )}
+          </For>
+          <Show when={terminal().length > 0}>
+            <box flexDirection="column">
+              <box flexDirection="row" gap={1} onMouseDown={() => setShowTerminal((x) => !x)}>
+                <text fg={theme().textMuted}>
+                  {showTerminal() ? "▼" : "▶"} done ({terminal().length})
+                </text>
+              </box>
+              <Show when={showTerminal()}>
                 <For each={terminal()}>
                   {(summary) => (
                     <WorkflowRow
@@ -179,9 +165,9 @@ function DagPanel(props: { api: TuiPluginApi; session_id: string }) {
                     />
                   )}
                 </For>
-              </box>
-            </Show>
-          </box>
+              </Show>
+            </box>
+          </Show>
         </Show>
       </box>
     </Show>

--- a/packages/tui/src/feature-plugins/sidebar/dag.tsx
+++ b/packages/tui/src/feature-plugins/sidebar/dag.tsx
@@ -1,67 +1,44 @@
 /** @jsxImportSource @opentui/solid */
 import type { TuiPlugin, TuiPluginApi } from "@opencode-ai/plugin/tui"
 import type { BuiltinTuiPlugin } from "../builtins"
-import { createMemo, For, Show, createSignal } from "solid-js"
+import { createMemo, Show } from "solid-js"
+import { dagStatusColor } from "../system/dag-inspector-utils"
 
 const id = "internal:sidebar-dag"
 
+/**
+ * Compact one-line indicator next to the prompt: presence + aggregate counts
+ * only. Node-level detail lives in the sidebar panel and the DAG inspector.
+ */
 function DagIndicator(props: { api: TuiPluginApi; session_id: string }) {
-  const [open, setOpen] = createSignal(true)
   const theme = () => props.api.theme.current
   const dags = createMemo(() => props.api.state.session.dag(props.session_id))
-  const active = createMemo(() => dags().filter((d) => d.status === "running" || d.status === "paused" || d.status === "stepping"))
+  const active = createMemo(() =>
+    dags().filter((d) => d.status === "running" || d.status === "paused" || d.status === "stepping"),
+  )
+  const attention = createMemo(() => active().filter((d) => d.status === "paused" || d.status === "stepping"))
 
-  const statusColor = (status: string) => {
-    if (status === "completed") return theme().success
-    if (status === "failed") return theme().error
-    if (status === "cancelled") return theme().textMuted
-    if (status === "running") return theme().textMuted
-    if (status === "paused") return theme().warning
-    if (status === "stepping") return theme().warning
-    return theme().textMuted
-  }
+  const label = createMemo(() => {
+    const running = active().length - attention().length
+    const parts = [
+      ...(running > 0 ? [`${running} running`] : []),
+      ...(attention().length > 0 ? [`${attention().length} paused`] : []),
+    ]
+    return parts.join(", ")
+  })
 
   return (
     <Show when={active().length > 0}>
-      <box>
-        <box flexDirection="row" gap={1} onMouseDown={() => active().length > 2 && setOpen((x) => !x)}>
-          <Show when={active().length > 2}>
-            <text fg={theme().text}>{open() ? "▼" : "▶"}</text>
-          </Show>
-          <text fg={theme().text}>
-            <b>DAG System</b>
-            <Show when={!open() || active().length <= 2}>
-              <span style={{ fg: theme().textMuted }}>
-                {" "}
-                ({active().length} workflow{active().length > 1 ? "s" : ""})
-              </span>
-            </Show>
-          </text>
-        </box>
-        <Show when={active().length <= 2 || open()}>
-          <For each={active()}>
-            {(dag) => (
-              <box flexDirection="row" gap={1}>
-                <text
-                  flexShrink={0}
-                  style={{
-                    fg: statusColor(dag.status),
-                  }}
-                >
-                  •
-                </text>
-                <text fg={theme().text} wrapMode="word">
-                  {dag.title}{" "}
-                  <span style={{ fg: theme().textMuted }}>
-                    ({Number(dag.completedNodes)}/{Number(dag.nodeCount)}
-                    {Number(dag.runningNodes) > 0 ? `, ${Number(dag.runningNodes)} running` : ""}
-                    {Number(dag.failedNodes) > 0 ? `, ${Number(dag.failedNodes)} failed` : ""})
-                  </span>
-                </text>
-              </box>
-            )}
-          </For>
-        </Show>
+      <box flexDirection="row" gap={1}>
+        <text
+          flexShrink={0}
+          style={{ fg: dagStatusColor(theme(), attention().length > 0 ? "paused" : "running") }}
+        >
+          •
+        </text>
+        <text fg={theme().text} wrapMode="none">
+          DAG <span style={{ fg: theme().textMuted }}>({label()})</span>
+        </text>
       </box>
     </Show>
   )

--- a/packages/tui/src/feature-plugins/system/dag-inspector-utils.ts
+++ b/packages/tui/src/feature-plugins/system/dag-inspector-utils.ts
@@ -42,13 +42,79 @@ export function computeWaves(nodes: readonly DagNode[]): DagNode[][] {
   return result
 }
 
+/**
+ * Visual row index of a node inside the rendered wave list, counting one row
+ * per wave header and one row per node. Used to scroll the selected node into
+ * view — valid only while every node renders as a single row.
+ */
+export function computeNodeRowIndex(layers: readonly (readonly DagNode[])[], nodeID: string): number | undefined {
+  let row = 0
+  for (const layer of layers) {
+    row++ // wave header
+    for (const node of layer) {
+      if (node.id === nodeID) return row
+      row++
+    }
+  }
+  return undefined
+}
+
 export function formatDagError(error: string) {
   return error
     .replace(/^Cause\(\[Die\((.*)\)\]\)$/, "$1")
     .replace(/^ProviderModelNotFoundError:\s*/, "")
 }
 
-export type DagControlOperation = "pause" | "resume" | "cancel"
+/** Compact "3m 12s" duration between two epoch-millis timestamps. The SDK
+ * serializes numbers with Infinity/NaN sentinels — non-finite inputs yield
+ * no duration. */
+export function formatDagDuration(startedAt: number | string | undefined, completedAt: number | string | undefined): string | undefined {
+  if (typeof startedAt !== "number" || !Number.isFinite(startedAt)) return undefined
+  const end = typeof completedAt === "number" && Number.isFinite(completedAt) ? completedAt : Date.now()
+  const totalSeconds = Math.max(0, Math.round((end - startedAt) / 1000))
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+  if (minutes === 0) return `${seconds}s`
+  return `${minutes}m ${seconds}s`
+}
+
+/** Single-line preview of a node's output for the detail pane. */
+export function formatDagOutputPreview(output: unknown, maxLength = 200): string | undefined {
+  if (output === undefined || output === null) return undefined
+  const text = typeof output === "string" ? output : JSON.stringify(output)
+  const flat = text.replace(/\s+/g, " ").trim()
+  if (flat === "") return undefined
+  return flat.length > maxLength ? `${flat.slice(0, maxLength)}…` : flat
+}
+
+/**
+ * Shared status→color mapping for every DAG surface (sidebar indicator,
+ * sidebar panel, inspector) so one status never renders in different colors
+ * across views. Accepts both workflow and node statuses. Generic over the
+ * theme's color type (RGBA at runtime).
+ */
+export function dagStatusColor<Color>(
+  theme: { success: Color; error: Color; warning: Color; text: Color; textMuted: Color },
+  status: string,
+): Color {
+  if (status === "completed") return theme.success
+  if (status === "failed") return theme.error
+  if (status === "paused" || status === "stepping") return theme.warning
+  if (status === "running") return theme.textMuted
+  if (status === "pending" || status === "queued") return theme.textMuted
+  if (status === "skipped" || status === "cancelled" || status === "aborted") return theme.textMuted
+  return theme.text
+}
+
+/** Status glyph for node rows — mirrors the todo-item ✓ vocabulary. */
+export function dagNodeGlyph(status: string): string {
+  if (status === "completed") return "✓"
+  if (status === "failed") return "✗"
+  if (status === "skipped" || status === "cancelled" || status === "aborted") return "⊘"
+  return "○"
+}
+
+export type DagControlOperation = "pause" | "resume" | "cancel" | "step"
 
 export function dagControlUnavailableMessage(status: string | undefined, operation: DagControlOperation) {
   const allowed =
@@ -56,14 +122,18 @@ export function dagControlUnavailableMessage(status: string | undefined, operati
       ? status === "running" || status === "stepping"
       : operation === "resume"
         ? status === "paused" || status === "stepping"
-        : status === "running" || status === "stepping" || status === "paused"
+        : operation === "step"
+          ? status === "running" || status === "stepping"
+          : status === "running" || status === "stepping" || status === "paused"
   if (allowed) return undefined
-  const action = operation === "pause" ? "paused" : operation === "resume" ? "resumed" : "cancelled"
+  const action =
+    operation === "pause" ? "paused" : operation === "resume" ? "resumed" : operation === "step" ? "stepped" : "cancelled"
   return `Workflow is ${status ?? "unavailable"} and cannot be ${action}`
 }
 
 export function dagControlProgressMessage(operation: DagControlOperation) {
   if (operation === "pause") return "Pausing workflow..."
   if (operation === "resume") return "Resuming workflow..."
+  if (operation === "step") return "Stepping workflow..."
   return "Cancelling workflow..."
 }

--- a/packages/tui/src/feature-plugins/system/dag-inspector.tsx
+++ b/packages/tui/src/feature-plugins/system/dag-inspector.tsx
@@ -1,15 +1,21 @@
 /** @jsxImportSource @opentui/solid */
 import type { TuiPlugin, TuiPluginApi } from "@opencode-ai/plugin/tui"
 import type { BuiltinTuiPlugin } from "../builtins"
-import { createMemo, For, Show, createSignal, createEffect, onCleanup } from "solid-js"
+import type { ScrollBoxRenderable } from "@opentui/core"
+import { createMemo, For, Show, Switch, Match, createSignal, createEffect, onCleanup } from "solid-js"
 import { Spinner } from "../../component/spinner"
-import { TextAttributes } from "@opentui/core"
 import { useBindings, useCommandShortcut } from "../../keymap"
+import { Panel, PanelGroup, Separator } from "./diff-viewer-ui"
 import {
+  computeNodeRowIndex,
   computeWaves,
   dagControlProgressMessage,
   dagControlUnavailableMessage,
+  dagNodeGlyph,
+  dagStatusColor,
+  formatDagDuration,
   formatDagError,
+  formatDagOutputPreview,
   type DagControlOperation,
   type DagNode,
 } from "./dag-inspector-utils"
@@ -17,6 +23,18 @@ import type { DagWorkflowSummary } from "@opencode-ai/sdk/v2"
 
 const id = "internal:system-dag-inspector"
 const ROUTE = "dag"
+const WORKFLOW_LIST_WIDTH = 32
+
+function scrollRowIntoView(scroll: ScrollBoxRenderable | undefined, index: number) {
+  if (!scroll) return
+  if (index < scroll.scrollTop) {
+    scroll.scrollTo(index)
+    return
+  }
+  if (index >= scroll.scrollTop + scroll.viewport.height) {
+    scroll.scrollTo(index - scroll.viewport.height + 1)
+  }
+}
 
 function DagInspector(props: { api: TuiPluginApi }) {
   const theme = () => props.api.theme.current
@@ -31,6 +49,8 @@ function DagInspector(props: { api: TuiPluginApi }) {
   const [fetchedWorkflows, setFetchedWorkflows] = createSignal<ReadonlyArray<DagWorkflowSummary> | undefined>()
   const [workflowLoad, setWorkflowLoad] = createSignal<"loading" | "loaded" | "error">("loading")
   const [actionMessage, setActionMessage] = createSignal<string | undefined>()
+  let workflowScroll: ScrollBoxRenderable | undefined
+  let nodeScroll: ScrollBoxRenderable | undefined
 
   const workflows = createMemo(() => {
     const sid = params()?.sessionID
@@ -140,6 +160,28 @@ function DagInspector(props: { api: TuiPluginApi }) {
     const sel = selectedNode()
     if (sel && ns.some((n) => n.id === sel)) return
     setSelectedNode(ns[0]?.id)
+  })
+
+  // Keep the selected workflow visible in the (unsliced) scrollable list.
+  createEffect(() => {
+    const sel = selectedWorkflow()
+    if (!sel) return
+    const index = workflows().findIndex((w) => w.id === sel)
+    if (index === -1) return
+    const scrollSelected = () => scrollRowIntoView(workflowScroll, index)
+    scrollSelected()
+    requestAnimationFrame(scrollSelected)
+  })
+
+  // Keep the selected node visible inside the wave list.
+  createEffect(() => {
+    const sel = selectedNode()
+    if (!sel) return
+    const row = computeNodeRowIndex(layers(), sel)
+    if (row === undefined) return
+    const scrollSelected = () => scrollRowIntoView(nodeScroll, row)
+    scrollSelected()
+    requestAnimationFrame(scrollSelected)
   })
 
   const moveNode = (delta: number) => {
@@ -270,6 +312,14 @@ function DagInspector(props: { api: TuiPluginApi }) {
       },
     },
     {
+      name: "dag.step",
+      title: "Step selected workflow (run one node)",
+      category: "Workflow",
+      run() {
+        control("step")
+      },
+    },
+    {
       name: "dag.cancel",
       title: "Cancel selected workflow",
       category: "Workflow",
@@ -289,232 +339,252 @@ function DagInspector(props: { api: TuiPluginApi }) {
 
   const closeShortcut = useCommandShortcut("dag.close")
   const enterShortcut = useCommandShortcut("dag.enter")
+  const pauseShortcut = useCommandShortcut("dag.pause")
+  const resumeShortcut = useCommandShortcut("dag.resume")
+  const stepShortcut = useCommandShortcut("dag.step")
+  const cancelShortcut = useCommandShortcut("dag.cancel")
 
   const selectedWorkflowSummary = createMemo(() => workflows().find((workflow) => workflow.id === selectedWorkflow()))
+  const selectedNodeDetail = createMemo(() => orderedNodes().find((node) => node.id === selectedNode()))
 
-  const statusColor = (status: string) => {
-    if (status === "completed") return theme().success
-    if (status === "failed") return theme().error
-    if (status === "running") return theme().textMuted
-    if (status === "pending" || status === "queued") return theme().textMuted
-    if (status === "skipped" || status === "cancelled") return theme().textMuted
-    return theme().text
-  }
+  const statusColor = (status: string) => dagStatusColor(theme(), status)
 
   return (
-    <box flexDirection="column" width="100%" height="100%" padding={1} gap={1}>
-      <box
-        flexDirection="row"
-        width="100%"
-        flexShrink={0}
-        justifyContent="space-between"
-        border={["bottom"]}
-        borderColor={theme().borderSubtle}
-      >
-        <box flexDirection="column" paddingBottom={1}>
-          <text fg={theme().text} attributes={TextAttributes.BOLD}>
-            DAG Inspector
+    <box width="100%" height="100%">
+      <PanelGroup axis="y" width="100%" height="100%">
+        <Panel border="none" flexShrink={0} padding={0} paddingLeft={1}>
+          <text fg={theme().text}>DAG </text>
+          <text fg={theme().textMuted}>{selectedWorkflowSummary()?.title ?? "workflow inspector"}</text>
+          <box flexGrow={1} />
+          <text fg={theme().textMuted}>
+            {workflows().length} {workflows().length === 1 ? "workflow" : "workflows"}
           </text>
-          <text fg={theme().textMuted}>Workflow execution overview</text>
-        </box>
-        <text fg={theme().textMuted}>
-          {workflows().length} {workflows().length === 1 ? "workflow" : "workflows"}
-        </text>
-      </box>
+        </Panel>
 
-      <box flexDirection="row" width="100%" flexGrow={1} minHeight={0} gap={1}>
-        {/* Left column: workflow list */}
-        <box width="25.5%" minWidth={20} border={["right"]} borderColor={theme().borderSubtle}>
-          <box flexDirection="column" width="100%" paddingRight={1} gap={1}>
-            <box flexDirection="row" width="100%" justifyContent="space-between">
-              <text fg={theme().text} attributes={TextAttributes.BOLD}>
-                Workflows
-              </text>
-              <text fg={theme().textMuted}>{workflows().length}</text>
-            </box>
-            <Show when={workflowLoad() === "loading"}>
-              <text fg={theme().textMuted}>Loading...</text>
-            </Show>
-            <Show when={workflowLoad() !== "loading" && workflows().length === 0}>
-              <text fg={theme().textMuted}>No workflows</text>
-            </Show>
-            <For each={workflows().slice(0, 10)}>
-              {(wf) => (
-                <box
-                  flexDirection="column"
-                  width="100%"
-                  paddingLeft={1}
-                  paddingRight={1}
-                  onMouseUp={() => setSelectedWorkflow(wf.id)}
-                  style={{ backgroundColor: selectedWorkflow() === wf.id ? theme().backgroundMenu : undefined }}
-                >
-                  <box flexDirection="row" width="100%" gap={1}>
-                    <text fg={selectedWorkflow() === wf.id ? theme().accent : theme().textMuted} flexShrink={0}>
-                      {selectedWorkflow() === wf.id ? "›" : " "}
-                    </text>
-                    <text
-                      flexShrink={0}
-                      style={{
-                        fg: statusColor(wf.status),
+        <box flexGrow={1} minHeight={0}>
+          <Switch>
+            <Match when={workflowLoad() === "loading" && workflows().length === 0}>
+              <Separator axis="x" />
+              <box flexGrow={1} paddingLeft={1}>
+                <text fg={theme().textMuted}>Loading workflows...</text>
+              </box>
+            </Match>
+            <Match when={workflowLoad() === "error" && workflows().length === 0}>
+              <Separator axis="x" />
+              <box flexGrow={1} paddingLeft={1}>
+                <text fg={theme().error}>Unable to load workflows</text>
+              </box>
+            </Match>
+            <Match when={workflows().length === 0}>
+              <Separator axis="x" />
+              <box flexGrow={1} paddingLeft={1}>
+                <text fg={theme().textMuted}>No workflows for this session</text>
+              </box>
+            </Match>
+            <Match when={workflows().length > 0}>
+              <PanelGroup axis="x">
+                <Panel border="both" width={WORKFLOW_LIST_WIDTH}>
+                  <scrollbox
+                    ref={(element: ScrollBoxRenderable) => (workflowScroll = element)}
+                    verticalScrollbarOptions={{ visible: false }}
+                    horizontalScrollbarOptions={{ visible: false }}
+                  >
+                    <For each={workflows()}>
+                      {(wf) => {
+                        const selected = () => selectedWorkflow() === wf.id
+                        return (
+                          <box
+                            flexDirection="row"
+                            gap={1}
+                            width="100%"
+                            backgroundColor={selected() ? theme().primary : undefined}
+                            onMouseUp={() => setSelectedWorkflow(wf.id)}
+                          >
+                            <text fg={selected() ? theme().background : statusColor(wf.status)} flexShrink={0}>
+                              •
+                            </text>
+                            <box flexGrow={1} minWidth={0}>
+                              <text fg={selected() ? theme().background : theme().text} wrapMode="none">
+                                {wf.title}
+                              </text>
+                            </box>
+                            <text fg={selected() ? theme().background : theme().textMuted} flexShrink={0}>
+                              {Number(wf.completedNodes)}/{Number(wf.nodeCount)}
+                            </text>
+                          </box>
+                        )
                       }}
-                    >
+                    </For>
+                  </scrollbox>
+                </Panel>
+
+                <Panel flexGrow={1} minHeight={0} border="none">
+                  <Separator axis="x" start="edge-out" />
+                  <box flexDirection="row" gap={1} paddingLeft={1} flexShrink={0}>
+                    <text fg={statusColor(selectedWorkflowSummary()?.status ?? "")} flexShrink={0}>
                       •
                     </text>
-                    <text fg={theme().text} wrapMode="word">
-                      {wf.title}
+                    <text fg={theme().text}>{selectedWorkflowSummary()?.status ?? "unknown"}</text>
+                    <Show when={actionMessage()}>
+                      <text fg={theme().warning} wrapMode="none">
+                        {actionMessage()}
+                      </text>
+                    </Show>
+                    <box flexGrow={1} />
+                    <text fg={theme().textMuted} flexShrink={0}>
+                      {nodes().length} {nodes().length === 1 ? "node" : "nodes"} · {layers().length}{" "}
+                      {layers().length === 1 ? "wave" : "waves"}
                     </text>
                   </box>
-                  <box paddingLeft={4}>
-                    <text fg={theme().textMuted}>
-                      {Number(wf.completedNodes)}/{Number(wf.nodeCount)} nodes · {wf.status}
-                    </text>
-                  </box>
-                </box>
-              )}
-            </For>
-          </box>
-        </box>
-
-        {/* Right column: node tree in topological waves */}
-        <box flexGrow={1} minWidth={0} paddingLeft={1}>
-          <Show
-            when={selectedWorkflow()}
-            fallback={
-              <text fg={theme().textMuted}>
-                {workflowLoad() === "loading"
-                  ? "Loading workflows..."
-                  : workflowLoad() === "error"
-                    ? "Unable to load workflows"
-                    : "No workflows for this session"}
-              </text>
-            }
-          >
-            <box flexDirection="column" width="100%" gap={1}>
-              <box
-                flexDirection="column"
-                width="100%"
-                flexShrink={0}
-                paddingBottom={1}
-                border={["bottom"]}
-                borderColor={theme().borderSubtle}
-              >
-                <box flexDirection="row" width="100%" justifyContent="space-between">
-                  <box flexDirection="column">
-                    <text fg={theme().textMuted}>Selected workflow</text>
-                    <text fg={theme().text} attributes={TextAttributes.BOLD}>
-                      {selectedWorkflowSummary()?.title ?? "Unknown"}
-                    </text>
-                  </box>
-                  <box flexDirection="row" gap={1}>
-                    <text fg={statusColor(selectedWorkflowSummary()?.status ?? "")}>•</text>
-                    <text fg={statusColor(selectedWorkflowSummary()?.status ?? "")}>
-                      {selectedWorkflowSummary()?.status ?? "unknown"}
-                    </text>
-                  </box>
-                </box>
-                <text fg={theme().textMuted}>ID: {selectedWorkflow()}</text>
-              </box>
-
-              <Show when={actionMessage()}>
-                <text fg={theme().warning} wrapMode="word">
-                  {actionMessage()}
-                </text>
-              </Show>
-
-              <box flexDirection="row" width="100%" justifyContent="space-between">
-                <text fg={theme().text} attributes={TextAttributes.BOLD}>
-                  Execution
-                </text>
-                <text fg={theme().textMuted}>
-                  {nodes().length} {nodes().length === 1 ? "node" : "nodes"} · {layers().length}{" "}
-                  {layers().length === 1 ? "wave" : "waves"}
-                </text>
-              </box>
-
-              {/* Wave header: nodes at the same topological depth, NOT a barrier */}
-              <For each={layers()}>
-                {(layer, layerIdx) => (
-                  <box
-                    flexDirection="column"
-                    width="100%"
-                    paddingLeft={1}
-                    border={["left"]}
-                    borderColor={theme().borderSubtle}
+                  <Separator axis="x" start="edge" />
+                  <scrollbox
+                    ref={(element: ScrollBoxRenderable) => (nodeScroll = element)}
+                    flexGrow={1}
+                    minHeight={0}
+                    verticalScrollbarOptions={{ visible: false }}
+                    horizontalScrollbarOptions={{ visible: false }}
                   >
-                    <box flexDirection="row" width="100%" justifyContent="space-between">
-                      <text fg={theme().accent} attributes={TextAttributes.BOLD}>
-                        Wave {layerIdx() + 1}
-                      </text>
-                      <text fg={theme().textMuted}>
-                        {layer.length} {layer.length === 1 ? "node" : "nodes"}
-                      </text>
-                    </box>
-                    <For each={layer}>
-                      {(node) => (
-                        <box
-                          flexDirection="column"
-                          width="100%"
-                          onMouseUp={() => setSelectedNode(node.id)}
-                          style={{ backgroundColor: selectedNode() === node.id ? theme().backgroundMenu : undefined }}
-                        >
-                          <box flexDirection="row" gap={1} width="100%">
-                            <text fg={selectedNode() === node.id ? theme().accent : theme().textMuted} flexShrink={0}>
-                              {selectedNode() === node.id ? "›" : " "}
+                    <For each={layers()}>
+                      {(layer, layerIdx) => (
+                        <>
+                          {/* Wave header: nodes at the same topological depth, NOT a barrier */}
+                          <box flexDirection="row" gap={1} width="100%" paddingLeft={1}>
+                            <text fg={theme().textMuted} wrapMode="none">
+                              wave {layerIdx() + 1} · {layer.length} {layer.length === 1 ? "node" : "nodes"}
                             </text>
-                            <Show when={node.status !== "running"} fallback={<Spinner color={theme().textMuted} />}>
-                              <text
-                                flexShrink={0}
-                                style={{
-                                  fg: statusColor(node.status),
-                                }}
-                              >
-                                •
-                              </text>
-                            </Show>
-                            <text fg={theme().text} wrapMode="word">
-                              {node.name}
-                            </text>
-                            <text fg={theme().textMuted}>[{node.worker_type}]</text>
                           </box>
-                          <Show when={node.depends_on.length > 0}>
-                            <box paddingLeft={4} paddingRight={1}>
-                              <text fg={theme().textMuted} wrapMode="word">
-                                depends on {node.depends_on.join(", ")}
-                              </text>
-                            </box>
-                          </Show>
-                          <Show when={node.status === "failed" && node.error_reason}>
-                            <box paddingLeft={4} paddingRight={1}>
-                              <text fg={theme().error} wrapMode="word">
-                                ⚠ {formatDagError(node.error_reason!)}
-                              </text>
-                            </box>
-                          </Show>
-                        </box>
+                          <For each={layer}>
+                            {(node) => {
+                              const selected = () => selectedNode() === node.id
+                              return (
+                                <box
+                                  flexDirection="row"
+                                  gap={1}
+                                  width="100%"
+                                  paddingLeft={2}
+                                  backgroundColor={selected() ? theme().primary : undefined}
+                                  onMouseUp={() => setSelectedNode(node.id)}
+                                >
+                                  <Show
+                                    when={node.status !== "running"}
+                                    fallback={<Spinner color={selected() ? theme().background : theme().textMuted} />}
+                                  >
+                                    <text fg={selected() ? theme().background : statusColor(node.status)} flexShrink={0}>
+                                      {dagNodeGlyph(node.status)}
+                                    </text>
+                                  </Show>
+                                  <box flexGrow={1} minWidth={0}>
+                                    <text
+                                      fg={
+                                        selected()
+                                          ? theme().background
+                                          : node.status === "running"
+                                            ? theme().text
+                                            : theme().textMuted
+                                      }
+                                      wrapMode="none"
+                                    >
+                                      {node.name}
+                                    </text>
+                                  </box>
+                                  <text fg={selected() ? theme().background : theme().textMuted} flexShrink={0}>
+                                    {node.worker_type}
+                                  </text>
+                                </box>
+                              )
+                            }}
+                          </For>
+                        </>
                       )}
                     </For>
-                  </box>
-                )}
-              </For>
-            </box>
-          </Show>
+                  </scrollbox>
+                  <Separator axis="x" start="edge-in" />
+                  <Show when={selectedNodeDetail()}>
+                    {(node) => (
+                      <box flexDirection="column" paddingLeft={1} flexShrink={0}>
+                        <box flexDirection="row" gap={1}>
+                          <text fg={theme().text} wrapMode="none">
+                            {node().name}
+                          </text>
+                          <text fg={theme().textMuted} wrapMode="none">
+                            {node().worker_type}
+                            {node().model_id ? ` · ${node().model_id}` : ""}
+                            {formatDagDuration(node().started_at, node().completed_at)
+                              ? ` · ${formatDagDuration(node().started_at, node().completed_at)}`
+                              : ""}
+                          </text>
+                        </box>
+                        <Show when={node().depends_on.length > 0}>
+                          <text fg={theme().textMuted} wrapMode="none">
+                            depends on {node().depends_on.join(", ")}
+                          </text>
+                        </Show>
+                        <Switch>
+                          <Match when={node().error_reason}>
+                            <text fg={theme().error} wrapMode="word">
+                              {formatDagError(node().error_reason!)}
+                            </text>
+                          </Match>
+                          <Match when={formatDagOutputPreview(node().output)}>
+                            <text fg={theme().textMuted} wrapMode="word">
+                              {formatDagOutputPreview(node().output)}
+                            </text>
+                          </Match>
+                        </Switch>
+                      </box>
+                    )}
+                  </Show>
+                </Panel>
+              </PanelGroup>
+            </Match>
+          </Switch>
         </box>
-      </box>
 
-      {/* Footer: shortcut hints */}
-      <box flexDirection="row" gap={2} flexShrink={0} border={["top"]} borderColor={theme().borderSubtle}>
-        <text fg={theme().textMuted}>↑/↓ node</text>
-        <text fg={theme().textMuted}>←/→ workflow</text>
-        <Show when={enterShortcut()}>
-          <text fg={theme().textMuted}>{enterShortcut()} open session</text>
-        </Show>
-        <text fg={theme().textMuted}>p pause</text>
-        <text fg={theme().textMuted}>r resume</text>
-        <text fg={theme().textMuted}>x cancel</text>
-        <Show when={closeShortcut()}>
-          <text fg={theme().textMuted}>{closeShortcut()} close</text>
-        </Show>
-      </box>
+        <Panel flexShrink={0} gap={2} paddingLeft={1} border="none">
+          <Show when={enterShortcut()}>
+            {(shortcut) => (
+              <text fg={theme().text}>
+                {shortcut()} <span style={{ fg: theme().textMuted }}>open session</span>
+              </text>
+            )}
+          </Show>
+          <Show when={pauseShortcut()}>
+            {(shortcut) => (
+              <text fg={theme().text}>
+                {shortcut()} <span style={{ fg: theme().textMuted }}>pause</span>
+              </text>
+            )}
+          </Show>
+          <Show when={resumeShortcut()}>
+            {(shortcut) => (
+              <text fg={theme().text}>
+                {shortcut()} <span style={{ fg: theme().textMuted }}>resume</span>
+              </text>
+            )}
+          </Show>
+          <Show when={stepShortcut()}>
+            {(shortcut) => (
+              <text fg={theme().text}>
+                {shortcut()} <span style={{ fg: theme().textMuted }}>step</span>
+              </text>
+            )}
+          </Show>
+          <Show when={cancelShortcut()}>
+            {(shortcut) => (
+              <text fg={theme().text}>
+                {shortcut()} <span style={{ fg: theme().textMuted }}>cancel</span>
+              </text>
+            )}
+          </Show>
+          <Show when={closeShortcut()}>
+            {(shortcut) => (
+              <text fg={theme().text}>
+                {shortcut()} <span style={{ fg: theme().textMuted }}>close</span>
+              </text>
+            )}
+          </Show>
+        </Panel>
+      </PanelGroup>
     </box>
   )
 }

--- a/packages/tui/test/feature-plugins/dag-inspector-utils.test.ts
+++ b/packages/tui/test/feature-plugins/dag-inspector-utils.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, test } from "bun:test"
 import {
+  computeNodeRowIndex,
   computeWaves,
   dagControlProgressMessage,
   dagControlUnavailableMessage,
+  dagNodeGlyph,
+  dagStatusColor,
+  formatDagDuration,
   formatDagError,
+  formatDagOutputPreview,
   type DagNode,
 } from "../../src/feature-plugins/system/dag-inspector-utils"
 
@@ -87,5 +92,62 @@ describe("DAG control state", () => {
     expect(dagControlProgressMessage("pause")).toBe("Pausing workflow...")
     expect(dagControlProgressMessage("resume")).toBe("Resuming workflow...")
     expect(dagControlProgressMessage("cancel")).toBe("Cancelling workflow...")
+  })
+
+  test("step is available while running or stepping only", () => {
+    expect(dagControlUnavailableMessage("running", "step")).toBeUndefined()
+    expect(dagControlUnavailableMessage("stepping", "step")).toBeUndefined()
+    expect(dagControlUnavailableMessage("paused", "step")).toBe("Workflow is paused and cannot be stepped")
+    expect(dagControlProgressMessage("step")).toBe("Stepping workflow...")
+  })
+})
+
+describe("computeNodeRowIndex", () => {
+  test("counts one row per wave header plus one row per node", () => {
+    const layers = computeWaves([node("a"), node("b", ["a"]), node("c", ["a"]), node("d", ["b", "c"])])
+    // rows: 0 wave1 header, 1 a, 2 wave2 header, 3 b, 4 c, 5 wave3 header, 6 d
+    expect(computeNodeRowIndex(layers, "a")).toBe(1)
+    expect(computeNodeRowIndex(layers, "b")).toBe(3)
+    expect(computeNodeRowIndex(layers, "c")).toBe(4)
+    expect(computeNodeRowIndex(layers, "d")).toBe(6)
+    expect(computeNodeRowIndex(layers, "missing")).toBeUndefined()
+  })
+})
+
+describe("shared status presentation", () => {
+  const theme = { success: "S", error: "E", warning: "W", text: "T", textMuted: "M" }
+
+  test("one status maps to one color across every DAG surface", () => {
+    expect(dagStatusColor(theme, "completed")).toBe("S")
+    expect(dagStatusColor(theme, "failed")).toBe("E")
+    expect(dagStatusColor(theme, "paused")).toBe("W")
+    expect(dagStatusColor(theme, "stepping")).toBe("W")
+    expect(dagStatusColor(theme, "running")).toBe("M")
+    expect(dagStatusColor(theme, "skipped")).toBe("M")
+    expect(dagStatusColor(theme, "cancelled")).toBe("M")
+  })
+
+  test("node glyphs mirror the todo-item vocabulary", () => {
+    expect(dagNodeGlyph("completed")).toBe("✓")
+    expect(dagNodeGlyph("failed")).toBe("✗")
+    expect(dagNodeGlyph("skipped")).toBe("⊘")
+    expect(dagNodeGlyph("pending")).toBe("○")
+  })
+})
+
+describe("node detail formatting", () => {
+  test("formats durations and tolerates SDK non-finite sentinels", () => {
+    expect(formatDagDuration(1_000, 63_000)).toBe("1m 2s")
+    expect(formatDagDuration(1_000, 5_000)).toBe("4s")
+    expect(formatDagDuration(undefined, 5_000)).toBeUndefined()
+    expect(formatDagDuration("NaN", 5_000)).toBeUndefined()
+  })
+
+  test("flattens output previews to one bounded line", () => {
+    expect(formatDagOutputPreview("line one\n  line two")).toBe("line one line two")
+    expect(formatDagOutputPreview({ verdict: "ACCEPT" })).toBe('{"verdict":"ACCEPT"}')
+    expect(formatDagOutputPreview(null)).toBeUndefined()
+    expect(formatDagOutputPreview("   ")).toBeUndefined()
+    expect(formatDagOutputPreview("x".repeat(300))?.length).toBe(201)
   })
 })


### PR DESCRIPTION
# fix(tui): align DAG surfaces with native opencode style

## 摘要

DAG 的三处 TUI 界面（Inspector 全屏路由 / 侧栏面板 / 侧栏指示器）与原生 opencode 设计词汇对齐（审计文档 P2-8）。

## 关键变更

- **Inspector**（`dag-inspector.tsx`）：重写为 diff-viewer 骨架——PanelGroup/Panel/Separator 布局、左列 scrollbox（废除 `slice(0,10)` 截断）、`scrollRowIntoView` 跟随选中、`theme.primary` 反色高亮、选中节点详情区（worker/model/耗时/依赖/错误/输出摘要）、新增 `dag.step` 命令、footer 全部走 `useCommandShortcut` 动态渲染。
- **侧栏面板**（`dag-panel.tsx`）：重写为原生三件套模式（可折叠 header ▼/▶ + `<b>` + `•` 色点行）。
- **侧栏指示器**（`dag.tsx`）：单行紧凑化。
- **共享呈现层**（`dag-inspector-utils.ts`）：统一配色 `dagStatusColor<Color>`、glyph、`formatDagDuration`（容忍 SDK Infinity/NaN 哨兵）、`formatDagOutputPreview`、`computeNodeRowIndex`；step 加入 `DagControlOperation`。
- 键位：`dag_step` 注册进 `Definitions`/`CommandMap`（可重绑定）。
- 测试：`dag-inspector-utils.test.ts` 新增 6 组纯函数单测。

## 验证

- typecheck（tsgo --noEmit）：tui 全绿
- `packages/tui`：`bun test` → 224 pass / 1 skip / 0 fail（基于 dev 独立验证，不依赖 engine 分支）
