### PR TITLE
fix(tui): stabilize dag inspector layout and contextual footer

### DIFF
--- a/packages/tui/src/feature-plugins/system/dag-inspector-utils.ts
+++ b/packages/tui/src/feature-plugins/system/dag-inspector-utils.ts
@@ -158,16 +158,17 @@ export function dagNodeGlyph(status: string): string {
 
 export type DagControlOperation = "pause" | "resume" | "cancel" | "step"
 
+/** Whether a control operation applies to the workflow's current status.
+ * Shared by keybinding feedback and the footer's contextual hints so the
+ * hint bar never advertises an operation that would only produce a toast. */
+export function dagControlAllowed(status: string | undefined, operation: DagControlOperation): boolean {
+  if (operation === "pause" || operation === "step") return status === "running" || status === "stepping"
+  if (operation === "resume") return status === "paused" || status === "stepping"
+  return status === "running" || status === "stepping" || status === "paused"
+}
+
 export function dagControlUnavailableMessage(status: string | undefined, operation: DagControlOperation) {
-  const allowed =
-    operation === "pause"
-      ? status === "running" || status === "stepping"
-      : operation === "resume"
-        ? status === "paused" || status === "stepping"
-        : operation === "step"
-          ? status === "running" || status === "stepping"
-          : status === "running" || status === "stepping" || status === "paused"
-  if (allowed) return undefined
+  if (dagControlAllowed(status, operation)) return undefined
   const action =
     operation === "pause" ? "paused" : operation === "resume" ? "resumed" : operation === "step" ? "stepped" : "cancelled"
   return `Workflow is ${status ?? "unavailable"} and cannot be ${action}`

--- a/packages/tui/src/feature-plugins/system/dag-inspector.tsx
+++ b/packages/tui/src/feature-plugins/system/dag-inspector.tsx
@@ -9,6 +9,7 @@ import { Panel, PanelGroup, Separator } from "./diff-viewer-ui"
 import {
   computeNodeRowIndex,
   computeWaves,
+  dagControlAllowed,
   dagControlProgressMessage,
   dagControlUnavailableMessage,
   dagNodeGlyph,
@@ -27,6 +28,9 @@ import type { DagWorkflowSummary } from "@opencode-ai/sdk/v2"
 const id = "internal:system-dag-inspector"
 const ROUTE = "dag"
 const WORKFLOW_LIST_WIDTH = 32
+// Node detail rows below the wave list: header, dependencies, error/output
+// preview. Fixed so changing the selection never moves the footer.
+const NODE_DETAIL_HEIGHT = 3
 
 function scrollRowIntoView(scroll: ScrollBoxRenderable | undefined, index: number) {
   if (!scroll) return
@@ -350,6 +354,21 @@ function DagInspector(props: { api: TuiPluginApi }) {
   const selectedWorkflowSummary = createMemo(() => workflows().find((workflow) => workflow.id === selectedWorkflow()))
   const selectedNodeDetail = createMemo(() => orderedNodes().find((node) => node.id === selectedNode()))
 
+  // Footer hints mirror the diff-viewer's `key label` vocabulary. Control
+  // hints are contextual: only operations valid for the selected workflow's
+  // status appear, so pause/resume never advertise a guaranteed no-op.
+  const footerHints = createMemo(() => {
+    const status = selectedWorkflowSummary()?.status
+    return [
+      { key: enterShortcut(), label: "open session", show: true },
+      { key: pauseShortcut(), label: "pause", show: dagControlAllowed(status, "pause") },
+      { key: resumeShortcut(), label: "resume", show: dagControlAllowed(status, "resume") },
+      { key: stepShortcut(), label: "step", show: dagControlAllowed(status, "step") },
+      { key: cancelShortcut(), label: "cancel", show: dagControlAllowed(status, "cancel") },
+      { key: closeShortcut(), label: "close", show: true },
+    ].filter((hint) => hint.show && hint.key !== "")
+  })
+
   // 1s tick driving the running-node deadline countdown. Only active while the
   // selected node is actually counting down — idle inspectors don't re-render.
   const [now, setNow] = createSignal(Date.now())
@@ -486,7 +505,7 @@ function DagInspector(props: { api: TuiPluginApi }) {
                                       {dagNodeGlyph(node.status)}
                                     </text>
                                   </Show>
-                                  <box flexGrow={1} minWidth={0}>
+                                  <box flexShrink={1} minWidth={0}>
                                     <text
                                       fg={
                                         selected()
@@ -500,7 +519,11 @@ function DagInspector(props: { api: TuiPluginApi }) {
                                       {node.name}
                                     </text>
                                   </box>
-                                  <text fg={selected() ? theme().background : theme().textMuted} flexShrink={0}>
+                                  <text
+                                    fg={selected() ? theme().background : theme().textMuted}
+                                    wrapMode="none"
+                                    flexShrink={0}
+                                  >
                                     {node.worker_type}
                                   </text>
                                 </box>
@@ -512,49 +535,54 @@ function DagInspector(props: { api: TuiPluginApi }) {
                     </For>
                   </scrollbox>
                   <Separator axis="x" start="edge-in" />
-                  <Show when={selectedNodeDetail()}>
-                    {(node) => (
-                      <box flexDirection="column" paddingLeft={1} flexShrink={0}>
-                        <box flexDirection="row" gap={1}>
-                          <text fg={theme().text} wrapMode="none">
-                            {node().name}
-                          </text>
-                          <text fg={theme().textMuted} wrapMode="none">
-                            {node().worker_type}
-                            {node().model_id ? ` · ${node().model_id}` : ""}
-                            {formatDagDuration(node().started_at, node().completed_at)
-                              ? ` · ${formatDagDuration(node().started_at, node().completed_at)}`
-                              : ""}
-                            {dagNodeHistoryLabel(node()) ? ` · ${dagNodeHistoryLabel(node())}` : ""}
-                          </text>
-                          <Show when={formatDagDeadline(node().status, node().deadline_ms, now())}>
-                            {(deadline) => (
-                              <text fg={deadline() === "overdue" ? theme().error : theme().warning} wrapMode="none">
-                                {deadline()}
-                              </text>
-                            )}
+                  <box flexDirection="column" paddingLeft={1} flexShrink={0} height={NODE_DETAIL_HEIGHT}>
+                    <Show when={selectedNodeDetail()}>
+                      {(node) => (
+                        <>
+                          <box flexDirection="row" gap={1}>
+                            <text fg={theme().text} wrapMode="none" flexShrink={0}>
+                              {node().name}
+                            </text>
+                            <text fg={theme().textMuted} wrapMode="none">
+                              {node().worker_type}
+                              {node().model_id ? ` · ${node().model_id}` : ""}
+                              {formatDagDuration(node().started_at, node().completed_at)
+                                ? ` · ${formatDagDuration(node().started_at, node().completed_at)}`
+                                : ""}
+                              {dagNodeHistoryLabel(node()) ? ` · ${dagNodeHistoryLabel(node())}` : ""}
+                            </text>
+                            <Show when={formatDagDeadline(node().status, node().deadline_ms, now())}>
+                              {(deadline) => (
+                                <text wrapMode="none" flexShrink={0}>
+                                  <span style={{ fg: theme().textMuted }}>·</span>{" "}
+                                  <span style={{ fg: deadline() === "overdue" ? theme().error : theme().warning }}>
+                                    {deadline()}
+                                  </span>
+                                </text>
+                              )}
+                            </Show>
+                          </box>
+                          <Show when={node().depends_on.length > 0}>
+                            <text fg={theme().textMuted} wrapMode="none">
+                              depends on {node().depends_on.join(", ")}
+                            </text>
                           </Show>
-                        </box>
-                        <Show when={node().depends_on.length > 0}>
-                          <text fg={theme().textMuted} wrapMode="none">
-                            depends on {node().depends_on.join(", ")}
-                          </text>
-                        </Show>
-                        <Switch>
-                          <Match when={node().error_reason}>
-                            <text fg={theme().error} wrapMode="word">
-                              {formatDagError(node().error_reason!)}
-                            </text>
-                          </Match>
-                          <Match when={formatDagOutputPreview(node().output)}>
-                            <text fg={theme().textMuted} wrapMode="word">
-                              {formatDagOutputPreview(node().output)}
-                            </text>
-                          </Match>
-                        </Switch>
-                      </box>
-                    )}
-                  </Show>
+                          <Switch>
+                            <Match when={node().error_reason}>
+                              <text fg={theme().error} wrapMode="none">
+                                {formatDagError(node().error_reason!)}
+                              </text>
+                            </Match>
+                            <Match when={formatDagOutputPreview(node().output)}>
+                              <text fg={theme().textMuted} wrapMode="none">
+                                {formatDagOutputPreview(node().output)}
+                              </text>
+                            </Match>
+                          </Switch>
+                        </>
+                      )}
+                    </Show>
+                  </box>
                 </Panel>
               </PanelGroup>
             </Match>
@@ -562,48 +590,13 @@ function DagInspector(props: { api: TuiPluginApi }) {
         </box>
 
         <Panel flexShrink={0} gap={2} paddingLeft={1} border="none">
-          <Show when={enterShortcut()}>
-            {(shortcut) => (
+          <For each={footerHints()}>
+            {(hint) => (
               <text fg={theme().text}>
-                {shortcut()} <span style={{ fg: theme().textMuted }}>open session</span>
+                {hint.key} <span style={{ fg: theme().textMuted }}>{hint.label}</span>
               </text>
             )}
-          </Show>
-          <Show when={pauseShortcut()}>
-            {(shortcut) => (
-              <text fg={theme().text}>
-                {shortcut()} <span style={{ fg: theme().textMuted }}>pause</span>
-              </text>
-            )}
-          </Show>
-          <Show when={resumeShortcut()}>
-            {(shortcut) => (
-              <text fg={theme().text}>
-                {shortcut()} <span style={{ fg: theme().textMuted }}>resume</span>
-              </text>
-            )}
-          </Show>
-          <Show when={stepShortcut()}>
-            {(shortcut) => (
-              <text fg={theme().text}>
-                {shortcut()} <span style={{ fg: theme().textMuted }}>step</span>
-              </text>
-            )}
-          </Show>
-          <Show when={cancelShortcut()}>
-            {(shortcut) => (
-              <text fg={theme().text}>
-                {shortcut()} <span style={{ fg: theme().textMuted }}>cancel</span>
-              </text>
-            )}
-          </Show>
-          <Show when={closeShortcut()}>
-            {(shortcut) => (
-              <text fg={theme().text}>
-                {shortcut()} <span style={{ fg: theme().textMuted }}>close</span>
-              </text>
-            )}
-          </Show>
+          </For>
         </Panel>
       </PanelGroup>
     </box>

--- a/packages/tui/test/feature-plugins/dag-inspector-utils.test.ts
+++ b/packages/tui/test/feature-plugins/dag-inspector-utils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test"
 import {
   computeNodeRowIndex,
   computeWaves,
+  dagControlAllowed,
   dagControlProgressMessage,
   dagControlUnavailableMessage,
   dagNodeGlyph,
@@ -103,6 +104,16 @@ describe("DAG control state", () => {
     expect(dagControlUnavailableMessage("stepping", "step")).toBeUndefined()
     expect(dagControlUnavailableMessage("paused", "step")).toBe("Workflow is paused and cannot be stepped")
     expect(dagControlProgressMessage("step")).toBe("Stepping workflow...")
+  })
+
+  test("dagControlAllowed mirrors the unavailable-message predicate", () => {
+    expect(dagControlAllowed("running", "pause")).toBe(true)
+    expect(dagControlAllowed("paused", "pause")).toBe(false)
+    expect(dagControlAllowed("paused", "resume")).toBe(true)
+    expect(dagControlAllowed("running", "resume")).toBe(false)
+    expect(dagControlAllowed("paused", "cancel")).toBe(true)
+    expect(dagControlAllowed("completed", "cancel")).toBe(false)
+    expect(dagControlAllowed(undefined, "pause")).toBe(false)
   })
 })
 

--- a/packages/tui/test/feature-plugins/dag-inspector.test.tsx
+++ b/packages/tui/test/feature-plugins/dag-inspector.test.tsx
@@ -528,4 +528,59 @@ describe("DagInspector", () => {
       viewer.app.renderer.destroy()
     }
   })
+
+  test("node rows render the worker type inline next to the name", async () => {
+    const viewer = await renderDagInspector({
+      workflows: [wfSummary({ id: "wf-1", nodeCount: 1 })],
+      nodes: [dagNode({ id: "n-1", name: "compile", worker_type: "review", status: "pending" })],
+    })
+    try {
+      await viewer.app.waitForFrame((frame) => frame.includes("compile review"))
+    } finally {
+      viewer.app.renderer.destroy()
+    }
+  })
+
+  test("footer only advertises controls valid for the workflow status", async () => {
+    const viewer = await renderDagInspector({
+      workflows: [wfSummary({ id: "wf-1", status: "paused" })],
+      nodes: [dagNode({ id: "n-1", name: "build", status: "pending" })],
+    })
+    try {
+      await viewer.app.waitForFrame((frame) => {
+        const footer = frame.split("\n").find((row) => row.includes("open session"))
+        if (!footer) return false
+        return (
+          footer.includes("resume") && footer.includes("cancel") && !footer.includes("pause") && !footer.includes("step")
+        )
+      })
+    } finally {
+      viewer.app.renderer.destroy()
+    }
+  })
+
+  test("footer row stays fixed while node selection changes detail content", async () => {
+    const viewer = await renderDagInspector({
+      workflows: [wfSummary({ id: "wf-1", nodeCount: 2, failedNodes: 1 })],
+      nodes: [
+        dagNode({ id: "a", name: "bare", status: "pending" }),
+        dagNode({ id: "b", name: "detailed", status: "failed", depends_on: ["a"], error_reason: "boom" }),
+      ],
+    })
+    try {
+      const footerRow = (frame: string) => frame.split("\n").findIndex((row) => row.includes("open session"))
+      let before = -1
+      // Selection starts on "bare" (header-only detail).
+      await viewer.app.waitForFrame((frame) => {
+        before = footerRow(frame)
+        return before >= 0 && frame.includes("bare")
+      })
+      // Moving to "detailed" adds dependency and error rows to the detail
+      // pane; the fixed-height pane must keep the footer on the same row.
+      viewer.commands.get("dag.down")!.run?.({} as never)
+      await viewer.app.waitForFrame((frame) => frame.includes("boom") && footerRow(frame) === before)
+    } finally {
+      viewer.app.renderer.destroy()
+    }
+  })
 })


### PR DESCRIPTION
## Summary

Fixes three UI issues in the `/dag` inspector reported from a wide (360-col) terminal, and tidies the code toward the diff-viewer reference patterns.

- **Node rows**: `worker_type` was pushed to the far right edge of the wide node panel by a flex spring, appearing orphaned/clipped next to the scrollbar. It now renders inline next to the node name in muted color (`✓ scope-discovery explore`), matching the detail header and sidebar dag-panel vocabulary. Long names truncate before pushing the worker type off-screen.
- **Detail pane jitter**: the pane height varied 1–5 rows with selection (deps row, error/output row, word-wrap), moving the footer up/down. It is now fixed at 3 single-line rows (`NODE_DETAIL_HEIGHT`), so the footer never moves. The deadline countdown is also separated from the duration with a muted dot (`explore · 1m 9s · 8m 48s left`).
- **Footer hints**: all six hints rendered unconditionally (pause and resume simultaneously). Control hints are now contextual via a new `dagControlAllowed` predicate shared with `dagControlUnavailableMessage`, so the bar only advertises operations valid for the selected workflow status; hidden operations still toast an explanation when pressed. The six repeated `<Show>` blocks collapsed into one memo + `<For>`.

## Testing

From `packages/tui`:
- `tsgo --noEmit` clean
- `bun test test/feature-plugins/dag-inspector-utils.test.ts test/feature-plugins/dag-inspector.test.tsx`: **41 pass / 0 fail**, including 4 new regression tests (predicate parity, inline worker type, contextual footer on paused workflow, fixed footer row across selection changes)