### PR TITLE
feat(tui): DAG replan history, deadline countdown, queued presentation

### DIFF
--- a/docs/dag-bug-condition-skip-as-satisfied.md
+++ b/docs/dag-bug-condition-skip-as-satisfied.md
@@ -11,12 +11,12 @@
 | 编号 | 级别 | 标题 | 类型 |
 |------|------|------|------|
 | [P0-1](#p0-1) | P0 | condition_false 被当作 satisfied，门禁拒绝被下游完全无视 | 正确性（已实证） |
-| [P0-2](#p0-2) | P0 | max_concurrency 只限流 LLM 调用，子会话被急切创建，QUEUED 是死状态 | 正确性 + 性能 |
+| [P0-2](#p0-2) | P0 | max_concurrency 只限流 LLM 调用，子会话被急切创建，QUEUED 是死状态 | 正确性 + 性能（**已修复：PR #122 queued admission**） |
 | [P0-3](#p0-3) | P0 | 连续单步（step）是状态机死路 | 正确性 |
 | [P1-1](#p1-1) | P1 | create 不校验 depends_on 引用 / 重复节点 ID / max_total_nodes | 正确性 |
-| [P1-2](#p1-2) | P1 | sanitizer 破坏性替换损坏 diff/代码产出物，与 diff-review 契约矛盾 | 正确性 |
-| [P1-3](#p1-3) | P1 | spawnReady 每节点重复全量读，O(ready × nodes) 查询 | 性能 |
-| [P1-4](#p1-4) | P1 | getWorkflowSummaries JS 聚合 + 事件热路径前置查询 | 性能 |
+| [P1-2](#p1-2) | P1 | sanitizer 破坏性替换损坏 diff/代码产出物，与 diff-review 契约矛盾 | 正确性（**已修复：PR #121 字段级豁免**） |
+| [P1-3](#p1-3) | P1 | spawnReady 每节点重复全量读，O(ready × nodes) 查询 | 性能（**已修复：PR #121 快照复用**） |
+| [P1-4](#p1-4) | P1 | getWorkflowSummaries JS 聚合 + 事件热路径前置查询 | 性能（**已修复：PR #121 SQL 聚合**） |
 | [P1-5](#p1-5) | P1 | 失败节点无法通过 replan restart 重跑（必须换新 ID），工具描述未告知 | 使用陷阱 |
 | [P2-1](#p2-1) | P2 | required 节点失败 → 工作流终态是 cancelled 而非 failed | 语义 |
 | [P2-2](#p2-2) | P2 | 崩溃恢复对 running 节点一律判失败，required 级联即整流程报废 | 语义（**已修复：recovery-pause**） |
@@ -24,9 +24,9 @@
 | [P2-4](#p2-4) | P2 | 死代码/死状态：ViolationTable、ARCHIVED、NodeStatus.PAUSED/ABORTED | 清理 |
 | [P2-5](#p2-5) | P2 | inline 模板走临时文件写读删，spawn 热路径纯多余 I/O | 性能 |
 | [P2-6](#p2-6) | P2 | condition DSL 表达力不足，且只能引用直接依赖 | 场景 |
-| [P2-7](#p2-7) | P2 | HTTP API 不对称：无 start / extend | 场景 |
-| [P2-8](#p2-8) | P2 | TUI：Inspector 无滚动、列表截断与导航不一致、无 step 控制、配色两套 | UX |
-| [P2-9](#p2-9) | P2 | summary 进度不计 skipped，工作流"跑完了但分子不满" | UX |
+| [P2-7](#p2-7) | P2 | HTTP API 不对称：无 start / extend | 场景（**已修复：PR #123**） |
+| [P2-8](#p2-8) | P2 | TUI：Inspector 无滚动、列表截断与导航不一致、无 step 控制、配色两套 | UX（**已修复：PR #120 + #124 残余项**） |
+| [P2-9](#p2-9) | P2 | summary 进度不计 skipped，工作流"跑完了但分子不满" | UX（**已修复：PR #122 计数 + #124 展示**） |
 | [P2-10](#p2-10) | P2 | pause 语义（不停止在跑节点）无任何文档/UI 提示 | UX |
 
 ---
@@ -204,6 +204,8 @@ condition == false
 <a id="p0-2"></a>
 ## P0-2：max_concurrency 只限流 LLM 调用，子会话被急切创建，QUEUED 是死状态
 
+> **状态**：已修复（PR #122：durable `dag.node.queued` 事件 + 子会话/NodeStarted 移入 permit 内；deadline 仍从录取时刻起算；queued 崩溃重启按 pending 重新排队不计 ownershipLost）
+
 **位置**：`packages/opencode/src/dag/runtime/spawn.ts:97-156`、`loop.ts:79-230`
 
 `spawnReady` 对每个 ready 节点立即执行 `spawnNode`，而 `sessions.create`（L97）与 `NodeStarted` 事件发布（L119）都发生在 **semaphore 取许可之前**（L156 才 `take(1)`）。后果链：
@@ -251,6 +253,8 @@ condition == false
 <a id="p1-2"></a>
 ## P1-2：sanitizer 破坏性替换损坏 diff/代码产出物，与 diff-review 契约矛盾
 
+> **状态**：已修复（PR #121：`reviewEvidenceKeys` 推导的实现证据字段原文保留，`<implementation-evidence>` 定界包裹；其余字段防注入面不变）
+
 **位置**：`packages/opencode/src/dag/templates/sanitize.ts:16-28`、`loop.ts:130`
 
 `sanitize` 把所有 <code>```</code> 替换为 <code>``</code>、行首 `system:` 替换为 `[REDACTED]:`、`you are now a` 替换为 `[REDACTED]`，并作用于**所有上游节点输出**（`resolvedMapping = sanitizeInput(...)`）。而 `review-lifecycle.ts` 的 diff-review 契约**要求**下游收到真实的 diff/patch 工件——任何含 code fence 的 diff、含 "system:" 的日志都会被静默改写，**审查者审的是被篡改的补丁**。防注入与工件保真当前不可兼得。
@@ -265,6 +269,8 @@ condition == false
 <a id="p1-3"></a>
 ## P1-3：spawnReady 每节点重复全量读，O(ready × nodes) 查询
 
+> **状态**：已修复（PR #121：每轮调度一次 getNodes 快照；ready 节点依赖已终态、本轮内输出不可变）
+
 **位置**：`loop.ts:89`（condition 分支）、`loop.ts:111`（input_mapping 分支）
 
 每个 ready 节点最多两次 `store.getNodes(dagID)` 全表读，一轮调度 N 个 ready 节点 = 最多 2N 次全量查询。**修复**：每轮 `spawnReady` 开头读一次 nodes 快照并复用（condition 求值与 mapping 解析都只需要终态依赖的 output，快照一致性足够）。
@@ -273,6 +279,8 @@ condition == false
 
 <a id="p1-4"></a>
 ## P1-4：getWorkflowSummaries JS 聚合 + 事件热路径前置查询
+
+> **状态**：已修复（PR #121：GROUP BY 计数下沉 SQL；无 sessionID 事件的 getWorkflow 前置查询移入 dagID 级去抖动窗口之后）
 
 **位置**：`packages/core/src/dag/store.ts:226-257`、`summary-publisher.ts:104-120`
 
@@ -372,6 +380,8 @@ condition == false
 <a id="p2-7"></a>
 ## P2-7：HTTP API 不对称——无 start / extend
 
+> **状态**：已修复（PR #123：`POST /dag` start + `control(extend)`，同时修正 control 响应 schema 剥掉 replan/extend 处置数组的既有缺陷；SDK regen + exercise 场景门禁）
+
 **位置**：`server/routes/instance/httpapi/handlers/dag.ts`
 
 control 支持 pause/resume/cancel/complete/step/replan，但**无 extend、无 start**——外部系统无法通过 HTTP 发起或追加工作流，只能由 agent 工具面发起。若 HTTP 面定位为完整控制面，需补齐并同步 SDK 再生成（`./packages/sdk/js/script/build.ts`）与 `test/server/httpapi-exercise` 场景。
@@ -380,6 +390,8 @@ control 支持 pause/resume/cancel/complete/step/replan，但**无 extend、无 
 
 <a id="p2-8"></a>
 ## P2-8：TUI Inspector / 面板缺陷合集
+
+> **状态**：已修复（主体 PR #120 三界面对齐；残余 PR #124：restarted ×N 历史标注 / running·queued 节点 deadline 倒计时 / queued 专属 glyph 与计数）
 
 **位置**：`packages/tui/src/feature-plugins/system/dag-inspector.tsx`、`sidebar/dag-panel.tsx`
 
@@ -399,6 +411,8 @@ control 支持 pause/resume/cancel/complete/step/replan，但**无 extend、无 
 
 <a id="p2-9"></a>
 ## P2-9：summary 进度不计 skipped
+
+> **状态**：已修复（计数面 PR #122：summary 增加 skippedNodes/queuedNodes；展示面 PR #124：进度分子 = completed+skipped）
 
 **位置**：`store.ts:242-250`（只计 completed/running/failed）
 
@@ -450,7 +464,15 @@ final-audit 的结构化输出为：
 第三批（性能 + 清理 + UX）：
   P1-3 / P1-4 / P2-*
 
-已完成：P0-1 / P0-3 / P1-1 / P1-5（报错面）/ P2-1 / P2-2（recovery-pause）/ P2-3（验证关闭+契约测试）/ P2-4（violation 读面清理）/ P2-5 / P2-6（引用校验）/ P2-8（TUI 对齐）/ P2-10（文案）
+已完成（全部 16 项清零）：
+  PR #119：P0-1 / P0-3 / P1-1 / P1-5 / P2-1 / P2-2（recovery-pause）/ P2-3（验证关闭+契约测试）/ P2-4 / P2-5 / P2-6 / P2-10
+  PR #120：P2-8 主体（TUI 三界面对齐）
+  PR #121（B 批）：P1-2（sanitize 字段级豁免）/ P1-3（spawn 快照）/ P1-4（SQL 聚合 + 去抖动前置查询消除）
+  PR #122（A 批）：P0-2（durable queued 录取 + permit 内建会话）/ P2-9 计数面（skipped/queued 进 summary）
+  PR #123（C 批）：P2-7（HTTP start/extend + control 响应 schema 修正 + SDK regen）
+  PR #124（D 批）：P2-8 残余（restarted ×N 历史标注 / deadline 倒计时 / queued 呈现）+ P2-9 展示语义（completed+skipped 进度分母）
+
+合入顺序（stacked）：#119 → #121 → #122 → #123 → #124；#120 独立，于 #124 内已合流。
 ```
 
 ---

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/dag.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/dag.ts
@@ -39,6 +39,11 @@ export const NodeResponse = Schema.Struct({
   child_session_id: Schema.optional(Schema.String),
   output: Schema.optional(Schema.Unknown),
   error_reason: Schema.optional(Schema.String),
+  // Deadline (absolute epoch millis) fixed at admission; drives the running-
+  // node countdown in the TUI inspector (P2-8).
+  deadline_ms: Schema.optional(Schema.Number),
+  // Incremented by replan restart — surfaces "restarted ×N" history in the TUI.
+  replan_attempts: Schema.Number,
   started_at: Schema.optional(Schema.Number),
   completed_at: Schema.optional(Schema.Number),
 }).annotate({ identifier: "Dag.Node" })

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/dag.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/dag.ts
@@ -57,6 +57,8 @@ export const dagHandlers = HttpApiBuilder.group(InstanceHttpApi, "dag", (handler
       ...(r.childSessionId !== null ? { child_session_id: r.childSessionId } : {}),
       ...(r.output !== null ? { output: r.output } : {}),
       ...(r.errorReason !== null ? { error_reason: r.errorReason } : {}),
+      ...(r.deadlineMs !== null ? { deadline_ms: r.deadlineMs } : {}),
+      replan_attempts: r.replanAttempts,
       ...(r.startedAt !== null ? { started_at: r.startedAt } : {}),
       ...(r.completedAt !== null ? { completed_at: r.completedAt } : {}),
     })

--- a/packages/opencode/test/server/httpapi-exercise/index.ts
+++ b/packages/opencode/test/server/httpapi-exercise/index.ts
@@ -1828,6 +1828,7 @@ const scenarios: Scenario[] = [
         check(typeof n.id === "string", "node should have id")
         check(typeof n.status === "string", "node should have status")
         check(Array.isArray(n.depends_on), "node should have depends_on")
+        check(typeof n.replan_attempts === "number", "node should have replan_attempts")
       }),
     ),
 

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -3906,6 +3906,8 @@ export type DagNode = {
   child_session_id?: string
   output?: unknown
   error_reason?: string
+  deadline_ms?: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
+  replan_attempts: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
   started_at?: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
   completed_at?: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
 }

--- a/packages/tui/src/feature-plugins/sidebar/dag-panel.tsx
+++ b/packages/tui/src/feature-plugins/sidebar/dag-panel.tsx
@@ -4,7 +4,7 @@ import type { DagNode, DagWorkflowSummary } from "@opencode-ai/sdk/v2"
 import type { BuiltinTuiPlugin } from "../builtins"
 import { createEffect, createMemo, createSignal, For, Show } from "solid-js"
 import { Spinner } from "../../component/spinner"
-import { dagNodeGlyph, dagStatusColor } from "../system/dag-inspector-utils"
+import { dagNodeGlyph, dagStatusColor, formatDagProgress } from "../system/dag-inspector-utils"
 
 const id = "internal:sidebar-dag-panel"
 
@@ -24,8 +24,9 @@ function WorkflowRow(props: {
   const completed = () => Number(props.summary.completedNodes)
   const running = () => Number(props.summary.runningNodes)
   const failed = () => Number(props.summary.failedNodes)
+  const queued = () => Number(props.summary.queuedNodes)
 
-  const signature = () => `${total()}:${completed()}:${running()}:${failed()}`
+  const signature = () => `${total()}:${completed()}:${running()}:${failed()}:${queued()}`
 
   const fetchNodes = async (dagID: string, sig: string) => {
     try {
@@ -61,8 +62,9 @@ function WorkflowRow(props: {
         <text fg={theme().text} wrapMode="word">
           {props.summary.title}{" "}
           <span style={{ fg: theme().textMuted }}>
-            ({completed()}/{total()}
+            ({formatDagProgress(props.summary)}
             {running() > 0 ? `, ${running()} running` : ""}
+            {queued() > 0 ? `, ${queued()} queued` : ""}
             {failed() > 0 ? `, ${failed()} failed` : ""})
           </span>
         </text>

--- a/packages/tui/src/feature-plugins/system/dag-inspector-utils.ts
+++ b/packages/tui/src/feature-plugins/system/dag-inspector-utils.ts
@@ -87,6 +87,47 @@ export function formatDagOutputPreview(output: unknown, maxLength = 200): string
   return flat.length > maxLength ? `${flat.slice(0, maxLength)}…` : flat
 }
 
+/** Countdown to a node's absolute deadline — "3m 12s left" while budget
+ * remains, "overdue" past it. Only meaningful for nodes still executing
+ * (running/queued); terminal nodes yield no label. Tolerates the SDK's
+ * Infinity/NaN number sentinels. */
+export function formatDagDeadline(
+  status: string,
+  deadlineMs: number | string | undefined,
+  now = Date.now(),
+): string | undefined {
+  if (status !== "running" && status !== "queued") return undefined
+  if (typeof deadlineMs !== "number" || !Number.isFinite(deadlineMs)) return undefined
+  const remaining = deadlineMs - now
+  if (remaining <= 0) return "overdue"
+  const totalSeconds = Math.round(remaining / 1000)
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+  if (minutes === 0) return `${seconds}s left`
+  return `${minutes}m ${seconds}s left`
+}
+
+/** Replan history annotation — replan_attempts increments on replan restart,
+ * so any positive count means this execution replaced a failed attempt.
+ * Accepts the SDK's Infinity/NaN string sentinels (non-finite → no label). */
+export function dagNodeHistoryLabel(node: { replan_attempts: number | string }): string | undefined {
+  const attempts = Number(node.replan_attempts)
+  if (!Number.isFinite(attempts) || attempts <= 0) return undefined
+  return `restarted ×${attempts}`
+}
+
+/** Progress fraction counting completed+skipped as settled (P2-9): a skipped
+ * node is a legitimate terminal outcome (condition gates), so a gated
+ * workflow finishes at N/N instead of lying with a smaller numerator.
+ * Accepts the SDK's Infinity/NaN string sentinels (coerced via Number). */
+export function formatDagProgress(summary: {
+  nodeCount: number | string
+  completedNodes: number | string
+  skippedNodes: number | string
+}): string {
+  return `${Number(summary.completedNodes) + Number(summary.skippedNodes)}/${Number(summary.nodeCount)}`
+}
+
 /**
  * Shared status→color mapping for every DAG surface (sidebar indicator,
  * sidebar panel, inspector) so one status never renders in different colors
@@ -111,6 +152,7 @@ export function dagNodeGlyph(status: string): string {
   if (status === "completed") return "✓"
   if (status === "failed") return "✗"
   if (status === "skipped" || status === "cancelled" || status === "aborted") return "⊘"
+  if (status === "queued") return "◌"
   return "○"
 }
 

--- a/packages/tui/src/feature-plugins/system/dag-inspector.tsx
+++ b/packages/tui/src/feature-plugins/system/dag-inspector.tsx
@@ -12,10 +12,13 @@ import {
   dagControlProgressMessage,
   dagControlUnavailableMessage,
   dagNodeGlyph,
+  dagNodeHistoryLabel,
   dagStatusColor,
+  formatDagDeadline,
   formatDagDuration,
   formatDagError,
   formatDagOutputPreview,
+  formatDagProgress,
   type DagControlOperation,
   type DagNode,
 } from "./dag-inspector-utils"
@@ -347,6 +350,16 @@ function DagInspector(props: { api: TuiPluginApi }) {
   const selectedWorkflowSummary = createMemo(() => workflows().find((workflow) => workflow.id === selectedWorkflow()))
   const selectedNodeDetail = createMemo(() => orderedNodes().find((node) => node.id === selectedNode()))
 
+  // 1s tick driving the running-node deadline countdown. Only active while the
+  // selected node is actually counting down — idle inspectors don't re-render.
+  const [now, setNow] = createSignal(Date.now())
+  createEffect(() => {
+    const detail = selectedNodeDetail()
+    if (!detail || (detail.status !== "running" && detail.status !== "queued")) return
+    const timer = setInterval(() => setNow(Date.now()), 1000)
+    onCleanup(() => clearInterval(timer))
+  })
+
   const statusColor = (status: string) => dagStatusColor(theme(), status)
 
   return (
@@ -409,7 +422,7 @@ function DagInspector(props: { api: TuiPluginApi }) {
                               </text>
                             </box>
                             <text fg={selected() ? theme().background : theme().textMuted} flexShrink={0}>
-                              {Number(wf.completedNodes)}/{Number(wf.nodeCount)}
+                              {formatDagProgress(wf)}
                             </text>
                           </box>
                         )
@@ -512,7 +525,15 @@ function DagInspector(props: { api: TuiPluginApi }) {
                             {formatDagDuration(node().started_at, node().completed_at)
                               ? ` · ${formatDagDuration(node().started_at, node().completed_at)}`
                               : ""}
+                            {dagNodeHistoryLabel(node()) ? ` · ${dagNodeHistoryLabel(node())}` : ""}
                           </text>
+                          <Show when={formatDagDeadline(node().status, node().deadline_ms, now())}>
+                            {(deadline) => (
+                              <text fg={deadline() === "overdue" ? theme().error : theme().warning} wrapMode="none">
+                                {deadline()}
+                              </text>
+                            )}
+                          </Show>
                         </box>
                         <Show when={node().depends_on.length > 0}>
                           <text fg={theme().textMuted} wrapMode="none">

--- a/packages/tui/test/feature-plugins/dag-inspector-utils.test.ts
+++ b/packages/tui/test/feature-plugins/dag-inspector-utils.test.ts
@@ -5,10 +5,13 @@ import {
   dagControlProgressMessage,
   dagControlUnavailableMessage,
   dagNodeGlyph,
+  dagNodeHistoryLabel,
   dagStatusColor,
+  formatDagDeadline,
   formatDagDuration,
   formatDagError,
   formatDagOutputPreview,
+  formatDagProgress,
   type DagNode,
 } from "../../src/feature-plugins/system/dag-inspector-utils"
 
@@ -20,6 +23,7 @@ const node = (id: string, depends_on: string[] = [], name = id): DagNode => ({
   worker_type: "task",
   required: false,
   depends_on,
+  replan_attempts: 0,
 })
 
 describe("computeWaves", () => {
@@ -131,6 +135,7 @@ describe("shared status presentation", () => {
     expect(dagNodeGlyph("completed")).toBe("✓")
     expect(dagNodeGlyph("failed")).toBe("✗")
     expect(dagNodeGlyph("skipped")).toBe("⊘")
+    expect(dagNodeGlyph("queued")).toBe("◌")
     expect(dagNodeGlyph("pending")).toBe("○")
   })
 })
@@ -149,5 +154,25 @@ describe("node detail formatting", () => {
     expect(formatDagOutputPreview(null)).toBeUndefined()
     expect(formatDagOutputPreview("   ")).toBeUndefined()
     expect(formatDagOutputPreview("x".repeat(300))?.length).toBe(201)
+  })
+
+  test("deadline countdown only labels nodes still executing", () => {
+    expect(formatDagDeadline("running", 63_000, 1_000)).toBe("1m 2s left")
+    expect(formatDagDeadline("queued", 5_000, 1_000)).toBe("4s left")
+    expect(formatDagDeadline("running", 1_000, 5_000)).toBe("overdue")
+    expect(formatDagDeadline("completed", 63_000, 1_000)).toBeUndefined()
+    expect(formatDagDeadline("running", undefined, 1_000)).toBeUndefined()
+    expect(formatDagDeadline("running", "Infinity", 1_000)).toBeUndefined()
+  })
+
+  test("replan history label appears only after a restart", () => {
+    expect(dagNodeHistoryLabel({ replan_attempts: 0 })).toBeUndefined()
+    expect(dagNodeHistoryLabel({ replan_attempts: 1 })).toBe("restarted ×1")
+    expect(dagNodeHistoryLabel({ replan_attempts: 3 })).toBe("restarted ×3")
+  })
+
+  test("progress counts completed+skipped as settled (P2-9)", () => {
+    expect(formatDagProgress({ nodeCount: 9, completedNodes: 3, skippedNodes: 4 })).toBe("7/9")
+    expect(formatDagProgress({ nodeCount: 2, completedNodes: 0, skippedNodes: 0 })).toBe("0/2")
   })
 })

--- a/packages/tui/test/feature-plugins/dag-inspector.test.tsx
+++ b/packages/tui/test/feature-plugins/dag-inspector.test.tsx
@@ -45,6 +45,7 @@ function dagNode(overrides: Partial<DagNode> & { id: string }): DagNode {
     worker_type: "build",
     required: false,
     depends_on: [],
+    replan_attempts: 0,
     ...overrides,
   }
 }


### PR DESCRIPTION
# feat(tui): DAG replan history, deadline countdown, queued presentation

审计清单 D 批（P2-8 残余 + P2-9 展示语义），stacked 于 #123（`feat/dag-http-control`），并合流了 #120（`fix/tui-dag-alignment`）。**#120 与前置栈合入 dev 后本 PR diff 收敛为 D 批增量。**

## 关键变更

### 数据面（HTTP API + SDK）
- `NodeResponse` 透出 `deadline_ms`（录取时刻固定的绝对期限）与 `replan_attempts`（replan restart 递增计数）——数据一直在 NodeRow，此前 HTTP 面未透出。
- SDK regen（2 行 additive）；`httpapi-exercise` 的 nodes 场景补 `replan_attempts` 断言（shape 变更门禁）。

### Inspector（`dag-inspector.tsx`）
- 详情区新增 **deadline 倒计时**：running/queued 节点显示 "Nm Ns left"（超期转 `overdue` 红色）；1s tick 仅在选中节点确实在倒计时时激活，空闲 inspector 不重渲染。
- 详情区新增 **replan 历史标注**：`restarted ×N`（replan_attempts > 0 时）。
- 左列进度改 `formatDagProgress`（P2-9：completed+skipped 计入已定案，门禁跳过的工作流收尾时不再显示 "3/9" 假分母）。

### 侧栏（`dag-panel.tsx`）
- 进度分数同步 P2-9 语义；新增 `N queued` 计数（permit 排队与真 running 区分）；signature 加入 queued 维度触发节点重取。

### 共享呈现层（`dag-inspector-utils.ts`）
- 新增纯函数 `formatDagDeadline` / `dagNodeHistoryLabel` / `formatDagProgress`（均容忍 SDK Infinity/NaN 哨兵）；`dagNodeGlyph` 加 queued 专属 `◌`。

## 验证
- typecheck：tui/opencode 均绿（tsgo --noEmit）
- 测试：tui 228 全绿（新增 deadline/history/progress/glyph 单测）；opencode test/dag 232 全绿
- `test:httpapi` 三模式全过（pass=217 fail=0 missing=0）
