### PR TITLE
test(dag): persist bootstrap recovery fixture instead of dag.create

### DIFF
--- a/packages/opencode/test/project/bootstrap-dag-wiring.test.ts
+++ b/packages/opencode/test/project/bootstrap-dag-wiring.test.ts
@@ -5,6 +5,8 @@ import { InstanceStore } from "@/project/instance-store"
 import { Project } from "@/project/project"
 import { Session } from "@/session/session"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { Database } from "@opencode-ai/core/database/database"
+import { WorkflowNodeTable, WorkflowTable } from "@opencode-ai/core/dag/sql"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { SessionProjector } from "@opencode-ai/core/session/projector"
 import { Effect, Layer } from "effect"
@@ -12,7 +14,7 @@ import { tmpdirScoped } from "../fixture/fixture"
 import { pollWithTimeout, testEffect } from "../lib/effect"
 
 const appLayer = LayerNode.buildLayer(
-  LayerNode.group([InstanceStore.node, Dag.node, Project.node, Session.node, SessionProjector.node]),
+  LayerNode.group([InstanceStore.node, Dag.node, Project.node, Session.node, SessionProjector.node, Database.node]),
 )
 const appIt = testEffect(Layer.mergeAll(appLayer, CrossSpawnSpawner.defaultLayer))
 
@@ -21,12 +23,13 @@ describe("instance bootstrap DAG wiring", () => {
     Effect.gen(function* () {
       const directory = yield* tmpdirScoped({ git: true })
       const instances = yield* InstanceStore.Service
-      const workflowID = yield* instances.provide(
+      const workflowID = "dag_bootstrap_recovery"
+      yield* instances.provide(
         { directory },
         Effect.gen(function* () {
           const context = yield* InstanceState.context
           const session = yield* Session.Service
-          const dag = yield* Dag.Service
+          const database = yield* Database.Service
           const parent = yield* session.create({ title: "bootstrap DAG wiring" })
           yield* pollWithTimeout(
             session.get(parent.id).pipe(
@@ -35,25 +38,81 @@ describe("instance bootstrap DAG wiring", () => {
             ),
             "session projection did not become visible",
           )
-          return yield* dag.create({
-            projectID: context.project.id,
-            sessionID: parent.id,
-            title: "condition false",
-            config: {
-              name: "condition false",
-              nodes: [
-                {
-                  id: "skip",
-                  name: "skip without a model call",
-                  worker_type: "reviewer",
-                  depends_on: [],
-                  required: true,
-                  prompt_template: { inline: "unused" },
-                  condition: "missing == true",
-                },
-              ],
-            },
-          })
+          // Persist a mid-flight workflow directly: a completed gate plus a
+          // pending conditional that evaluates false against the gate's output.
+          // dag.create would have to run the gate through a real provider to
+          // reach this state; recovery only needs the durable rows (same
+          // fixture shape as dag-wake-integration's recovery scenario).
+          yield* database.db
+            .transaction((tx) =>
+              Effect.gen(function* () {
+                yield* tx
+                  .insert(WorkflowTable)
+                  .values({
+                    id: workflowID,
+                    project_id: context.project.id as never,
+                    session_id: parent.id as never,
+                    title: "condition false",
+                    status: "running",
+                    config: JSON.stringify({
+                      name: "condition false",
+                      nodes: [
+                        {
+                          id: "gate",
+                          name: "gate",
+                          worker_type: "build",
+                          depends_on: [],
+                          required: true,
+                          prompt_template: { inline: "gate" },
+                        },
+                        {
+                          id: "skip",
+                          name: "skip without a model call",
+                          worker_type: "reviewer",
+                          depends_on: ["gate"],
+                          required: true,
+                          prompt_template: { inline: "unused" },
+                          condition: 'gate.output == "ACCEPT"',
+                        },
+                      ],
+                    }),
+                    seq: 2,
+                    wake_reported: false,
+                  })
+                  .run()
+                yield* tx
+                  .insert(WorkflowNodeTable)
+                  .values([
+                    {
+                      id: "gate",
+                      workflow_id: workflowID,
+                      name: "gate",
+                      worker_type: "build",
+                      status: "completed",
+                      required: true,
+                      depends_on: [],
+                      output: "REJECT",
+                      wake_eligible: false,
+                      wake_reported: false,
+                      seq: 2,
+                    },
+                    {
+                      id: "skip",
+                      workflow_id: workflowID,
+                      name: "skip without a model call",
+                      worker_type: "reviewer",
+                      status: "pending",
+                      required: true,
+                      depends_on: ["gate"],
+                      wake_eligible: false,
+                      wake_reported: false,
+                      seq: 1,
+                    },
+                  ])
+                  .run()
+              }),
+            )
+            .pipe(Effect.orDie)
         }),
       )
       yield* instances.reload({ directory })
@@ -64,9 +123,9 @@ describe("instance bootstrap DAG wiring", () => {
           const result = yield* pollWithTimeout(
             Effect.gen(function* () {
               const workflow = yield* dag.store.getWorkflow(workflowID)
-              const nodes = yield* dag.store.getNodes(workflowID)
-              if (workflow?.status !== "completed" || nodes[0]?.status !== "skipped") return
-              return { workflow, node: nodes[0] }
+              const skipped = (yield* dag.store.getNodes(workflowID)).find((n) => n.id === "skip")
+              if (workflow?.status !== "completed" || skipped?.status !== "skipped") return
+              return { workflow, node: skipped }
             }),
             "bootstrap did not start the DAG scheduler",
             "1 second",


### PR DESCRIPTION
## Why

`bootstrap-dag-wiring.test.ts` broke on `dev` after #119 merged: its fixture was a root node whose condition referenced a node outside `depends_on` — exactly the shape the new create-time validation rejects. The failure shows up in the dev full-test runs (Unit Tests linux) as `Invalid workflow config: node "skip" condition references "missing"...`.

A root node cannot carry a reference condition without a dependency, and adding a real dependency would force a provider call — so `dag.create` cannot reach the intended state at all under the new semantics.

## What

- Persist a mid-flight workflow directly (completed `gate` with output `REJECT` + pending conditional `skip`), mirroring the recovery fixture in `dag-wake-integration.test.ts`.
- Bootstrap then evaluates the condition against the durable rows: `skip` → skipped, workflow → completed. Same assertions as before.
- Expose `Database.node` in the test's LayerNode group (deduped with the instance graph's own node) so the fixture rows go into the same DB.

## Verification

- `tsgo --noEmit` green in packages/opencode
- `bun test test/project/bootstrap-dag-wiring.test.ts` → 1 pass