### PR TITLE
fix(test): make httpapi exerciser interruptible and bound cleanup

### DIFF
--- a/packages/opencode/test/server/httpapi-exercise/backend.ts
+++ b/packages/opencode/test/server/httpapi-exercise/backend.ts
@@ -12,31 +12,44 @@ type CallOptions = {
 }
 
 export function call(scenario: ActiveScenario, ctx: SeededContext<unknown>, options: CallOptions = {}) {
-  return Effect.promise(async () =>
-    capture(await app(await runtime(), options).request(toRequest(scenario, ctx)), scenario.capture),
+  // The signal parameter is load-bearing: Effect.promise is interruptible only
+  // when the callback declares it (evaluate.length !== 0). Without it the
+  // scenario timeout cannot break a stuck request and the runner hangs
+  // silently. The signal is also threaded into the Request so the handler
+  // side observes the abort.
+  return Effect.promise(async (signal) =>
+    capture(await app(await runtime(), options).request(toRequest(scenario, ctx, signal)), scenario.capture),
   )
 }
 
 export function callAuthProbe(scenario: ActiveScenario, credentials: "missing" | "valid" = "missing") {
-  return Effect.promise(async () => {
+  return Effect.promise(async (signal) => {
     const controller = new AbortController()
-    return Promise.race([
-      Promise.resolve(
-        app(await runtime(), { auth: { password: "secret" } }).request(
-          toAuthProbeRequest(scenario, credentials, controller.signal),
-        ),
-      ).then((response) => capture(response, scenario.capture)),
-      Bun.sleep(1_000).then(() => {
-        controller.abort("auth probe timed out")
-        return {
-          status: 0,
-          contentType: "",
-          text: "auth probe timed out",
-          body: undefined,
-          timedOut: true,
-        }
-      }),
-    ])
+    // Forward fiber interruption (scenario timeout) into the probe abort so
+    // neither the request nor the race below can outlive the scenario.
+    const abortOuter = () => controller.abort("scenario interrupted")
+    signal.addEventListener("abort", abortOuter, { once: true })
+    try {
+      return await Promise.race([
+        Promise.resolve(
+          app(await runtime(), { auth: { password: "secret" } }).request(
+            toAuthProbeRequest(scenario, credentials, controller.signal),
+          ),
+        ).then((response) => capture(response, scenario.capture)),
+        Bun.sleep(1_000).then(() => {
+          controller.abort("auth probe timed out")
+          return {
+            status: 0,
+            contentType: "",
+            text: "auth probe timed out",
+            body: undefined,
+            timedOut: true,
+          }
+        }),
+      ])
+    } finally {
+      signal.removeEventListener("abort", abortOuter)
+    }
   })
 }
 
@@ -77,12 +90,13 @@ function app(modules: Runtime, options: CallOptions) {
   })
 }
 
-function toRequest(scenario: ActiveScenario, ctx: SeededContext<unknown>) {
+function toRequest(scenario: ActiveScenario, ctx: SeededContext<unknown>, signal: AbortSignal) {
   const spec = scenario.request(ctx, ctx.state)
   return new Request(new URL(spec.path, "http://localhost"), {
     method: scenario.method,
     headers: spec.body === undefined ? spec.headers : { "content-type": "application/json", ...spec.headers },
     body: spec.body === undefined ? undefined : JSON.stringify(spec.body),
+    signal,
   })
 }
 

--- a/packages/opencode/test/server/httpapi-exercise/runner.ts
+++ b/packages/opencode/test/server/httpapi-exercise/runner.ts
@@ -80,9 +80,13 @@ function withContext<A, E>(
     (ctx) =>
       Effect.gen(function* () {
         yield* trace(options, scenario, `${label} tmpdir cleanup start`)
-        yield* Effect.promise(async () => {
-          await ctx.dir?.[Symbol.asyncDispose]()
-        }).pipe(Effect.ignore)
+        // Finalizers run uninterruptibly — the scenario timeout cannot break a
+        // hung dispose, so the hard cap lives inside the promise itself.
+        yield* Effect.promise(() =>
+          bounded(`${scenario.name}: tmpdir dispose`, async () => {
+            await ctx.dir?.[Symbol.asyncDispose]()
+          }),
+        )
         yield* trace(options, scenario, `${label} tmpdir cleanup done`)
       }),
   ).pipe(
@@ -262,11 +266,43 @@ const resetState = Effect.promise(async () => {
   const modules = await runtime()
   Flag.OPENCODE_SERVER_PASSWORD = original.OPENCODE_SERVER_PASSWORD
   Flag.OPENCODE_SERVER_USERNAME = original.OPENCODE_SERVER_USERNAME
-  await disposeApps()
-  await modules.disposeAllInstances()
-  await modules.resetDatabase()
+  // This runs from Effect.ensuring, i.e. uninterruptibly — a single promise
+  // that never resolves here used to hang the whole runner with zero output
+  // (the 2026-07-27 CI incident). Bound every step independently so a stuck
+  // dispose degrades into a loud warning and the run continues.
+  await bounded("disposeApps", () => disposeApps())
+  await bounded("disposeAllInstances", () => modules.disposeAllInstances())
+  await bounded("resetDatabase", () => modules.resetDatabase())
   await Bun.sleep(25)
 })
+
+/**
+ * Hard-timeout wrapper for cleanup promises: never rejects, never hangs.
+ * On timeout the underlying promise is left behind (there is nothing safe to
+ * do with it) and the runner moves on instead of silently freezing.
+ */
+const CLEANUP_STEP_TIMEOUT_MS = 10_000
+
+async function bounded(label: string, work: () => Promise<unknown>, ms = CLEANUP_STEP_TIMEOUT_MS) {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const timeout = new Promise<"timeout">((resolve) => {
+    timer = setTimeout(() => resolve("timeout"), ms)
+  })
+  const winner = await Promise.race([
+    work().then(
+      () => "done" as const,
+      (error: unknown) => {
+        console.error(`[cleanup] ${label} failed: ${String(error)}`)
+        return "done" as const
+      },
+    ),
+    timeout,
+  ])
+  clearTimeout(timer)
+  if (winner === "timeout") {
+    console.error(`[cleanup] ${label} exceeded ${ms}ms — forcing continuation (resource may leak)`)
+  }
+}
 
 /**
  * Create a DAG workflow fixture with mixed node statuses for HTTP happy-path tests.


### PR DESCRIPTION
## 概述

修复 HttpAPI exerciser harness 的可中断性缺陷（2026-07-27 CI gate 静默挂死事故的根因，PR #128 缓解后的正题修复）。仅动 harness（`test/server/httpapi-exercise/`），不动被测 server 业务代码。

## 前置检查

按要求先查 dev 最近 CI：PR #128 合入后所有 run 全绿，无新的 gate 挂起/超时记录 → 走通用加固路线。

## 根因与修法

effect-smol 的 `Effect.promise(evaluate)` 只有当回调**声明 signal 参数**（`evaluate.length !== 0`）时才注册为可中断（见 `dist/internal/effect.js` 的 `callbackOptions(fn, evaluate.length !== 0)`）；零参回调不可中断，`Effect.timeoutOrElse` 打断 fiber 后仍会永远等待——这正是"孤儿 bun 进程还活着、零 FAIL 输出"的机制。

1. **`backend.ts` `call()`**：`Effect.promise(async (signal) => ...)` 并把 signal 穿入 `Request`——场景超时现在能真实中断卡住的请求。
2. **`backend.ts` `callAuthProbe()`**：同样声明 signal，并把 fiber 中断转发到 probe 的 AbortController（原有 1s race 保留）。
3. **`runner.ts` `resetState`**（挂在 `Effect.ensuring`，天然不可中断）：`disposeApps` / `disposeAllInstances` / `resetDatabase` 每步独立 `bounded()` 硬超时（10s，`Promise.race` + 告警 + 强制继续），单点 promise 卡死降级为一条 `[cleanup] ... exceeded` 日志而非全局无输出挂死。
4. **`runner.ts` tmpdir dispose finalizer**：同样走 `bounded()`。

## 验证（packages/opencode/script 下直跑）

- `bun httpapi-exercise.ts --mode effect --fail-on-missing --fail-on-skip --progress --trace`：**pass=217 fail=0 skip=0 missing=0**
- `--mode coverage`：pass=217 fail=0
- `--mode auth`：pass=217 fail=0
- `tsgo --noEmit`（packages/opencode）通过。
