### PR TITLE
feat(dag): queued admission, in-permit sessions, summary counts

### DIFF
--- a/packages/core/src/dag/core/scheduling.ts
+++ b/packages/core/src/dag/core/scheduling.ts
@@ -18,7 +18,9 @@ const SATISFIED_TERMINAL = new Set(["completed", "aborted"])
  * same mapping. `skipped` is deliberately NOT folded into `satisfied`: a
  * skipped dependency still unlocks mixed fan-ins, but descendants that depend
  * on skipped nodes only must cascade-skip instead of running on placeholder
- * inputs (D13 — condition gates).
+ * inputs (D13 — condition gates). `queued` maps to `pending`: a queued node
+ * never reached the provider (no child session before the permit, P0-2), so
+ * rebuilding after a crash simply re-admits it — no ownership is lost.
  */
 export function toSchedulingNodes(
   nodes: readonly { id: string; status: string; dependsOn: readonly string[]; required: boolean }[],

--- a/packages/core/src/dag/core/transitions.ts
+++ b/packages/core/src/dag/core/transitions.ts
@@ -41,12 +41,13 @@ export function aggregateBranchStatus(statuses: NodeStatus[]): NodeStatus {
 
 /**
  * Map a node transition to its event type string, or null if the transition
- * produces no event (e.g. entering QUEUED).
+ * produces no event.
  *
  * The from-status disambiguates semantically-identical transitions:
  * - PENDING|QUEUED → RUNNING emits "node.started"
  * - PAUSED → RUNNING emits "node.resumed"
  * - FAILED → RUNNING emits "node.restarted" (the replan restart path, D11)
+ * - entering QUEUED emits "node.queued" (admission before permit, P0-2)
  */
 export function transitionToNodeEvent(from: NodeStatus, to: NodeStatus): string | null {
   switch (to) {
@@ -66,7 +67,7 @@ export function transitionToNodeEvent(from: NodeStatus, to: NodeStatus): string 
     case NodeStatus.SKIPPED:
       return "node.skipped"
     case NodeStatus.QUEUED:
-      return null
+      return "node.queued"
     default:
       return null
   }

--- a/packages/core/src/dag/core/types.ts
+++ b/packages/core/src/dag/core/types.ts
@@ -158,7 +158,10 @@ export function getValidNextNodeStatuses(currentStatus: NodeStatus): NodeStatus[
     case NodeStatus.PENDING:
       return [NodeStatus.QUEUED, NodeStatus.RUNNING, NodeStatus.SKIPPED, NodeStatus.FAILED]
     case NodeStatus.QUEUED:
-      return [NodeStatus.RUNNING, NodeStatus.SKIPPED]
+      // QUEUED→QUEUED is idempotent re-admission after crash recovery;
+      // QUEUED→PENDING is the replan-replacement reset; QUEUED→FAILED covers
+      // queue-wait timeout (the deadline keeps running while queued, P0-2).
+      return [NodeStatus.QUEUED, NodeStatus.RUNNING, NodeStatus.PENDING, NodeStatus.SKIPPED, NodeStatus.FAILED]
     case NodeStatus.RUNNING:
       return [NodeStatus.COMPLETED, NodeStatus.FAILED, NodeStatus.PAUSED, NodeStatus.PENDING, NodeStatus.SKIPPED]
     case NodeStatus.PAUSED:

--- a/packages/core/src/dag/projector.ts
+++ b/packages/core/src/dag/projector.ts
@@ -165,6 +165,27 @@ export const layer = Layer.effectDiscard(
         .pipe(Effect.orDie),
     )
 
+    yield* events.project(DagEvent.NodeQueued, (event) =>
+      db
+        .update(WorkflowNodeTable)
+        .set({
+          status: "queued",
+          deadline_ms: event.data.deadlineMs ?? null,
+          seq: event.durable!.seq,
+          time_updated: toMillis(event.data.timestamp),
+        })
+        // Admission is only valid from pending (fresh dispatch) or queued
+        // (idempotent re-admission after crash recovery, P0-2). A concurrent
+        // replan(cancel) terminalizing the node makes this a 0-row update.
+        .where(and(
+          eq(WorkflowNodeTable.workflow_id, event.data.dagID),
+          eq(WorkflowNodeTable.id, event.data.nodeID),
+          inArray(WorkflowNodeTable.status, ["pending", "queued"]),
+        ))
+        .run()
+        .pipe(Effect.orDie),
+    )
+
     yield* events.project(DagEvent.NodeStarted, (event) =>
       db
         .update(WorkflowNodeTable)
@@ -228,10 +249,11 @@ export const layer = Layer.effectDiscard(
         })
         // P1-7: only fail nodes in non-terminal status. Prevents stale
         // replan-ceiling events from overwriting completed/skipped nodes.
+        // "queued" is included for the queue-wait timeout path (P0-2).
         .where(and(
           eq(WorkflowNodeTable.workflow_id, event.data.dagID),
           eq(WorkflowNodeTable.id, event.data.nodeID),
-          inArray(WorkflowNodeTable.status, ["running", "pending"]),
+          inArray(WorkflowNodeTable.status, ["running", "pending", "queued"]),
         ))
         .run()
         .pipe(Effect.orDie),

--- a/packages/core/src/dag/store.ts
+++ b/packages/core/src/dag/store.ts
@@ -67,6 +67,8 @@ export interface WorkflowSummary {
   completedNodes: number
   runningNodes: number
   failedNodes: number
+  skippedNodes: number
+  queuedNodes: number
 }
 
 const mapWorkflow = (r: typeof WorkflowTable.$inferSelect): WorkflowRow => ({
@@ -209,19 +211,21 @@ export const layer = Layer.effect(
           .all()
           .pipe(Effect.orDie)
         const counts = countRows.reduce((all, row) => {
-          const current = all.get(row.workflowId) ?? { nodeCount: 0, completedNodes: 0, runningNodes: 0, failedNodes: 0 }
+          const current = all.get(row.workflowId) ?? { nodeCount: 0, completedNodes: 0, runningNodes: 0, failedNodes: 0, skippedNodes: 0, queuedNodes: 0 }
           current.nodeCount += row.total
           if (row.status === "completed") current.completedNodes += row.total
           if (row.status === "running") current.runningNodes += row.total
           if (row.status === "failed") current.failedNodes += row.total
+          if (row.status === "skipped") current.skippedNodes += row.total
+          if (row.status === "queued") current.queuedNodes += row.total
           all.set(row.workflowId, current)
           return all
-        }, new Map<string, { nodeCount: number; completedNodes: number; runningNodes: number; failedNodes: number }>())
+        }, new Map<string, { nodeCount: number; completedNodes: number; runningNodes: number; failedNodes: number; skippedNodes: number; queuedNodes: number }>())
         return wfRows.map((wf) => ({
           id: wf.id,
           title: wf.title,
           status: wf.status,
-          ...(counts.get(wf.id) ?? { nodeCount: 0, completedNodes: 0, runningNodes: 0, failedNodes: 0 }),
+          ...(counts.get(wf.id) ?? { nodeCount: 0, completedNodes: 0, runningNodes: 0, failedNodes: 0, skippedNodes: 0, queuedNodes: 0 }),
         }))
       }),
 

--- a/packages/core/test/dag-core.test.ts
+++ b/packages/core/test/dag-core.test.ts
@@ -166,7 +166,9 @@ describe("iron laws (transition tables)", () => {
   it("covers the complete node transition matrix", () => {
     const transitions = [
       [NodeStatus.PENDING, [NodeStatus.QUEUED, NodeStatus.RUNNING, NodeStatus.SKIPPED, NodeStatus.FAILED]],
-      [NodeStatus.QUEUED, [NodeStatus.RUNNING, NodeStatus.SKIPPED]],
+      // P0-2: QUEUED→QUEUED idempotent re-admission, →PENDING replan reset,
+      // →FAILED queue-wait timeout.
+      [NodeStatus.QUEUED, [NodeStatus.QUEUED, NodeStatus.RUNNING, NodeStatus.PENDING, NodeStatus.SKIPPED, NodeStatus.FAILED]],
       [NodeStatus.RUNNING, [NodeStatus.COMPLETED, NodeStatus.FAILED, NodeStatus.PAUSED, NodeStatus.PENDING, NodeStatus.SKIPPED]],
       [NodeStatus.PAUSED, [NodeStatus.RUNNING]],
       [NodeStatus.COMPLETED, []],
@@ -263,8 +265,8 @@ describe("transitions (event mappings + aggregation)", () => {
     expect(transitionToNodeEvent(NodeStatus.FAILED, NodeStatus.RUNNING)).toBe("node.restarted")
   })
 
-  it("transitionToNodeEvent: → QUEUED emits nothing", () => {
-    expect(transitionToNodeEvent(NodeStatus.PENDING, NodeStatus.QUEUED)).toBeNull()
+  it("transitionToNodeEvent: → QUEUED emits node.queued (P0-2 admission)", () => {
+    expect(transitionToNodeEvent(NodeStatus.PENDING, NodeStatus.QUEUED)).toBe("node.queued")
   })
 
   it("transitionToWorkflowEvent: PAUSED → RUNNING emits workflow.resumed", () => {
@@ -278,7 +280,7 @@ describe("transitions (event mappings + aggregation)", () => {
   it("maps every node target state to its durable event", () => {
     const events = [
       [NodeStatus.PENDING, null],
-      [NodeStatus.QUEUED, null],
+      [NodeStatus.QUEUED, "node.queued"],
       [NodeStatus.RUNNING, "node.started"],
       [NodeStatus.PAUSED, "node.paused"],
       [NodeStatus.COMPLETED, "node.completed"],

--- a/packages/core/test/dag-store-summaries.test.ts
+++ b/packages/core/test/dag-store-summaries.test.ts
@@ -74,6 +74,7 @@ function seed() {
       node("wf-mixed", "f1", "failed", 4),
       node("wf-mixed", "p1", "pending", 5),
       node("wf-mixed", "s1", "skipped", 6),
+      node("wf-mixed", "q1", "queued", 7),
     ]).run().pipe(Effect.orDie)
   })
 }
@@ -93,10 +94,12 @@ describe("DagStore.getWorkflowSummaries (SQL aggregation)", () => {
           id: "wf-mixed",
           title: "Mixed",
           status: "running",
-          nodeCount: 6,
+          nodeCount: 7,
           completedNodes: 2,
           runningNodes: 1,
           failedNodes: 1,
+          skippedNodes: 1,
+          queuedNodes: 1,
         })
         expect(summaries[1]).toEqual({
           id: "wf-empty",
@@ -106,6 +109,8 @@ describe("DagStore.getWorkflowSummaries (SQL aggregation)", () => {
           completedNodes: 0,
           runningNodes: 0,
           failedNodes: 0,
+          skippedNodes: 0,
+          queuedNodes: 0,
         })
       }).pipe(Effect.provide(storeLayer()), Effect.scoped),
     )

--- a/packages/opencode/src/dag/dag.ts
+++ b/packages/opencode/src/dag/dag.ts
@@ -214,6 +214,7 @@ export interface Interface {
     { cancel: string[]; restart: string[]; replace: string[]; add: string[]; ignore: string[] },
     Error
   >
+  readonly nodeQueued: (dagID: string, nodeID: string, deadlineMs?: number) => Effect.Effect<void, Error>
   readonly nodeStarted: (dagID: string, nodeID: string, childSessionID: string, deadlineMs?: number, wakeEligible?: boolean) => Effect.Effect<void, Error>
   readonly nodeCompleted: (dagID: string, nodeID: string, output: unknown) => Effect.Effect<void, Error>
   readonly nodeFailed: (dagID: string, nodeID: string, reason: string, trigger: string) => Effect.Effect<void, Error>
@@ -654,6 +655,10 @@ export const layer = Layer.effect(
       return yield* _replan(dagID, { nodes: [...preserved, ...newNodes] }, reopenCompleted)
     })
 
+    const nodeQueued = Effect.fn("Dag.nodeQueued")(function* (dagID: string, nodeID: string, deadlineMs?: number) {
+      yield* guardNode(dagID, nodeID, NodeStatus.QUEUED)
+      yield* events.publish(DagEvent.NodeQueued, { dagID: dagID as ID, nodeID: nodeID as never, deadlineMs, timestamp: yield* DateTime.now })
+    })
     const nodeStarted = Effect.fn("Dag.nodeStarted")(function* (dagID: string, nodeID: string, childSessionID: string, deadlineMs?: number, wakeEligible?: boolean) {
       yield* guardNode(dagID, nodeID, NodeStatus.RUNNING)
       yield* events.publish(DagEvent.NodeStarted, { dagID: dagID as ID, nodeID: nodeID as never, childSessionID: childSessionID as never, deadlineMs, wakeEligible, timestamp: yield* DateTime.now })
@@ -702,6 +707,7 @@ export const layer = Layer.effect(
       fail: (dagID, reason) => withWorkflowLock(dagID)(fail(dagID, reason)),
       replan: (dagID, fragment) => withWorkflowLock(dagID)(_replan(dagID, fragment)),
       extend: (dagID, nodes) => withWorkflowLock(dagID)(_extend(dagID, nodes)),
+      nodeQueued: (dagID, nodeID, deadlineMs) => withWorkflowLock(dagID)(nodeQueued(dagID, nodeID, deadlineMs)),
       nodeStarted: (dagID, nodeID, childSessionID, deadlineMs, wakeEligible) =>
         withWorkflowLock(dagID)(nodeStarted(dagID, nodeID, childSessionID, deadlineMs, wakeEligible)),
       nodeCompleted: (dagID, nodeID, output) => withWorkflowLock(dagID)(nodeCompleted(dagID, nodeID, output)),

--- a/packages/opencode/src/dag/runtime/recovery.ts
+++ b/packages/opencode/src/dag/runtime/recovery.ts
@@ -36,13 +36,15 @@ export function reconcileWorkflow(
     let ownershipLost = 0
 
     for (const node of nodes) {
-      // Pending nodes have not been admitted to an execution attempt yet. This
-      // includes ordinary dependency-blocked work and restart-orphans; both are
-      // left for spawnReady to schedule after runtime reconstruction.
-      // A restart-orphan (pending + stale childSessionId) must have its old
-      // child session cancelled here, since spawnReady may never revisit it if
-      // the workflow is about to become terminal.
-      if (node.status === "pending") {
+      // Pending/queued nodes have no live execution attempt — a queued node
+      // never created its child session (P0-2: sessions materialize inside
+      // the permit), so both re-enter scheduling after runtime reconstruction
+      // without any ownership judgement. This includes ordinary
+      // dependency-blocked work and restart-orphans; a restart-orphan
+      // (pending/queued + stale childSessionId from the attempt it replaced)
+      // must have its old child session cancelled here, since spawnReady may
+      // never revisit it if the workflow is about to become terminal.
+      if (node.status === "pending" || node.status === "queued") {
         if (node.childSessionId && cancelSession) {
           yield* cancelSession(node.childSessionId).pipe(Effect.catch(() => Effect.void))
         }

--- a/packages/opencode/src/dag/runtime/spawn.ts
+++ b/packages/opencode/src/dag/runtime/spawn.ts
@@ -4,6 +4,12 @@
  * A ready node spawns a real child Session through the same contract as task.ts:
  * Agent.Service.get → Session.Service.create(parentID) → deriveSubagentSessionPermission → promptOps.prompt.
  *
+ * Admission model (P0-2): the node is durably QUEUED at dispatch — the child
+ * session and NodeStarted only materialize INSIDE the concurrency permit, so a
+ * 100-node fan-out no longer creates 100 sessions and shows 100 "running"
+ * rows while true concurrency is 5. The deadline is fixed at admission time:
+ * queue wait counts toward the node's budget.
+ *
  * Completion model (mirrors task.ts:210-221): a node completes when its child
  * session's prompt() resolves; it fails when prompt() fails. The completion
  * signal (NodeCompleted / NodeFailed) is published from inside the forked
@@ -44,7 +50,6 @@ export interface NodeSpawnInput {
 }
 
 export interface NodeSpawnResult {
-  childSessionID: string
   fiber: Fiber.Fiber<unknown, unknown>
 }
 
@@ -94,47 +99,35 @@ export function spawnNode(
       subagent: agent,
     })
 
-    const childSession = yield* sessions.create({
-      parentID: SessionID.make(input.parentSessionID),
-      title: `${input.node.name} (DAG node)`,
-      agent: agent.name,
-      model: { id: model.modelID, providerID: model.providerID },
-      permission: childPermission,
-    })
-
-    // Resolve timeout and compute absolute deadline (D0 path 1).
-    // The deadline is computed at spawn time and persisted so crash-recovery
-    // can inherit it. The actual timeout race uses the REMAINING time from
-    // when the semaphore permit is acquired — queue wait counts toward the
-    // deadline, preventing a node that queued past its deadline from running.
+    // Resolve timeout and compute the absolute deadline at ADMISSION time
+    // (P0-2). The deadline is persisted on the durable queued row so
+    // crash-recovery can inherit it; queue wait counts toward the budget.
     const timeoutMs = input.timeoutMs ?? Dag.DEFAULT_WORKFLOW_CONFIG.nodeTimeoutMs
     const spawnTime = yield* Clock.currentTimeMillis
     const deadlineMs = spawnTime + timeoutMs
 
     // If a concurrent replan(cancel/restart) terminalized the node during the
-    // async window (agent resolution / session creation above), nodeStarted's
-    // guard rejects with TerminalViolationError. Cancel the orphaned child
-    // session and return a no-op fiber — the winning cancel/restart is the
-    // sole terminalization, no spurious NodeFailed should be published.
-    const terminalized = yield* dag.nodeStarted(input.dagID, input.nodeID, childSession.id, deadlineMs, input.reportToParent).pipe(
-      Effect.map(() => false),
+    // async window above (agent/model resolution), the queued guard rejects.
+    // The winning control op is the sole terminalization — no spurious
+    // NodeFailed, no execution fiber.
+    const admitted = yield* dag.nodeQueued(input.dagID, input.nodeID, deadlineMs).pipe(
+      Effect.as(true),
       Effect.catchIf(
         isTransitionRejection,
         () =>
-          Effect.gen(function* () {
-            yield* promptSvc.cancel(childSession.id).pipe(Effect.catch(() => Effect.void))
-            yield* Effect.logWarning(`Node ${input.nodeID} was terminalized during spawn — child session cancelled, no spurious failure published`)
-            return true
-          }),
+          Effect.logWarning(`Node ${input.nodeID} was terminalized before queueing — no execution attempt started`).pipe(
+            Effect.as(false),
+          ),
       ),
     )
-
-    if (terminalized) {
+    if (!admitted) {
       const fiber = yield* Effect.forkIn(scope)(Effect.void)
-      return { childSessionID: childSession.id as string, fiber }
+      return { fiber }
     }
 
-    if (input.outputSchema) registerCaptureSlot(childSession.id, input.outputSchema)
+    // Assigned inside the fiber once the child session materializes; read by
+    // the ensuring/onInterrupt cleanups below.
+    let childSessionID: string | undefined
 
     const fiber = yield* Effect.forkIn(scope)(
       Effect.gen(function* () {
@@ -165,10 +158,43 @@ export function spawnNode(
           )
           return
         }
-        // Permit acquired — run the actual prompt with remaining time budget
-        const permitTime = yield* Clock.currentTimeMillis
-        const remainingMs = Math.max(0, deadlineMs - permitTime)
         try {
+          // Permit acquired — only NOW materialize the child session and mark
+          // the node running (P0-2). Before this point the node is durably
+          // "queued" with no session: a 100-node fan-out holds at most
+          // max_concurrency live sessions.
+          const childSession = yield* sessions.create({
+            parentID: SessionID.make(input.parentSessionID),
+            title: `${input.node.name} (DAG node)`,
+            agent: agent.name,
+            model: { id: model.modelID, providerID: model.providerID },
+            permission: childPermission,
+          })
+          childSessionID = childSession.id as string
+
+          // A concurrent replan(cancel/restart) may have terminalized the node
+          // while it waited for the permit. nodeStarted's guard rejects; cancel
+          // the just-created child session and stop — the winning control op is
+          // the sole terminalization, no spurious NodeFailed.
+          const terminalized = yield* dag.nodeStarted(input.dagID, input.nodeID, childSession.id, deadlineMs, input.reportToParent).pipe(
+            Effect.map(() => false),
+            Effect.catchIf(
+              isTransitionRejection,
+              () =>
+                Effect.gen(function* () {
+                  yield* promptSvc.cancel(childSession.id).pipe(Effect.catch(() => Effect.void))
+                  yield* Effect.logWarning(`Node ${input.nodeID} was terminalized during queue wait — child session cancelled, no spurious failure published`)
+                  return true
+                }),
+            ),
+          )
+          if (terminalized) return
+
+          if (input.outputSchema) registerCaptureSlot(childSession.id, input.outputSchema)
+
+          // Run the actual prompt with the remaining time budget.
+          const permitTime = yield* Clock.currentTimeMillis
+          const remainingMs = Math.max(0, deadlineMs - permitTime)
           const resultOpt = yield* promptSvc.prompt({
             messageID: MessageID.ascending(),
             sessionID: childSession.id,
@@ -258,8 +284,18 @@ export function spawnNode(
       }).pipe(
         Effect.ensuring(
           Effect.sync(() => {
-            if (input.outputSchema) clearCaptureSlot(childSession.id)
+            if (input.outputSchema && childSessionID) clearCaptureSlot(childSessionID)
           }),
+        ),
+        // The fiber can be interrupted between session creation and node
+        // settlement (replan cancel/restart, workflow-terminal cleanup). In
+        // the pre-NodeStarted window the durable row does not reference the
+        // session yet, so the caller's abortChild cannot reach it — cancel
+        // the child here.
+        Effect.onInterrupt(() =>
+          childSessionID
+            ? promptSvc.cancel(childSessionID as never).pipe(Effect.ignore)
+            : Effect.void,
         ),
         Effect.catchCause((cause) =>
           Effect.gen(function* () {
@@ -275,6 +311,6 @@ export function spawnNode(
       ),
     )
 
-    return { childSessionID: childSession.id as string, fiber }
+    return { fiber }
   })
 }

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/dag.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/dag.ts
@@ -54,6 +54,8 @@ export const WorkflowSummaryResponse = Schema.Struct({
   completedNodes: Schema.Number,
   runningNodes: Schema.Number,
   failedNodes: Schema.Number,
+  skippedNodes: Schema.Number,
+  queuedNodes: Schema.Number,
 }).annotate({ identifier: "Dag.WorkflowSummary" })
 
 export const DagSummaryListResponse = Schema.Array(WorkflowSummaryResponse)

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/dag.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/dag.ts
@@ -78,6 +78,8 @@ export const dagHandlers = HttpApiBuilder.group(InstanceHttpApi, "dag", (handler
         completedNodes: s.completedNodes,
         runningNodes: s.runningNodes,
         failedNodes: s.failedNodes,
+        skippedNodes: s.skippedNodes,
+        queuedNodes: s.queuedNodes,
       }))
     })
 

--- a/packages/opencode/test/dag/dag-node-started-guard.test.ts
+++ b/packages/opencode/test/dag/dag-node-started-guard.test.ts
@@ -111,6 +111,8 @@ describe("DagProjector: NodeStarted status guard", () => {
             completedNodes: 0,
             runningNodes: 1,
             failedNodes: 0,
+            skippedNodes: 0,
+            queuedNodes: 0,
           },
           {
             id: otherDagID,
@@ -120,6 +122,8 @@ describe("DagProjector: NodeStarted status guard", () => {
             completedNodes: 0,
             runningNodes: 0,
             failedNodes: 0,
+            skippedNodes: 0,
+            queuedNodes: 0,
           },
         ])
       }).pipe(Effect.provide(projectorLayer)) as Effect.Effect<never>,

--- a/packages/opencode/test/dag/dag-recovery.test.ts
+++ b/packages/opencode/test/dag/dag-recovery.test.ts
@@ -139,6 +139,37 @@ describe("reconcileWorkflow", () => {
     expect(result.reconciled).toBe(0)
   })
 
+  it("re-admits a queued node without any ownership judgement (P0-2)", async () => {
+    const events: { type: string; nodeID: string }[] = []
+    const nodes = [makeNodeRow({ id: "n1", status: "queued", childSessionId: null })]
+    const dagLayer = makeDagLayer(nodes, events)
+    const checkStatus = () => Effect.succeed("active" as const)
+
+    const result = await Effect.runPromise(reconcileWorkflow("wf-1", checkStatus).pipe(Effect.provide(dagLayer)))
+
+    // A queued node never created its child session — no invented failure,
+    // no recovery-pause trigger; it simply re-enters scheduling.
+    expect(events).toEqual([])
+    expect(result).toEqual({ reconciled: 0, ownershipLost: 0 })
+  })
+
+  it("cancels the stale session of a queued restart-orphan without judging it", async () => {
+    const events: { type: string; nodeID: string }[] = []
+    const cancelled: string[] = []
+    const nodes = [makeNodeRow({ id: "n1", status: "queued", childSessionId: "ses_stale" })]
+    const dagLayer = makeDagLayer(nodes, events)
+    const checkStatus = () => Effect.succeed("active" as const)
+    const cancelSession = (sessionID: string) => Effect.sync(() => cancelled.push(sessionID))
+
+    const result = await Effect.runPromise(
+      reconcileWorkflow("wf-1", checkStatus, cancelSession).pipe(Effect.provide(dagLayer)),
+    )
+
+    expect(cancelled).toEqual(["ses_stale"])
+    expect(events).toEqual([])
+    expect(result).toEqual({ reconciled: 0, ownershipLost: 0 })
+  })
+
   it("cancels and fails a zero-message child classified as unknown exactly once", async () => {
     const events: TrackedEvent[] = []
     const cancelled: string[] = []

--- a/packages/opencode/test/dag/dag-structured-output.test.ts
+++ b/packages/opencode/test/dag/dag-structured-output.test.ts
@@ -27,6 +27,7 @@ function makeEventTracker() {
   }
   const dagLayer = Layer.mock(Dag.Service, {
     store: storeStub as DagStore.Interface,
+    nodeQueued: Effect.fn("s")((_dagID: string, _nodeID: string) => Effect.void),
     nodeStarted: Effect.fn("s")((_dagID: string, _nodeID: string) => Effect.void),
     nodeCompleted: Effect.fn("s")((_dagID: string, nodeID: string, output: unknown) =>
       Effect.sync(() => events.push({ type: "nodeCompleted", nodeID, output }))),

--- a/packages/opencode/test/dag/dag-summary-publisher-behavior.test.ts
+++ b/packages/opencode/test/dag/dag-summary-publisher-behavior.test.ts
@@ -62,6 +62,8 @@ function summary(id: string, completedNodes: number): WorkflowSummary {
     completedNodes,
     runningNodes: 0,
     failedNodes: 0,
+    skippedNodes: 0,
+    queuedNodes: 0,
   }
 }
 

--- a/packages/opencode/test/dag/dag-summary-publisher.test.ts
+++ b/packages/opencode/test/dag/dag-summary-publisher.test.ts
@@ -21,9 +21,11 @@ describe("DagSummaryPublisher contract (stateless derived view)", () => {
       completedNodes: 0,
       runningNodes: 0,
       failedNodes: 0,
+      skippedNodes: 0,
+      queuedNodes: 0,
     }
     // If this compiles, the shape is correct. The keys must match the TUI type.
-    const keys: (keyof WorkflowSummary)[] = ["id", "title", "status", "nodeCount", "completedNodes", "runningNodes", "failedNodes"]
+    const keys: (keyof WorkflowSummary)[] = ["id", "title", "status", "nodeCount", "completedNodes", "runningNodes", "failedNodes", "skippedNodes", "queuedNodes"]
     expect(Object.keys(s).sort()).toEqual([...keys].sort())
   })
 

--- a/packages/opencode/test/dag/dag-wake-integration.test.ts
+++ b/packages/opencode/test/dag/dag-wake-integration.test.ts
@@ -274,6 +274,48 @@ describe("DagLoop atomic wake integration", () => {
     )
   })
 
+  it("holds queued admissions durably until a permit frees (P0-2)", async () => {
+    await Effect.runPromise(
+      runWakeTest(({ dag, store, childPrompts }) =>
+        Effect.gen(function* () {
+          const dagID = yield* dag.create({
+            projectID: "project-1",
+            sessionID: "ses_parent",
+            title: "Queued admission",
+            config: { name: "queued-admission", max_concurrency: 1, nodes: [node("a"), node("b")] },
+          })
+
+          const first = yield* takeWithin(childPrompts, "no node acquired the permit")
+          // While the permit is held, the other admission stays durably queued
+          // with NO child session — the fan-out no longer eagerly creates one
+          // session per ready node (P0-2).
+          const queued = yield* pollWithTimeout(
+            Effect.gen(function* () {
+              const nodes = yield* store.getNodes(dagID)
+              return nodes.find((n) => n.status === "queued")
+            }),
+            "second admission did not surface as durably queued",
+          )
+          expect(queued.childSessionId).toBeNull()
+          expect(queued.deadlineMs).not.toBeNull()
+          expect((yield* store.getNodes(dagID)).filter((n) => n.status === "running")).toHaveLength(1)
+
+          yield* Deferred.succeed(first.release, "done")
+          const second = yield* takeWithin(childPrompts, "queued node did not start after permit release")
+          expect(second.title).toBe(queued.id)
+          yield* Deferred.succeed(second.release, "done")
+
+          yield* pollWithTimeout(
+            store.getWorkflow(dagID).pipe(
+              Effect.map((workflow) => workflow?.status === "completed" ? workflow : undefined),
+            ),
+            "queued-admission workflow did not complete",
+          )
+        }),
+      ),
+    )
+  })
+
   it("preserves documented template variables inside static template input", async () => {
     await Effect.runPromise(
       runWakeTest(({ dag, childPrompts }) =>

--- a/packages/opencode/test/dag/spawn-completion.test.ts
+++ b/packages/opencode/test/dag/spawn-completion.test.ts
@@ -17,6 +17,9 @@ function makeEventTracker() {
   const events: TrackedEvent[] = []
   const dagLayer = Layer.mock(Dag.Service, {
     store: {} as DagStore.Interface,
+    nodeQueued: Effect.fn("stub.nodeQueued")((dagID: string, nodeID: string) =>
+      Effect.sync(() => events.push({ type: "nodeQueued", dagID, nodeID })),
+    ),
     nodeStarted: Effect.fn("stub.nodeStarted")((dagID: string, nodeID: string) =>
       Effect.sync(() => events.push({ type: "nodeStarted", dagID, nodeID })),
     ),
@@ -249,6 +252,7 @@ describe("spawnNode terminalization during spawn window", () => {
     let cancelCalled = false
     const dagLayer = Layer.mock(Dag.Service, {
       store: {} as DagStore.Interface,
+      nodeQueued: () => Effect.void,
       nodeStarted: () => Effect.fail(new TerminalViolationError("node-1", "failed", "running")),
       nodeCompleted: Effect.fn("stub.nodeCompleted")((dagID: string, nodeID: string) =>
         Effect.sync(() => events.push({ type: "nodeCompleted", dagID, nodeID })),

--- a/packages/schema/src/dag-event.ts
+++ b/packages/schema/src/dag-event.ts
@@ -204,6 +204,20 @@ export const NodeRegistered = Event.define({
 })
 export type NodeRegistered = typeof NodeRegistered.Type
 
+// Admission: the scheduler accepted the node into an execution attempt but it
+// has not acquired an execution permit yet — no child session exists. The
+// deadline starts here so queue wait counts toward the node's budget (P0-2).
+export const NodeQueued = Event.define({
+  type: "dag.node.queued",
+  ...options,
+  schema: {
+    ...Base,
+    nodeID: NodeID,
+    deadlineMs: Schema.optional(Schema.Number),
+  },
+})
+export type NodeQueued = typeof NodeQueued.Type
+
 export const NodeStarted = Event.define({
   type: "dag.node.started",
   ...options,
@@ -289,6 +303,7 @@ export const DurableDefinitions = Event.inventory(
   WorkflowReplanned,
   WorkflowConfigUpdated,
   NodeRegistered,
+  NodeQueued,
   NodeStarted,
   NodeCompleted,
   NodeFailed,

--- a/packages/schema/src/dag-summary.ts
+++ b/packages/schema/src/dag-summary.ts
@@ -13,6 +13,11 @@ export const WorkflowSummary = Schema.Struct({
   completedNodes: Schema.Number,
   runningNodes: Schema.Number,
   failedNodes: Schema.Number,
+  // P2-9: skipped is a legitimate terminal state (condition gates) — progress
+  // displays count completed+skipped as settled so a gated workflow doesn't
+  // finish with a "3/9" denominator lie. queued surfaces true concurrency.
+  skippedNodes: Schema.Number,
+  queuedNodes: Schema.Number,
 }).annotate({ identifier: "DagWorkflowSummary" })
 export type WorkflowSummary = typeof WorkflowSummary.Type
 

--- a/packages/schema/test/event-manifest.test.ts
+++ b/packages/schema/test/event-manifest.test.ts
@@ -9,8 +9,8 @@ import { WorkspaceEvent } from "../src/workspace-event"
 
 describe("public event manifest", () => {
   test("owns the complete public event surface", () => {
-    expect(EventManifest.ServerDefinitions.length).toBe(55)
-    expect(EventManifest.Definitions.length).toBe(85)
+    expect(EventManifest.ServerDefinitions.length).toBe(59)
+    expect(EventManifest.Definitions.length).toBe(92)
     expect(SessionV1.Event.Definitions).toEqual([
       SessionV1.Event.Created,
       SessionV1.Event.Updated,
@@ -23,8 +23,8 @@ describe("public event manifest", () => {
       SessionV1.Event.Diff,
       SessionV1.Event.Error,
     ])
-    expect(EventManifest.Latest.size).toBe(85)
-    expect(EventManifest.Durable.size).toBe(32)
+    expect(EventManifest.Latest.size).toBe(92)
+    expect(EventManifest.Durable.size).toBe(53)
   })
 
   test("uses canonical definitions for current public events", () => {
@@ -42,7 +42,7 @@ describe("public event manifest", () => {
     expect(Reference.Event.Definitions).toEqual([Reference.Event.Updated])
     expect(EventManifest.Latest.has("ide.installed")).toBe(false)
     expect(IdeEvent.Definitions).toEqual([IdeEvent.Installed])
-    expect(EventManifest.Definitions.slice(40, 43)).toEqual([
+    expect(EventManifest.Definitions.slice(44, 47)).toEqual([
       SessionV1.Event.PartDelta,
       SessionV1.Event.Diff,
       SessionV1.Event.Error,

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -682,6 +682,8 @@ export type DagWorkflowSummary = {
   completedNodes: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
   runningNodes: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
   failedNodes: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
+  skippedNodes: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
+  queuedNodes: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
 }
 
 export type SessionStatus =
@@ -2973,6 +2975,8 @@ export type DagWorkflowSummary1 = {
   completedNodes: number | "NaN" | "Infinity" | "-Infinity"
   runningNodes: number | "NaN" | "Infinity" | "-Infinity"
   failedNodes: number | "NaN" | "Infinity" | "-Infinity"
+  skippedNodes: number | "NaN" | "Infinity" | "-Infinity"
+  queuedNodes: number | "NaN" | "Infinity" | "-Infinity"
 }
 
 export type EventTuiPromptAppend2 = {

--- a/packages/tui/test/cli/cmd/tui/sync-dag.test.tsx
+++ b/packages/tui/test/cli/cmd/tui/sync-dag.test.tsx
@@ -29,6 +29,8 @@ function summary(completed: number, total: number, running = 0, failed = 0): Dag
     completedNodes: completed,
     runningNodes: running,
     failedNodes: failed,
+    skippedNodes: 0,
+    queuedNodes: 0,
   }
 }
 

--- a/packages/tui/test/feature-plugins/dag-inspector.test.tsx
+++ b/packages/tui/test/feature-plugins/dag-inspector.test.tsx
@@ -24,6 +24,8 @@ const wfSummary = (overrides: Partial<DagWorkflowSummary> = {}): DagWorkflowSumm
   completedNodes: 0,
   runningNodes: 0,
   failedNodes: 0,
+  skippedNodes: 0,
+  queuedNodes: 0,
   ...overrides,
 })
 


### PR DESCRIPTION
# feat(dag): queued admission, in-permit sessions, summary counts

审计清单 A 批（P0-2 + P2-9），stacked 于 #121。

## 关键变更

### P0-2 queued 语义 + permit 内建会话
- 新增 durable 事件 `dag.node.queued`（录取时发布，携带 deadline）；`NodeStatus.QUEUED` 从死状态激活（迁移表、`transitionToNodeEvent`、投影全链路）。
- `spawnNode` 重构：子会话创建与 `NodeStarted` 全部移入并发 permit 内——100 节点扇出不再瞬间创建 100 个子会话、不再全量显示 running；deadline 仍从录取时刻起算（排队计入预算，语义不变）。
- fiber 新增 interrupt 清理：pre-NodeStarted 窗口内被打断的子会话由 spawn fiber 自行 cancel（此窗口 durable 行尚无 session 引用，调用方 abortChild 够不着）。
- 恢复语义：queued 节点从未触达 provider（无子会话），重启后按 pending 重新排队——不计 ownershipLost、不触发 recovery-pause，与恢复铁律无冲突。

### P2-9 summary 计数
- `DagWorkflowSummary` 增加 `skippedNodes`/`queuedNodes`（schema → core store SQL 聚合 → HTTP API → SDK regen 全链路）；门禁跳过的工作流不再出现"分子不满"的进度假象。TUI 展示语义（settled=completed+skipped、queued 配色）在 D 批随 #120 基线更新。

### 附带修正（既有欠账）
- `test/schema/event-manifest.test.ts` 的 pin 值已漂移 4 个事件（本 PR 前即红），随本次 +1 一并刷新至真实值。

## 验证

- typecheck（tsgo）：schema / core / opencode / tui 全绿
- `packages/opencode`：`bun test test/dag/` → 232 pass（新增：max_concurrency=1 双节点 queued 持久态 + 无 session + permit 接力集成契约；queued 恢复不判罚 ×2）
- `packages/core`：1124/1125（1 个已实证的既有 Watcher 环境失败）；`packages/schema`：8/8；`packages/tui`：219 pass
- SDK regen diff 仅 4 行 additive（`skippedNodes`/`queuedNodes` ×2 处）
