### PR TITLE
feat(dag): HTTP API start and extend routes

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/groups/dag.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/dag.ts
@@ -61,12 +61,33 @@ export const WorkflowSummaryResponse = Schema.Struct({
 export const DagSummaryListResponse = Schema.Array(WorkflowSummaryResponse)
 
 export const DagControlPayload = Schema.Struct({
-  operation: Schema.Literals(["pause", "resume", "cancel", "replan", "step", "complete"]),
+  operation: Schema.Literals(["pause", "resume", "cancel", "replan", "extend", "step", "complete"]),
   fragment: Schema.optional(Schema.Unknown),
+})
+
+// replan/extend return the plan disposition; other ops return status only.
+// The optional arrays must be declared here or the response encoder strips them.
+export const DagControlResponse = Schema.Struct({
+  status: Schema.String,
+  cancel: Schema.optional(Schema.Array(Schema.String)),
+  restart: Schema.optional(Schema.Array(Schema.String)),
+  replace: Schema.optional(Schema.Array(Schema.String)),
+  add: Schema.optional(Schema.Array(Schema.String)),
+  ignore: Schema.optional(Schema.Array(Schema.String)),
+}).annotate({ identifier: "Dag.ControlResult" })
+
+// Config is validated by Dag.create at runtime (duplicate ids, dangling deps,
+// condition references, node ceiling) — same fail-fast path as the tool
+// surface; a schema-level WorkflowConfig would duplicate that contract.
+export const DagStartPayload = Schema.Struct({
+  session_id: Schema.String,
+  title: Schema.optional(Schema.String),
+  config: Schema.Unknown,
 })
 
 export const DagPaths = {
   list: `${root}`,
+  start: `${root}`,
   bySession: `${root}/session/:sessionID`,
   summary: `${root}/session/:sessionID/summary`,
   detail: `${root}/:dagID`,
@@ -141,14 +162,24 @@ export const DagApi = HttpApi.make("dag").add(
       ),
     )
     .add(
+      HttpApiEndpoint.post("start", DagPaths.start, {
+        query: WorkspaceRoutingQuery,
+        payload: DagStartPayload,
+        success: described(WorkflowResponse, "Created workflow"),
+        error: [ApiNotFoundError, ConflictError],
+      }).annotateMerge(
+        OpenApi.annotations({ identifier: "dag.start", summary: "Create and start a DAG workflow" }),
+      ),
+    )
+    .add(
       HttpApiEndpoint.post("control", DagPaths.control, {
         params: { dagID: Schema.String },
         query: WorkspaceRoutingQuery,
         payload: DagControlPayload,
-        success: described(Schema.Struct({ status: Schema.String }), "Control result"),
+        success: described(DagControlResponse, "Control result (replan/extend include the plan disposition)"),
         error: [ApiNotFoundError, ConflictError],
       }).annotateMerge(
-        OpenApi.annotations({ identifier: "dag.control", summary: "Control a workflow (pause/resume/cancel/replan/step/complete)" }),
+        OpenApi.annotations({ identifier: "dag.control", summary: "Control a workflow (pause/resume/cancel/replan/extend/step/complete)" }),
       ),
     )
     .annotateMerge(OpenApi.annotations({ title: "dag", description: "DAG workflow inspector + control routes" }))

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/dag.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/dag.ts
@@ -3,6 +3,8 @@ import { HttpApiBuilder } from "effect/unstable/httpapi"
 import { InstanceHttpApi } from "../api"
 import { InvalidRequestError, ConflictError, notFound } from "../errors"
 import { Dag } from "@/dag/dag"
+import { Session } from "@/session/session"
+import { SessionID } from "@/session/schema"
 import { InvalidTransitionError, TerminalViolationError } from "@opencode-ai/core/dag/core/types"
 import type { DagStore } from "@opencode-ai/core/dag/store"
 
@@ -26,6 +28,7 @@ function mapTransitionConflict<Success>(effect: Effect.Effect<Success, Error>) {
 export const dagHandlers = HttpApiBuilder.group(InstanceHttpApi, "dag", (handlers) =>
   Effect.gen(function* () {
     const dag = yield* Dag.Service
+    const sessions = yield* Session.Service
 
     const wf = (r: DagStore.WorkflowRow) => ({
       id: r.id,
@@ -100,6 +103,31 @@ export const dagHandlers = HttpApiBuilder.group(InstanceHttpApi, "dag", (handler
       return node(row)
     })
 
+    const start = Effect.fn("DagHttpApi.start")(function* (ctx: { payload: { session_id: string; title?: string; config: unknown } }) {
+      const config = ctx.payload.config
+      if (!config || typeof config !== "object" || !Array.isArray((config as Record<string, unknown>).nodes)) {
+        return yield* Effect.fail(new InvalidRequestError({ message: "start requires 'config' with a 'nodes' array" }))
+      }
+      const session = yield* sessions.get(SessionID.make(ctx.payload.session_id)).pipe(
+        Effect.catch(() => Effect.fail(notFound(`Session not found: ${ctx.payload.session_id}`))),
+      )
+      const cfg = config as Dag.WorkflowConfig
+      // Same code path as the workflow tool's start action — create validates
+      // the config (duplicate ids / dangling deps / condition refs / ceiling)
+      // and fail-fast errors surface as 400, not 500 defects.
+      const dagID = yield* dag.create({
+        projectID: session.projectID,
+        sessionID: session.id,
+        title: ctx.payload.title ?? cfg.name,
+        config: cfg,
+      }).pipe(
+        Effect.catch((error) => Effect.fail(new InvalidRequestError({ message: error.message }))),
+      )
+      const row = yield* dag.store.getWorkflow(dagID).pipe(Effect.orDie)
+      if (!row) return yield* Effect.die(new Error(`created workflow missing from store: ${dagID}`))
+      return wf(row)
+    })
+
     const control = Effect.fn("DagHttpApi.control")(function* (ctx: { params: { dagID: string }; payload: { operation: string; fragment?: unknown } }) {
       const { dagID } = ctx.params
       const op = ctx.payload.operation
@@ -137,13 +165,22 @@ export const dagHandlers = HttpApiBuilder.group(InstanceHttpApi, "dag", (handler
           return yield* Effect.fail(new InvalidRequestError({ message: "replan requires 'fragment' with a 'nodes' array" }))
         }
         const result = yield* mapTransitionConflict(dag.replan(dagID, fragment as { nodes: Dag.NodeConfig[] }))
-        return { status: "ok", ...result } as never
+        return { status: "ok", ...result }
+      }
+      if (op === "extend") {
+        const fragment = ctx.payload.fragment
+        if (!fragment || typeof fragment !== "object" || !Array.isArray((fragment as Record<string, unknown>).nodes)) {
+          return yield* Effect.fail(new InvalidRequestError({ message: "extend requires 'fragment' with a 'nodes' array" }))
+        }
+        const result = yield* mapTransitionConflict(dag.extend(dagID, (fragment as { nodes: Dag.NodeConfig[] }).nodes))
+        return { status: "ok", ...result }
       }
       return yield* Effect.fail(new InvalidRequestError({ message: `Unknown operation: ${op}` }))
     })
 
     return handlers
       .handle("list", list)
+      .handle("start", start)
       .handle("bySession", bySession)
       .handle("summary", summary)
       .handle("detail", detail)

--- a/packages/opencode/test/server/httpapi-exercise/index.ts
+++ b/packages/opencode/test/server/httpapi-exercise/index.ts
@@ -1849,6 +1849,31 @@ const scenarios: Scenario[] = [
     ),
 
   http.protected
+    .post("/dag", "dag.start")
+    .mutating()
+    .seeded((ctx) => ctx.session({ title: "DAG start owner" }))
+    .at((ctx) => ({
+      path: "/dag",
+      headers: ctx.headers(),
+      body: {
+        session_id: ctx.state.id,
+        title: "HTTP started workflow",
+        config: {
+          name: "http-start",
+          nodes: [{ id: "n1", name: "N1", worker_type: "general", depends_on: [], required: true, prompt_template: { inline: "noop" } }],
+        },
+      },
+    }))
+    .jsonEffect(200, (body) =>
+      Effect.sync(() => {
+        object(body)
+        check(typeof body.id === "string", "start should return the created workflow id")
+        check(body.title === "HTTP started workflow", "start should honor the provided title")
+        check(typeof body.status === "string", "start should return the workflow status")
+      }),
+    ),
+
+  http.protected
     .post("/dag/{dagID}/control", "dag.control")
     .mutating()
     .seeded((ctx) =>
@@ -1863,6 +1888,34 @@ const scenarios: Scenario[] = [
       Effect.sync(() => {
         object(body)
         check(body.status === "ok", "control pause should return ok")
+      }),
+    ),
+
+  http.protected
+    .post("/dag/{dagID}/control", "dag.control")
+    .mutating()
+    .seeded((ctx) =>
+      ctx.session({ title: "DAG extend owner" }).pipe(
+        Effect.flatMap((s) =>
+          ctx.dag({ sessionID: s.id, nodes: [{ id: "n1", name: "N1", worker_type: "general", depends_on: [], required: true }] }),
+        ),
+      ),
+    )
+    .at((ctx) => ({
+      path: route("/dag/{dagID}/control", { dagID: ctx.state.dagID }),
+      headers: ctx.headers(),
+      body: {
+        operation: "extend",
+        fragment: {
+          nodes: [{ id: "n2", name: "N2", worker_type: "general", depends_on: ["n1"], required: false, prompt_template: { inline: "noop" } }],
+        },
+      },
+    }))
+    .jsonEffect(200, (body) =>
+      Effect.sync(() => {
+        object(body)
+        check(body.status === "ok", "control extend should return ok")
+        check(Array.isArray(body.add) && body.add.includes("n2"), "extend should report the added node")
       }),
     ),
 

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -36,6 +36,8 @@ import type {
   DagNodeDetailResponses,
   DagNodesErrors,
   DagNodesResponses,
+  DagStartErrors,
+  DagStartResponses,
   DagSummaryErrors,
   DagSummaryResponses,
   EventSubscribeResponses,
@@ -5218,6 +5220,45 @@ export class Dag extends HeyApiClient {
   }
 
   /**
+   * Create and start a DAG workflow
+   */
+  public start<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+      session_id?: string
+      title?: string
+      config?: unknown
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "body", key: "session_id" },
+            { in: "body", key: "title" },
+            { in: "body", key: "config" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<DagStartResponses, DagStartErrors, ThrowOnError>({
+      url: "/dag",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+
+  /**
    * List workflows by session
    */
   public bySession<ThrowOnError extends boolean = false>(
@@ -5370,14 +5411,14 @@ export class Dag extends HeyApiClient {
   }
 
   /**
-   * Control a workflow (pause/resume/cancel/replan/step/complete)
+   * Control a workflow (pause/resume/cancel/replan/extend/step/complete)
    */
   public control<ThrowOnError extends boolean = false>(
     parameters: {
       dagID: string
       directory?: string
       workspace?: string
-      operation?: "pause" | "resume" | "cancel" | "replan" | "step" | "complete"
+      operation?: "pause" | "resume" | "cancel" | "replan" | "extend" | "step" | "complete"
       fragment?: unknown
     },
     options?: Options<never, ThrowOnError>,

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -3910,6 +3910,15 @@ export type DagNode = {
   completed_at?: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
 }
 
+export type DagControlResult = {
+  status: string
+  cancel?: Array<string>
+  restart?: Array<string>
+  replace?: Array<string>
+  add?: Array<string>
+  ignore?: Array<string>
+}
+
 export type LocationInfo = {
   directory: string
   workspaceID?: string
@@ -11527,6 +11536,46 @@ export type DagListResponses = {
 
 export type DagListResponse = DagListResponses[keyof DagListResponses]
 
+export type DagStartData = {
+  body?: {
+    session_id: string
+    title?: string
+    config: unknown
+  }
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/dag"
+}
+
+export type DagStartErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * NotFoundError
+   */
+  404: NotFoundError
+  /**
+   * ConflictError
+   */
+  409: ConflictError
+}
+
+export type DagStartError = DagStartErrors[keyof DagStartErrors]
+
+export type DagStartResponses = {
+  /**
+   * Created workflow
+   */
+  200: DagWorkflow
+}
+
+export type DagStartResponse = DagStartResponses[keyof DagStartResponses]
+
 export type DagBySessionData = {
   body?: never
   path: {
@@ -11700,7 +11749,7 @@ export type DagNodeDetailResponse = DagNodeDetailResponses[keyof DagNodeDetailRe
 
 export type DagControlData = {
   body?: {
-    operation: "pause" | "resume" | "cancel" | "replan" | "step" | "complete"
+    operation: "pause" | "resume" | "cancel" | "replan" | "extend" | "step" | "complete"
     fragment?: unknown
   }
   path: {
@@ -11732,11 +11781,9 @@ export type DagControlError = DagControlErrors[keyof DagControlErrors]
 
 export type DagControlResponses = {
   /**
-   * Control result
+   * Control result (replan/extend include the plan disposition)
    */
-  200: {
-    status: string
-  }
+  200: DagControlResult
 }
 
 export type DagControlResponse = DagControlResponses[keyof DagControlResponses]


### PR DESCRIPTION
# feat(dag): HTTP API start and extend routes

审计清单 C 批（P2-7），stacked 于 #122（`fix/dag-queued-permit`）。

## 关键变更

### 路由补齐
- **`POST /dag`（dag.start）**：HTTP 面创建并启动工作流，镜像工具面 `dag.create` 同一代码路径——config 校验（重复 id / dangling deps / condition 引用 / 节点上限）fail-fast 映射为 400，session 不存在 404。
- **`control(extend)`**：控制面新增 `extend` 操作，镜像 `Dag.extend` 追加语义；transition 冲突沿用 `mapTransitionConflict` → 409。

### Control 响应 schema 修正
- `DagControlResponse` 声明 replan/extend 的处置数组（cancel/restart/replace/add/ignore）——此前 success schema 只有 `{status}`，encoder 会静默剥掉处置结果；handler 同步去掉 `as never` 硬转。

### 门禁配套
- `httpapi-exercise` 补 `dag.start` 与 `control(extend)` happy-path 场景；三模式（coverage/auth/effect）全过：pass=217 fail=0 missing=0。
- SDK 再生成（`dag.start` 方法 + `DagStart*` 类型 + ControlResult shape），产物 diff 纯 additive。

## 验证
- typecheck：opencode/tui 均绿（tsgo --noEmit）
- 测试：opencode test/dag 232 全绿；tui 219 全绿
- `test:httpapi` 三模式 --fail-on-missing --fail-on-skip 全过
