### PR TITLE
chore(ci): enforce oxlint warning ratchet in CI and pre-commit

### DIFF
--- a/.github/workflows/ci-typecheck.yml
+++ b/.github/workflows/ci-typecheck.yml
@@ -2,11 +2,13 @@
 # 🔍 CI · Typecheck
 # ----------------------------------------------------------------------------
 # Purpose : TypeScript type checking across all packages (bun typecheck)
+#           plus oxlint warning ratchet (bun run lint, --max-warnings gate)
 # Trigger : Push to `main`/`dev`, PRs targeting `main`/`dev`, manual dispatch
-# Jobs    : typecheck — single Linux runner, `bun typecheck`
+# Jobs    : typecheck — single Linux runner, `bun run lint` + `bun typecheck`
 # Gate    : Required status check on BOTH `dev` and `main` rulesets — it is
 #           the fast gate for feat/fix → dev PRs (full test suite only gates
-#           dev → main, see ci-test.yml).
+#           dev → main, see ci-test.yml). Lint lives inside this job so it
+#           blocks merges without editing the rulesets' required checks.
 # Notes   : No push trigger on feat/* or fix/* (frequent changes); PRs cover
 #           them.
 # ============================================================================
@@ -34,6 +36,9 @@ jobs:
 
       - name: Setup Bun
         uses: ./.github/actions/setup-bun
+
+      - name: Run lint
+        run: bun run lint
 
       - name: Run typecheck
         run: bun typecheck

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,4 @@
 #!/bin/sh
 set -e
+sh .husky/run-lint
 sh .husky/run-typecheck

--- a/.husky/run-lint
+++ b/.husky/run-lint
@@ -1,0 +1,23 @@
+#!/bin/sh
+# Shared lint runner for husky hooks.
+#
+# `bun run lint` is the primary path. Same environment defect as
+# run-typecheck: bun's workspace discovery walks ancestor directories and
+# dies with CouldntReadCurrentDirectory in sandboxed checkouts whose parents
+# are unreadable. In exactly that case, fall back to executing the root lint
+# script directly via node_modules/.bin (oxlint itself does not walk
+# ancestors). Real lint failures still fail on either path.
+set -e
+
+out=$(bun run lint 2>&1) && { printf '%s\n' "$out"; exit 0; }
+printf '%s\n' "$out"
+case "$out" in
+  *CouldntReadCurrentDirectory*) ;;
+  *) exit 1 ;;
+esac
+
+echo "bun workspace discovery unavailable — falling back to direct oxlint"
+# Reuse the root lint script verbatim so the --max-warnings ratchet stays in
+# one place (package.json).
+script=$(sed -n 's/.*"lint":[[:space:]]*"\([^"]*\)".*/\1/p' package.json | head -1)
+PATH="$(pwd)/node_modules/.bin:$PATH" sh -c "$script"

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicolo-ribaudo/oxc-project.github.io/refs/heads/json-schema/src/public/.oxlintrc.schema.json",
+  // Enforced in CI (ci-typecheck.yml) and pre-commit via the root `lint`
+  // script's --max-warnings ratchet: new warnings fail the gate. When fixing
+  // existing warnings, lower the threshold in package.json to match.
   "options": {
     "typeAware": true
   },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dev:console": "ulimit -n 10240 2>/dev/null; bun run --cwd packages/console/app dev",
     "dev:stats": "bun sst shell --stage=production -- bun run --cwd packages/stats/app dev",
     "dev:storybook": "bun --cwd packages/storybook storybook",
-    "lint": "oxlint",
+    "lint": "oxlint --max-warnings=4704",
     "typecheck": "bun turbo typecheck",
     "upgrade-opentui": "bun run script/upgrade-opentui.ts",
     "postinstall": "bun run --cwd packages/core fix-node-pty",


### PR DESCRIPTION
## What

Make the configured oxlint rules a mechanical merge gate.

- Root `lint` script now runs `oxlint --max-warnings=4704` (current baseline). All configured rules are warn-severity, so plain `oxlint` exits 0 regardless — the ratchet is what makes new warnings fail.
- `Run lint` step added inside the existing required **Typecheck** check in `ci-typecheck.yml`, so lint failure blocks merges to dev and main immediately, with no ruleset changes.
- `.husky/run-lint` (mirrors run-typecheck's sandbox fallback) wired into pre-commit.
- Ratchet contract documented in `.oxlintrc.json`: when fixing existing warnings, lower the threshold.

## Verification

- `oxlint --max-warnings=4704` → exit 0; `--max-warnings=4703` → exit 1 (gate proven)
- pre-commit hook ran lint + typecheck end-to-end on this commit