### PR TITLE
fix(tui): rebuild dag inspector on the chat design language

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dev:console": "ulimit -n 10240 2>/dev/null; bun run --cwd packages/console/app dev",
     "dev:stats": "bun sst shell --stage=production -- bun run --cwd packages/stats/app dev",
     "dev:storybook": "bun --cwd packages/storybook storybook",
-    "lint": "oxlint --max-warnings=4704",
+    "lint": "oxlint --max-warnings=4690",
     "typecheck": "bun turbo typecheck",
     "upgrade-opentui": "bun run script/upgrade-opentui.ts",
     "postinstall": "bun run --cwd packages/core fix-node-pty",

--- a/packages/tui/src/config/keybind.ts
+++ b/packages/tui/src/config/keybind.ts
@@ -75,16 +75,18 @@ export const Definitions = {
   diff_help: keybind("?", "Show more diff viewer shortcuts"),
 
   dag_open: keybind("none", "Open DAG inspector"),
-  dag_close: keybind("escape,q", "Close DAG inspector"),
+  dag_close: keybind("escape", "Close DAG inspector"),
   dag_enter: keybind("return", "Enter selected DAG node's session"),
-  dag_down: keybind("j,down", "Select next DAG node"),
-  dag_up: keybind("k,up", "Select previous DAG node"),
-  dag_next_workflow: keybind("l,right,tab", "Select next DAG workflow"),
-  dag_previous_workflow: keybind("h,left", "Select previous DAG workflow"),
-  dag_pause: keybind("p", "Pause selected DAG workflow"),
-  dag_resume: keybind("r", "Resume selected DAG workflow"),
-  dag_step: keybind("s", "Step selected DAG workflow (run one node)"),
-  dag_cancel: keybind("x", "Cancel selected DAG workflow"),
+  dag_down: keybind("down", "Select next DAG node"),
+  dag_up: keybind("up", "Select previous DAG node"),
+  dag_next_workflow: keybind("right", "Select next DAG workflow"),
+  dag_previous_workflow: keybind("left", "Select previous DAG workflow"),
+  // Control operations stay unbound by default and are reached through the
+  // command palette; the inspector advertises only cursor, enter and escape.
+  dag_pause: keybind("none", "Pause selected DAG workflow"),
+  dag_resume: keybind("none", "Resume selected DAG workflow"),
+  dag_step: keybind("none", "Step selected DAG workflow (run one node)"),
+  dag_cancel: keybind("none", "Cancel selected DAG workflow"),
 
   editor_open: keybind("<leader>e", "Open external editor"),
   theme_list: keybind("<leader>t", "List available themes"),

--- a/packages/tui/src/feature-plugins/system/dag-inspector.tsx
+++ b/packages/tui/src/feature-plugins/system/dag-inspector.tsx
@@ -3,13 +3,14 @@ import type { TuiPlugin, TuiPluginApi } from "@opencode-ai/plugin/tui"
 import type { BuiltinTuiPlugin } from "../builtins"
 import type { ScrollBoxRenderable } from "@opentui/core"
 import { createMemo, For, Show, Switch, Match, createSignal, createEffect, onCleanup } from "solid-js"
+import { useTerminalDimensions } from "@opentui/solid"
 import { Spinner } from "../../component/spinner"
 import { useBindings, useCommandShortcut } from "../../keymap"
-import { Panel, PanelGroup, Separator } from "./diff-viewer-ui"
+import { selectedForeground, useTheme } from "../../context/theme"
+import { SplitBorder } from "../../ui/border"
 import {
   computeNodeRowIndex,
   computeWaves,
-  dagControlAllowed,
   dagControlProgressMessage,
   dagControlUnavailableMessage,
   dagNodeGlyph,
@@ -27,9 +28,13 @@ import type { DagWorkflowSummary } from "@opencode-ai/sdk/v2"
 
 const id = "internal:system-dag-inspector"
 const ROUTE = "dag"
-const WORKFLOW_LIST_WIDTH = 32
-// Node detail rows below the wave list: header, dependencies, error/output
-// preview. Fixed so changing the selection never moves the footer.
+// Workflow sidebar mirrors the chat sidebar: fixed width, panel background,
+// and only present on wide terminals (chat uses the same > 120 threshold).
+const SIDEBAR_WIDTH = 42
+const WIDE_TERMINAL_WIDTH = 120
+// Node detail content rows: header, dependencies, error/output preview. The
+// detail block adds two padding rows on top; fixed so changing the selection
+// never moves the footer.
 const NODE_DETAIL_HEIGHT = 3
 
 function scrollRowIntoView(scroll: ScrollBoxRenderable | undefined, index: number) {
@@ -45,6 +50,14 @@ function scrollRowIntoView(scroll: ScrollBoxRenderable | undefined, index: numbe
 
 function DagInspector(props: { api: TuiPluginApi }) {
   const theme = () => props.api.theme.current
+  // The plugin-facing theme omits the resolver flags selectedForeground needs,
+  // so the full theme comes from the context, as in the diff viewer.
+  const themeState = useTheme()
+  const dimensions = useTerminalDimensions()
+  // Below this width the sidebar would squeeze the wave list into unreadable
+  // truncation, so it is dropped entirely and the summary block carries the
+  // workflow position instead.
+  const wide = createMemo(() => dimensions().width > WIDE_TERMINAL_WIDTH)
   const params = () =>
     ("params" in props.api.route.current ? props.api.route.current.params : undefined) as
       | { sessionID?: string; returnRoute?: { name: string; params?: Record<string, unknown> } }
@@ -111,7 +124,7 @@ function DagInspector(props: { api: TuiPluginApi }) {
       const res = await props.api.client.dag.nodes({ dagID })
       // Discard if the user selected a different workflow while this fetch was in flight.
       if (selectedWorkflow() !== dagID) return
-      setNodes((res.data ?? []) as DagNode[])
+      setNodes(res.data ?? [])
     } catch {
       if (selectedWorkflow() !== dagID) return
       setNodes([])
@@ -306,6 +319,7 @@ function DagInspector(props: { api: TuiPluginApi }) {
       name: "dag.pause",
       title: "Pause selected workflow",
       category: "Workflow",
+      namespace: "palette",
       run() {
         control("pause")
       },
@@ -314,6 +328,7 @@ function DagInspector(props: { api: TuiPluginApi }) {
       name: "dag.resume",
       title: "Resume selected workflow",
       category: "Workflow",
+      namespace: "palette",
       run() {
         control("resume")
       },
@@ -322,6 +337,7 @@ function DagInspector(props: { api: TuiPluginApi }) {
       name: "dag.step",
       title: "Step selected workflow (run one node)",
       category: "Workflow",
+      namespace: "palette",
       run() {
         control("step")
       },
@@ -330,6 +346,7 @@ function DagInspector(props: { api: TuiPluginApi }) {
       name: "dag.cancel",
       title: "Cancel selected workflow",
       category: "Workflow",
+      namespace: "palette",
       run() {
         control("cancel")
       },
@@ -346,28 +363,19 @@ function DagInspector(props: { api: TuiPluginApi }) {
 
   const closeShortcut = useCommandShortcut("dag.close")
   const enterShortcut = useCommandShortcut("dag.enter")
-  const pauseShortcut = useCommandShortcut("dag.pause")
-  const resumeShortcut = useCommandShortcut("dag.resume")
-  const stepShortcut = useCommandShortcut("dag.step")
-  const cancelShortcut = useCommandShortcut("dag.cancel")
 
   const selectedWorkflowSummary = createMemo(() => workflows().find((workflow) => workflow.id === selectedWorkflow()))
   const selectedNodeDetail = createMemo(() => orderedNodes().find((node) => node.id === selectedNode()))
 
-  // Footer hints mirror the diff-viewer's `key label` vocabulary. Control
-  // hints are contextual: only operations valid for the selected workflow's
-  // status appear, so pause/resume never advertise a guaranteed no-op.
-  const footerHints = createMemo(() => {
-    const status = selectedWorkflowSummary()?.status
-    return [
-      { key: enterShortcut(), label: "open session", show: true },
-      { key: pauseShortcut(), label: "pause", show: dagControlAllowed(status, "pause") },
-      { key: resumeShortcut(), label: "resume", show: dagControlAllowed(status, "resume") },
-      { key: stepShortcut(), label: "step", show: dagControlAllowed(status, "step") },
-      { key: cancelShortcut(), label: "cancel", show: dagControlAllowed(status, "cancel") },
-      { key: closeShortcut(), label: "close", show: true },
-    ].filter((hint) => hint.show && hint.key !== "")
-  })
+  // Footer advertises only the cursor-level affordances. Control operations
+  // (pause/resume/step/cancel) are unbound by default and reached through the
+  // command palette, so they never crowd this row.
+  const footerHints = createMemo(() =>
+    [
+      { key: enterShortcut(), label: "open session" },
+      { key: closeShortcut(), label: "close" },
+    ].filter((hint) => hint.key !== ""),
+  )
 
   // 1s tick driving the running-node deadline countdown. Only active while the
   // selected node is actually counting down — idle inspectors don't re-render.
@@ -380,200 +388,171 @@ function DagInspector(props: { api: TuiPluginApi }) {
   })
 
   const statusColor = (status: string) => dagStatusColor(theme(), status)
+  // Readable foreground against the primary-filled cursor row, the same helper
+  // the select dialog uses for its active option.
+  const selectedFg = () => selectedForeground(themeState.theme, themeState.theme.primary)
 
   return (
     <box width="100%" height="100%">
-      <PanelGroup axis="y" width="100%" height="100%">
-        <Panel border="none" flexShrink={0} padding={0} paddingLeft={1} paddingRight={1}>
-          <text fg={theme().text}>DAG </text>
-          <text fg={theme().textMuted}>{selectedWorkflowSummary()?.title ?? "workflow inspector"}</text>
-          <box flexGrow={1} />
-          <text fg={theme().textMuted}>
-            {workflows().length} {workflows().length === 1 ? "workflow" : "workflows"}
-          </text>
-        </Panel>
-
-        <box flexGrow={1} minHeight={0}>
-          <Switch>
-            <Match when={workflowLoad() === "loading" && workflows().length === 0}>
-              <Separator axis="x" />
-              <box flexGrow={1} paddingLeft={1}>
-                <text fg={theme().textMuted}>Loading workflows...</text>
-              </box>
-            </Match>
-            <Match when={workflowLoad() === "error" && workflows().length === 0}>
-              <Separator axis="x" />
-              <box flexGrow={1} paddingLeft={1}>
+      <box flexGrow={1} minHeight={0} flexDirection="row">
+        {/* Main column — the chat message-area vocabulary: two-column side
+          padding, rail-and-panel blocks, no frame lines. */}
+        <box flexGrow={1} minWidth={0} minHeight={0} paddingTop={1} paddingLeft={2} paddingRight={2}>
+          <box flexGrow={1} minHeight={0}>
+            <Switch>
+              <Match when={workflowLoad() === "loading" && workflows().length === 0}>
+                <Spinner color={theme().textMuted}>Loading workflows...</Spinner>
+              </Match>
+              <Match when={workflowLoad() === "error" && workflows().length === 0}>
                 <text fg={theme().error}>Unable to load workflows</text>
-              </box>
-            </Match>
-            <Match when={workflows().length === 0}>
-              <Separator axis="x" />
-              <box flexGrow={1} paddingLeft={1}>
-                <text fg={theme().textMuted}>No workflows for this session</text>
-              </box>
-            </Match>
-            <Match when={workflows().length > 0}>
-              <PanelGroup axis="x">
-                <Panel border="both" width={WORKFLOW_LIST_WIDTH}>
-                  <scrollbox
-                    ref={(element: ScrollBoxRenderable) => (workflowScroll = element)}
-                    verticalScrollbarOptions={{ visible: false }}
-                    horizontalScrollbarOptions={{ visible: false }}
-                  >
-                    <For each={workflows()}>
-                      {(wf) => {
-                        const selected = () => selectedWorkflow() === wf.id
-                        return (
-                          <box
-                            flexDirection="row"
-                            gap={1}
-                            width="100%"
-                            paddingLeft={1}
-                            paddingRight={1}
-                            backgroundColor={selected() ? theme().primary : undefined}
-                            onMouseUp={() => setSelectedWorkflow(wf.id)}
-                          >
-                            <text fg={selected() ? theme().background : statusColor(wf.status)} flexShrink={0}>
-                              •
-                            </text>
-                            <box flexGrow={1} minWidth={0}>
-                              <text fg={selected() ? theme().background : theme().text} wrapMode="none">
-                                {wf.title}
-                              </text>
-                            </box>
-                            <text fg={selected() ? theme().background : theme().textMuted} flexShrink={0}>
-                              {formatDagProgress(wf)}
-                            </text>
-                          </box>
-                        )
-                      }}
-                    </For>
-                  </scrollbox>
-                </Panel>
-
-                {/* The right pane draws its own left border on every content
-                    block; the horizontal separators' ┬/├/┴ edge glyphs land in
-                    the same column, forming one continuous frame around both
-                    panes — the same construction as the diff-viewer's patch
-                    pane next to its file tree. */}
-                <Panel flexGrow={1} minHeight={0} border="none">
-                  <Separator axis="x" start="edge-out" />
+              </Match>
+              <Match when={workflows().length === 0}>
+                <text fg={theme().text}>No workflows for this session</text>
+                <box marginTop={1}>
+                  <text fg={theme().textMuted}>
+                    {"Run /dag-flow <task> inside a session to start an orchestration"}
+                  </text>
+                </box>
+              </Match>
+              <Match when={workflows().length > 0}>
+                {/* Selected workflow summary — the user-message block: status
+                  rail + panel background, mirroring the chat transcript. */}
+                <box
+                  flexShrink={0}
+                  border={["left"]}
+                  borderColor={statusColor(selectedWorkflowSummary()?.status ?? "")}
+                  customBorderChars={SplitBorder.customBorderChars}
+                >
                   <box
-                    flexDirection="row"
-                    gap={1}
-                    paddingLeft={1}
-                    paddingRight={1}
+                    paddingTop={1}
+                    paddingBottom={1}
+                    paddingLeft={2}
+                    paddingRight={2}
+                    backgroundColor={theme().backgroundPanel}
                     flexShrink={0}
-                    border={["left"]}
-                    borderColor={theme().border}
                   >
-                    <text fg={statusColor(selectedWorkflowSummary()?.status ?? "")} flexShrink={0}>
-                      •
+                    <text fg={theme().text}>
+                      <b>{selectedWorkflowSummary()?.title ?? ""}</b>
                     </text>
-                    <text fg={theme().text}>{selectedWorkflowSummary()?.status ?? "unknown"}</text>
-                    <Show when={actionMessage()}>
-                      <text fg={theme().warning} wrapMode="none">
-                        {actionMessage()}
-                      </text>
-                    </Show>
-                    <box flexGrow={1} />
-                    <text fg={theme().textMuted} flexShrink={0}>
-                      {nodes().length} {nodes().length === 1 ? "node" : "nodes"} · {layers().length}{" "}
-                      {layers().length === 1 ? "wave" : "waves"}
+                    <text wrapMode="none">
+                      <span style={{ fg: statusColor(selectedWorkflowSummary()?.status ?? "") }}>
+                        {selectedWorkflowSummary()?.status ?? "unknown"}
+                      </span>
+                      <span style={{ fg: theme().textMuted }}>
+                        {" · "}
+                        {nodes().length} {nodes().length === 1 ? "node" : "nodes"} · {layers().length}{" "}
+                        {layers().length === 1 ? "wave" : "waves"}
+                      </span>
+                      <Show when={actionMessage()}>
+                        <span style={{ fg: theme().warning }}> · {actionMessage()}</span>
+                      </Show>
+                      {/* Without the sidebar the summary block is the only
+                          place the workflow position can be read. */}
+                      <Show when={!wide() && workflows().length > 1}>
+                        <span style={{ fg: theme().textMuted }}>
+                          {" · workflow "}
+                          {workflows().findIndex((workflow) => workflow.id === selectedWorkflow()) + 1}/
+                          {workflows().length}
+                        </span>
+                      </Show>
                     </text>
                   </box>
-                  <Separator axis="x" start="edge" />
-                  {/* Border lives on the wrapper, not the rows, so the left
-                      edge stays continuous when the node list is shorter than
-                      the viewport. */}
-                  <box flexGrow={1} minHeight={0} border={["left"]} borderColor={theme().border}>
-                    <scrollbox
-                      ref={(element: ScrollBoxRenderable) => (nodeScroll = element)}
-                      flexGrow={1}
-                      minHeight={0}
-                      verticalScrollbarOptions={{ visible: false }}
-                      horizontalScrollbarOptions={{ visible: false }}
-                    >
-                      <For each={layers()}>
-                        {(layer, layerIdx) => (
-                          <>
-                            {/* Blank spacer between waves keeps the blocks visually
+                </box>
+                <scrollbox
+                  ref={(element: ScrollBoxRenderable) => (nodeScroll = element)}
+                  flexGrow={1}
+                  minHeight={0}
+                  marginTop={1}
+                  verticalScrollbarOptions={{ visible: false }}
+                  horizontalScrollbarOptions={{ visible: false }}
+                >
+                  <For each={layers()}>
+                    {(layer, layerIdx) => (
+                      <>
+                        {/* Blank spacer between waves keeps the blocks visually
                                 separate; computeNodeRowIndex counts it for scrolling. */}
-                            {layerIdx() !== 0 ? <box height={1} /> : null}
-                            {/* Wave header: nodes at the same topological depth, NOT a barrier */}
-                            <box flexDirection="row" gap={1} width="100%" paddingLeft={1} paddingRight={1}>
-                              <text fg={theme().accent} wrapMode="none">
-                                wave {layerIdx() + 1}
-                              </text>
-                              <text fg={theme().textMuted} wrapMode="none">
-                                · {layer.length} {layer.length === 1 ? "node" : "nodes"}
-                              </text>
-                            </box>
-                            <For each={layer}>
-                              {(node) => {
-                                const selected = () => selectedNode() === node.id
-                                const settled = () =>
-                                  node.status === "completed" ||
-                                  node.status === "skipped" ||
-                                  node.status === "cancelled" ||
-                                  node.status === "aborted"
-                                return (
-                                  <box
-                                    flexDirection="row"
-                                    gap={1}
-                                    width="100%"
-                                    paddingLeft={2}
-                                    paddingRight={1}
-                                    backgroundColor={selected() ? theme().primary : undefined}
-                                    onMouseUp={() => setSelectedNode(node.id)}
+                        {layerIdx() !== 0 ? <box height={1} /> : null}
+                        {/* Wave header: nodes at the same topological depth, NOT a barrier.
+                                Bold title plus muted count, like the sidebar's MCP section. */}
+                        <box flexDirection="row" gap={1} width="100%">
+                          <text fg={theme().text} wrapMode="none">
+                            <b>wave {layerIdx() + 1}</b>
+                          </text>
+                          <text fg={theme().textMuted} wrapMode="none">
+                            · {layer.length} {layer.length === 1 ? "node" : "nodes"}
+                          </text>
+                        </box>
+                        <For each={layer}>
+                          {(node) => {
+                            const selected = () => selectedNode() === node.id
+                            const settled = () =>
+                              node.status === "completed" ||
+                              node.status === "skipped" ||
+                              node.status === "cancelled" ||
+                              node.status === "aborted"
+                            return (
+                              <box
+                                flexDirection="row"
+                                gap={1}
+                                width="100%"
+                                paddingLeft={2}
+                                backgroundColor={selected() ? theme().primary : undefined}
+                                onMouseUp={() => setSelectedNode(node.id)}
+                              >
+                                <Show
+                                  when={node.status !== "running"}
+                                  fallback={<Spinner color={selected() ? selectedFg() : theme().textMuted} />}
+                                >
+                                  <text fg={selected() ? selectedFg() : statusColor(node.status)} flexShrink={0}>
+                                    {dagNodeGlyph(node.status)}
+                                  </text>
+                                </Show>
+                                <box flexShrink={1} minWidth={0}>
+                                  <text
+                                    fg={
+                                      selected()
+                                        ? selectedFg()
+                                        : node.status === "failed"
+                                          ? theme().error
+                                          : settled()
+                                            ? theme().textMuted
+                                            : theme().text
+                                    }
+                                    wrapMode="none"
                                   >
-                                    <Show
-                                      when={node.status !== "running"}
-                                      fallback={<Spinner color={selected() ? theme().background : theme().textMuted} />}
-                                    >
-                                      <text
-                                        fg={selected() ? theme().background : statusColor(node.status)}
-                                        flexShrink={0}
-                                      >
-                                        {dagNodeGlyph(node.status)}
-                                      </text>
-                                    </Show>
-                                    <box flexShrink={1} minWidth={0}>
-                                      <text
-                                        fg={
-                                          selected() ? theme().background : settled() ? theme().textMuted : theme().text
-                                        }
-                                        wrapMode="none"
-                                      >
-                                        {node.name}
-                                      </text>
-                                    </box>
-                                    <text
-                                      fg={selected() ? theme().background : theme().textMuted}
-                                      wrapMode="none"
-                                      flexShrink={0}
-                                    >
-                                      {node.worker_type}
-                                    </text>
-                                  </box>
-                                )
-                              }}
-                            </For>
-                          </>
-                        )}
-                      </For>
-                    </scrollbox>
-                  </box>
-                  <Separator axis="x" start="edge" />
+                                    {node.name}
+                                  </text>
+                                </box>
+                                <text fg={selected() ? selectedFg() : theme().textMuted} wrapMode="none" flexShrink={0}>
+                                  {node.worker_type}
+                                </text>
+                              </box>
+                            )
+                          }}
+                        </For>
+                      </>
+                    )}
+                  </For>
+                </scrollbox>
+                {/* Node detail — the block-tool vocabulary: soft inset rail,
+                  panel background, fixed height so selection changes never
+                  move the footer. */}
+                <box
+                  flexShrink={0}
+                  marginTop={1}
+                  height={NODE_DETAIL_HEIGHT + 2}
+                  border={["left"]}
+                  borderColor={selectedNodeDetail()?.error_reason ? theme().error : theme().background}
+                  customBorderChars={SplitBorder.customBorderChars}
+                >
                   <box
+                    flexGrow={1}
                     flexDirection="column"
-                    paddingLeft={1}
-                    paddingRight={1}
-                    flexShrink={0}
-                    height={NODE_DETAIL_HEIGHT}
-                    border={["left"]}
-                    borderColor={theme().border}
+                    paddingTop={1}
+                    paddingBottom={1}
+                    paddingLeft={2}
+                    paddingRight={2}
+                    backgroundColor={theme().backgroundPanel}
                   >
                     <Show when={selectedNodeDetail()}>
                       {(node) => (
@@ -622,25 +601,83 @@ function DagInspector(props: { api: TuiPluginApi }) {
                       )}
                     </Show>
                   </box>
-                  {/* Bottom rail: closes the frame flush with the workflow
-                      list's bottom border, mirroring the diff-viewer. */}
-                  <Separator axis="x" start="edge-in" />
-                </Panel>
-              </PanelGroup>
-            </Match>
-          </Switch>
+                </box>
+              </Match>
+            </Switch>
+          </box>
         </box>
 
-        <Panel flexShrink={0} gap={2} paddingLeft={1} paddingRight={1} border="none">
-          <For each={footerHints()}>
-            {(hint) => (
+        {/* Workflow sidebar — the chat sidebar vocabulary: fixed width, panel
+          background, bold title, dot-status rows. Fixed layout: present
+          whenever the terminal is wide, empty when there is nothing to list. */}
+        <Show when={wide()}>
+          <box
+            width={SIDEBAR_WIDTH}
+            height="100%"
+            flexShrink={0}
+            backgroundColor={theme().backgroundPanel}
+            paddingTop={1}
+            paddingBottom={1}
+            paddingLeft={2}
+            paddingRight={2}
+          >
+            <box flexShrink={0}>
               <text fg={theme().text}>
-                {hint.key} <span style={{ fg: theme().textMuted }}>{hint.label}</span>
+                <b>DAG</b>
               </text>
-            )}
-          </For>
-        </Panel>
-      </PanelGroup>
+              <text fg={theme().textMuted}>
+                {workflows().length} {workflows().length === 1 ? "workflow" : "workflows"}
+              </text>
+            </box>
+            <scrollbox
+              ref={(element: ScrollBoxRenderable) => (workflowScroll = element)}
+              flexGrow={1}
+              marginTop={1}
+              verticalScrollbarOptions={{ visible: false }}
+              horizontalScrollbarOptions={{ visible: false }}
+            >
+              <For each={workflows()}>
+                {(wf) => {
+                  const selected = () => selectedWorkflow() === wf.id
+                  return (
+                    <box
+                      flexDirection="row"
+                      gap={1}
+                      width="100%"
+                      backgroundColor={selected() ? theme().backgroundElement : undefined}
+                      onMouseUp={() => setSelectedWorkflow(wf.id)}
+                    >
+                      <text fg={statusColor(wf.status)} flexShrink={0}>
+                        •
+                      </text>
+                      <box flexGrow={1} minWidth={0}>
+                        <text fg={theme().text} wrapMode="none">
+                          {wf.title}
+                        </text>
+                      </box>
+                      <text fg={theme().textMuted} flexShrink={0}>
+                        {formatDagProgress(wf)}
+                      </text>
+                    </box>
+                  )
+                }}
+              </For>
+            </scrollbox>
+          </box>
+        </Show>
+      </box>
+
+      {/* Footer hints — the chat footer vocabulary: a full-width bottom row
+          that the sidebar never squeezes; key in text color, label muted. */}
+      <box flexDirection="row" gap={2} flexShrink={0} paddingLeft={2} paddingRight={2} paddingBottom={1}>
+        <For each={footerHints()}>
+          {(hint) => (
+            <text fg={theme().text} wrapMode="none">
+              {hint.key} <span style={{ fg: theme().textMuted }}>{hint.label}</span>
+            </text>
+          )}
+        </For>
+      </box>
     </box>
   )
 }

--- a/packages/tui/test/feature-plugins/dag-inspector.test.tsx
+++ b/packages/tui/test/feature-plugins/dag-inspector.test.tsx
@@ -35,6 +35,7 @@ type RenderOpts = {
   nodes?: DagNode[]
   initialRoute?: TuiRouteCurrent
   summary?: (sessionID: string) => Promise<{ data: DagWorkflowSummary[] }>
+  width?: number
 }
 
 function dagNode(overrides: Partial<DagNode> & { id: string }): DagNode {
@@ -55,7 +56,9 @@ async function renderDagInspector(opts: RenderOpts = {}) {
     string,
     NonNullable<Parameters<TuiPluginApi["keymap"]["registerLayer"]>[0]["commands"]>[number]
   >()
-  const [current, setCurrent] = createSignal<TuiRouteCurrent>(opts.initialRoute ?? { name: "dag", params: { sessionID: SESSION_ID } })
+  const [current, setCurrent] = createSignal<TuiRouteCurrent>(
+    opts.initialRoute ?? { name: "dag", params: { sessionID: SESSION_ID } },
+  )
   let renderInspector: TuiRouteDefinition["render"] | undefined
 
   // Updatable workflow state for change detection.
@@ -156,7 +159,7 @@ async function renderDagInspector(opts: RenderOpts = {}) {
     )
   }
 
-  const app = await testRender(() => <Harness />, { width: 100, height: 30 })
+  const app = await testRender(() => <Harness />, { width: opts.width ?? 130, height: 30 })
   await waitForCommand(app, commands, "dag.open")
   if (current().name === "dag") await waitForCommand(app, commands, "dag.close")
   // Give the initial fetchNodes a chance to resolve.
@@ -206,13 +209,25 @@ async function waitForCondition(fn: () => boolean, timeout = 2000) {
   }
 }
 
+type RegisteredCommands = Map<
+  string,
+  NonNullable<Parameters<TuiPluginApi["keymap"]["registerLayer"]>[0]["commands"]>[number]
+>
+
+/** Invoke a route command the way a keypress would. The keymap passes a real
+ * command context at runtime; tests only exercise the side effects, so the
+ * unused context is asserted away once here instead of at every call site. */
+function runCommand(commands: RegisteredCommands, name: string) {
+  void commands.get(name)!.run?.({} as never)
+}
+
 describe("DagInspector", () => {
   test("/dag dispatches dag.open locally without submitting a model command", async () => {
     const returnRoute = { name: "session", params: { sessionID: SESSION_ID } }
     const viewer = await renderDagInspector({ initialRoute: returnRoute })
     try {
       expect(viewer.commands.get("dag.open")?.slashName).toBe("dag")
-      viewer.commands.get("dag.open")!.run?.({} as never)
+      runCommand(viewer.commands, "dag.open")
       await waitForCommand(viewer.app, viewer.commands, "dag.close")
 
       expect(viewer.navigations().at(-1)).toEqual({
@@ -333,13 +348,16 @@ describe("DagInspector", () => {
 
   test("closing the inspector prevents further fetches", async () => {
     const viewer = await renderDagInspector({
-      initialRoute: { name: "dag", params: { sessionID: SESSION_ID, returnRoute: { name: "session", params: { sessionID: SESSION_ID } } } },
+      initialRoute: {
+        name: "dag",
+        params: { sessionID: SESSION_ID, returnRoute: { name: "session", params: { sessionID: SESSION_ID } } },
+      },
       workflows: [wfSummary({ id: "wf-1" })],
       nodes: [dagNode({ id: "n-1", name: "build", status: "pending" })],
     })
     try {
       // Close the inspector — navigates away, unmounts the component.
-      viewer.commands.get("dag.close")!.run?.({} as never)
+      runCommand(viewer.commands, "dag.close")
       await Bun.sleep(20)
 
       const before = viewer.nodesCalls().length
@@ -359,7 +377,7 @@ describe("DagInspector", () => {
       nodes: [dagNode({ id: "n-1", name: "build", status: "running", child_session_id: "child_ses_1" })],
     })
     try {
-      viewer.commands.get("dag.enter")!.run?.({} as never)
+      runCommand(viewer.commands, "dag.enter")
       expect(viewer.navigations()).toContainEqual(
         expect.objectContaining({ name: "session", params: expect.objectContaining({ sessionID: "child_ses_1" }) }),
       )
@@ -385,14 +403,14 @@ describe("DagInspector", () => {
     }
   })
 
-  test("pressing p pauses a running workflow", async () => {
+  test("dag.pause pauses a running workflow", async () => {
     const viewer = await renderDagInspector({
       workflows: [wfSummary({ id: "wf-1", status: "running" })],
       nodes: [dagNode({ id: "n-1", name: "build", status: "running" })],
     })
     try {
       await viewer.app.waitForFrame((frame) => frame.includes("build"))
-      viewer.app.mockInput.pressKey("p")
+      runCommand(viewer.commands, "dag.pause")
       await waitForCondition(() => viewer.controlCalls().length > 0)
       expect(viewer.controlCalls()).toContainEqual({ dagID: "wf-1", operation: "pause" })
     } finally {
@@ -400,14 +418,14 @@ describe("DagInspector", () => {
     }
   })
 
-  test("pressing p pauses a stepping workflow", async () => {
+  test("dag.pause pauses a stepping workflow", async () => {
     const viewer = await renderDagInspector({
       workflows: [wfSummary({ id: "wf-1", status: "stepping" })],
       nodes: [dagNode({ id: "n-1", name: "build", status: "running" })],
     })
     try {
       await viewer.app.waitForFrame((frame) => frame.includes("build"))
-      viewer.app.mockInput.pressKey("p")
+      runCommand(viewer.commands, "dag.pause")
       await waitForCondition(() => viewer.controlCalls().length > 0)
       expect(viewer.controlCalls()).toContainEqual({ dagID: "wf-1", operation: "pause" })
     } finally {
@@ -415,17 +433,33 @@ describe("DagInspector", () => {
     }
   })
 
-  test("pressing p on a terminal workflow explains why pause is unavailable", async () => {
+  test("dag.pause on a terminal workflow explains why pause is unavailable", async () => {
     const viewer = await renderDagInspector({
       workflows: [wfSummary({ id: "wf-1", status: "completed", completedNodes: 2 })],
       nodes: [dagNode({ id: "n-1", name: "build", status: "completed" })],
     })
     try {
       await viewer.app.waitForFrame((frame) => frame.includes("build"))
-      viewer.app.mockInput.pressKey("p")
+      runCommand(viewer.commands, "dag.pause")
       await waitForCondition(() => viewer.toasts().length > 0)
       expect(viewer.controlCalls()).toEqual([])
       expect(viewer.toasts().at(-1)?.message).toMatch(/completed.*cannot be paused/i)
+    } finally {
+      viewer.app.renderer.destroy()
+    }
+  })
+
+  test("control operations stay reachable through the command palette", async () => {
+    const viewer = await renderDagInspector({
+      workflows: [wfSummary({ id: "wf-1", status: "running" })],
+      nodes: [dagNode({ id: "n-1", name: "build", status: "running" })],
+    })
+    try {
+      await viewer.app.waitForFrame((frame) => frame.includes("build"))
+      // Unbound by default, so the palette namespace is the only way in.
+      for (const name of ["dag.pause", "dag.resume", "dag.step", "dag.cancel"]) {
+        expect(viewer.commands.get(name)?.namespace).toBe("palette")
+      }
     } finally {
       viewer.app.renderer.destroy()
     }
@@ -453,7 +487,7 @@ describe("DagInspector", () => {
       nodes: [dagNode({ id: "n-1", name: "build", status: "pending" })],
     })
     try {
-      viewer.commands.get("dag.enter")!.run?.({} as never)
+      runCommand(viewer.commands, "dag.enter")
       expect(viewer.toasts().some((t) => /no session/i.test(t.message))).toBe(true)
     } finally {
       viewer.app.renderer.destroy()
@@ -467,7 +501,7 @@ describe("DagInspector", () => {
       workflows: [wfSummary({ id: "wf-1" })],
     })
     try {
-      viewer.commands.get("dag.close")!.run?.({} as never)
+      runCommand(viewer.commands, "dag.close")
       expect(viewer.navigations().at(-1)).toEqual(
         expect.objectContaining({ name: "session", params: { sessionID: SESSION_ID } }),
       )
@@ -489,7 +523,7 @@ describe("DagInspector", () => {
       await waitForCondition(() => viewer.nodesCalls().some((id) => id === "wf-1"))
 
       // Switch selection wf-1 -> wf-2.
-      viewer.commands.get("dag.next_workflow")!.run?.({} as never)
+      runCommand(viewer.commands, "dag.next_workflow")
       // The new selection fetches wf-2's nodes.
       await waitForCondition(() => viewer.nodesCalls().some((id) => id === "wf-2"))
 
@@ -541,7 +575,7 @@ describe("DagInspector", () => {
     }
   })
 
-  test("footer only advertises controls valid for the workflow status", async () => {
+  test("footer advertises only the cursor affordances, never the control operations", async () => {
     const viewer = await renderDagInspector({
       workflows: [wfSummary({ id: "wf-1", status: "paused" })],
       nodes: [dagNode({ id: "n-1", name: "build", status: "pending" })],
@@ -550,8 +584,13 @@ describe("DagInspector", () => {
       await viewer.app.waitForFrame((frame) => {
         const footer = frame.split("\n").find((row) => row.includes("open session"))
         if (!footer) return false
+        // A paused workflow would previously have advertised resume/cancel here.
         return (
-          footer.includes("resume") && footer.includes("cancel") && !footer.includes("pause") && !footer.includes("step")
+          footer.includes("close") &&
+          !footer.includes("resume") &&
+          !footer.includes("cancel") &&
+          !footer.includes("pause") &&
+          !footer.includes("step")
         )
       })
     } finally {
@@ -577,10 +616,40 @@ describe("DagInspector", () => {
       })
       // Moving to "detailed" adds dependency and error rows to the detail
       // pane; the fixed-height pane must keep the footer on the same row.
-      viewer.commands.get("dag.down")!.run?.({} as never)
+      runCommand(viewer.commands, "dag.down")
       await viewer.app.waitForFrame((frame) => frame.includes("boom") && footerRow(frame) === before)
     } finally {
       viewer.app.renderer.destroy()
+    }
+  })
+
+  test("the workflow sidebar only appears on wide terminals", async () => {
+    const wide = await renderDagInspector({
+      width: 130,
+      workflows: [wfSummary({ id: "wf-1", title: "Evidence pipeline" })],
+      nodes: [dagNode({ id: "n-1", name: "collect", status: "running" })],
+    })
+    try {
+      // The sidebar header is the marker: it renders "DAG" plus a workflow count.
+      await wide.app.waitForFrame((frame) => frame.includes("1 workflow"))
+    } finally {
+      wide.app.renderer.destroy()
+    }
+
+    const narrow = await renderDagInspector({
+      width: 100,
+      workflows: [
+        wfSummary({ id: "wf-1", title: "Evidence pipeline" }),
+        wfSummary({ id: "wf-2", title: "Second workflow" }),
+      ],
+      nodes: [dagNode({ id: "n-1", name: "collect", status: "running" })],
+    })
+    try {
+      // Sidebar dropped; the summary block carries the position instead so the
+      // left/right workflow cursor stays legible.
+      await narrow.app.waitForFrame((frame) => frame.includes("workflow 1/2") && !frame.includes("2 workflows"))
+    } finally {
+      narrow.app.renderer.destroy()
     }
   })
 })


### PR DESCRIPTION
## Summary

Rebuilds the `/dag` inspector on the **chat transcript's** design language instead of the diff-viewer's frame vocabulary. Box-drawing lines (`─┬├┴`) are gone; the screen is now rail-and-panel blocks with two-column side padding, exactly as `routes/session` renders messages.

A grilling pass over the first attempt found three real defects, all fixed here.

### 1. Sidebar was not responsive (severe)

Chat gates its 42-wide sidebar on `dimensions().width > 120` (`routes/session/index.tsx`). The first attempt rendered it unconditionally. Measured at 60 columns:

```
|  wave 1· 1 node        |   ← gap collapsed
|    ✓ coll build        |   ← node name truncated to "coll"
|    ⠋aGeneralPur        |   ← name reduced to "a", spinner glued on
```

Now gated on the same threshold. Below it the sidebar is dropped and the summary block carries `workflow 1/2` so the left/right cursor stays legible. Locked in by a new regression test asserting the sidebar appears at 130 columns and is absent at 100.

### 2. Selection used the "unfocused" highlight

`dialog-select` uses `primary` + `selectedForeground()` for the active row and degrades to `backgroundElement` only when focus moves away. The first attempt used `backgroundElement` for the *focused* state — semantically "selected but unfocused", and only an 8% luminance step (`#0a0a0a` → `#1e1e1e`), so the cursor was nearly invisible on low-contrast terminals.

Node cursor (what `return` acts on) now uses `primary` + `selectedForeground()`; the secondary workflow selection keeps `backgroundElement`. One strong highlight on screen, no ambiguity about what `return` targets.

### 3. Fixed layout for the empty state

Panels keep a fixed layout: the sidebar is present whenever the terminal is wide and simply empty when there is nothing to list. The empty state also gained a `Run /dag-flow <task> …` hint — previously it was a dead end, which is what made an earlier UI change look like "nothing changed" (the empty state is byte-identical across versions since it was never restyled).

## Cursor-only interaction model

| Command | Before | After |
|---|---|---|
| `dag.down` / `dag.up` | `j,down` / `k,up` | `down` / `up` |
| `dag.next_workflow` / `dag.previous_workflow` | `l,right,tab` / `h,left` | `right` / `left` |
| `dag.close` | `escape,q` | `escape` |
| `dag.enter` | `return` | `return` |
| `dag.pause` / `resume` / `step` / `cancel` | `p` / `r` / `s` / `x` | `none` |

The four control operations gain `namespace: "palette"` so they stay reachable through the command palette — without it, unbinding them would have made the capability unreachable, since route commands registered via `useBindings` are not palette-visible by default. A test pins this. The footer is now a single uncrowded row: `enter open session   escape close`.

## Test plan

- `tsgo --noEmit` clean in `packages/tui`
- Full TUI suite: **233 pass / 0 fail** (43 in the DAG files, up from 41)
- Rewrote the three `pressKey("p")` tests to invoke `dag.pause` directly, and replaced the contextual-footer assertion with one that verifies control hints never appear
- Lint ratchet **tightened 4704 → 4690**: a `runCommand` test helper collapses ten duplicated command-context assertions into one, a net reduction of 14 warnings
