### PR TITLE
chore(ci): bound and trace the httpapi exerciser gate

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -122,7 +122,16 @@ jobs:
       - name: Run HttpAPI Exerciser Gates
         if: runner.os == 'Linux'
         working-directory: packages/opencode
-        run: bun run test:httpapi
+        # The exerciser aggregates its report and prints it in one flush, so
+        # this step is silent while it runs. A latent uninterruptible hang
+        # (bare Effect.promise in scenario call/cleanup paths that the 30s
+        # scenario timeout cannot interrupt) froze the effect mode twice on
+        # 2026-07-27 — with no step timeout that occupies the runner for the
+        # default 6h. The full gate baseline is ~6m in CI, so 15m is generous;
+        # test:httpapi:ci adds --progress/--trace to effect mode so the log
+        # names the exact scenario and phase if it ever hangs again.
+        timeout-minutes: 15
+        run: bun run test:httpapi:ci
 
   e2e-tests:
     name: E2E Tests (${{ matrix.settings.name }})

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -9,6 +9,7 @@
     "typecheck": "tsgo --noEmit",
     "test": "bun test --timeout 30000 --only-failures",
     "test:httpapi": "bun run script/httpapi-exercise.ts --mode coverage --fail-on-missing --fail-on-skip && bun run script/httpapi-exercise.ts --mode auth --fail-on-missing --fail-on-skip && bun run script/httpapi-exercise.ts --mode effect --fail-on-missing --fail-on-skip",
+    "test:httpapi:ci": "bun run script/httpapi-exercise.ts --mode coverage --fail-on-missing --fail-on-skip && bun run script/httpapi-exercise.ts --mode auth --fail-on-missing --fail-on-skip && bun run script/httpapi-exercise.ts --mode effect --fail-on-missing --fail-on-skip --progress --trace",
     "bench:test": "bun run script/bench-test-suite.ts",
     "profile:test": "bun run script/profile-test-files.ts",
     "build": "bun run script/build.ts",


### PR DESCRIPTION
## Summary

Hardens the `Run HttpAPI Exerciser Gates` step after the effect mode hung twice on 2026-07-27 (dev push `d7a2496` + its rerun), silent for 55m/16m before manual cancel — on identical code (the only diff vs the last green run was TUI-only #127) and the identical runner image (ubuntu-24.04 `20260720.247.2`). All three modes pass locally in ~2m40s on the same commit (4/4 runs).

Root cause of the *symptom* (why a hang is silent and unbounded):
- The exerciser aggregates its report and prints it in one flush, so the step produces zero output while running — no way to tell which scenario is stuck.
- The 30s `scenarioTimeout` (`Effect.timeoutOrElse`) cannot interrupt bare `Effect.promise` regions in the scenario call/cleanup paths (`backend.ts` `call()`, `resetState` dispose chain), so one wedged promise hangs the process forever.
- The step had no `timeout-minutes`, so a hang occupies the runner for the default 6h.

## Changes

- `ci-test.yml`: `timeout-minutes: 15` on the gate step (~2.5x the 6m CI baseline) + incident comment.
- `packages/opencode/package.json`: new `test:httpapi:ci` script — same three gates, with `--progress --trace` on effect mode so the next hang's log names the exact scenario and phase (`RUN …` / `[trace] name: phase`). Local `test:httpapi` output stays clean.

Interruptibility fixes in the harness itself are deliberately out of scope until a traced hang identifies the wedged promise.

## Testing

- `bun script/httpapi-exercise.ts --mode effect --fail-on-missing --fail-on-skip --progress --trace`: exit 0, 217 pass, 3669 progress/trace lines.
- `package.json` JSON-parses; `ci-test.yml` YAML-parses.