### PR TITLE
fix(tui): restore the dag inspector's own structure, keep only the vocabulary

### DIFF
--- a/packages/tui/src/feature-plugins/system/dag-inspector.tsx
+++ b/packages/tui/src/feature-plugins/system/dag-inspector.tsx
@@ -7,7 +7,6 @@ import { useTerminalDimensions } from "@opentui/solid"
 import { Spinner } from "../../component/spinner"
 import { useBindings, useCommandShortcut } from "../../keymap"
 import { selectedForeground, useTheme } from "../../context/theme"
-import { SplitBorder } from "../../ui/border"
 import {
   computeNodeRowIndex,
   computeWaves,
@@ -28,10 +27,11 @@ import type { DagWorkflowSummary } from "@opencode-ai/sdk/v2"
 
 const id = "internal:system-dag-inspector"
 const ROUTE = "dag"
-// Workflow sidebar mirrors the chat sidebar: fixed width, panel background,
-// and only present on wide terminals (chat uses the same > 120 threshold).
-const SIDEBAR_WIDTH = 42
-const WIDE_TERMINAL_WIDTH = 120
+// The workflow list is primary navigation, not ambient metadata, so it is
+// always present. It only narrows on small terminals — never disappears.
+const NAV_WIDTH_MAX = 32
+const NAV_WIDTH_MIN = 18
+const NAV_WIDTH_SHARE = 0.3
 // Node detail content rows: header, dependencies, error/output preview. The
 // detail block adds two padding rows on top; fixed so changing the selection
 // never moves the footer.
@@ -54,10 +54,11 @@ function DagInspector(props: { api: TuiPluginApi }) {
   // so the full theme comes from the context, as in the diff viewer.
   const themeState = useTheme()
   const dimensions = useTerminalDimensions()
-  // Below this width the sidebar would squeeze the wave list into unreadable
-  // truncation, so it is dropped entirely and the summary block carries the
-  // workflow position instead.
-  const wide = createMemo(() => dimensions().width > WIDE_TERMINAL_WIDTH)
+  // Navigation stays on screen at every width; it yields columns to the wave
+  // list instead of vanishing, which is what a primary navigation pane owes.
+  const navWidth = createMemo(() =>
+    Math.max(NAV_WIDTH_MIN, Math.min(NAV_WIDTH_MAX, Math.floor(dimensions().width * NAV_WIDTH_SHARE))),
+  )
   const params = () =>
     ("params" in props.api.route.current ? props.api.route.current.params : undefined) as
       | { sessionID?: string; returnRoute?: { name: string; params?: Record<string, unknown> } }
@@ -394,9 +395,71 @@ function DagInspector(props: { api: TuiPluginApi }) {
 
   return (
     <box width="100%" height="100%">
-      <box flexGrow={1} minHeight={0} flexDirection="row">
-        {/* Main column — the chat message-area vocabulary: two-column side
-          padding, rail-and-panel blocks, no frame lines. */}
+      {/* Title row — identity, subject, scale. Bold reserved for identity. */}
+      <box flexDirection="row" gap={1} flexShrink={0} paddingTop={1} paddingLeft={2} paddingRight={2}>
+        <text fg={theme().text} flexShrink={0}>
+          <b>DAG</b>
+        </text>
+        <box flexGrow={1} minWidth={0}>
+          <text fg={theme().textMuted} wrapMode="none">
+            {selectedWorkflowSummary()?.title ?? "workflow inspector"}
+          </text>
+        </box>
+        <text fg={theme().textMuted} flexShrink={0}>
+          {workflows().length} {workflows().length === 1 ? "workflow" : "workflows"}
+        </text>
+      </box>
+
+      <box flexGrow={1} minHeight={0} flexDirection="row" marginTop={1}>
+        {/* Navigation pane — a distinct region marked by the panel surface and
+            its own padding rhythm rather than a drawn frame. Always present. */}
+        <box
+          width={navWidth()}
+          flexShrink={0}
+          minHeight={0}
+          backgroundColor={theme().backgroundPanel}
+          paddingTop={1}
+          paddingBottom={1}
+          paddingLeft={2}
+          paddingRight={2}
+        >
+          <scrollbox
+            ref={(element: ScrollBoxRenderable) => (workflowScroll = element)}
+            flexGrow={1}
+            minHeight={0}
+            verticalScrollbarOptions={{ visible: false }}
+            horizontalScrollbarOptions={{ visible: false }}
+          >
+            <For each={workflows()}>
+              {(wf) => {
+                const selected = () => selectedWorkflow() === wf.id
+                return (
+                  <box
+                    flexDirection="row"
+                    gap={1}
+                    width="100%"
+                    backgroundColor={selected() ? theme().backgroundElement : undefined}
+                    onMouseUp={() => setSelectedWorkflow(wf.id)}
+                  >
+                    <text fg={statusColor(wf.status)} flexShrink={0}>
+                      •
+                    </text>
+                    <box flexGrow={1} minWidth={0}>
+                      <text fg={theme().text} wrapMode="none">
+                        {wf.title}
+                      </text>
+                    </box>
+                    <text fg={theme().textMuted} flexShrink={0}>
+                      {formatDagProgress(wf)}
+                    </text>
+                  </box>
+                )
+              }}
+            </For>
+          </scrollbox>
+        </box>
+
+        {/* Content pane — waves and nodes. */}
         <box flexGrow={1} minWidth={0} minHeight={0} paddingTop={1} paddingLeft={2} paddingRight={2}>
           <box flexGrow={1} minHeight={0}>
             <Switch>
@@ -415,48 +478,21 @@ function DagInspector(props: { api: TuiPluginApi }) {
                 </box>
               </Match>
               <Match when={workflows().length > 0}>
-                {/* Selected workflow summary — the user-message block: status
-                  rail + panel background, mirroring the chat transcript. */}
-                <box
-                  flexShrink={0}
-                  border={["left"]}
-                  borderColor={statusColor(selectedWorkflowSummary()?.status ?? "")}
-                  customBorderChars={SplitBorder.customBorderChars}
-                >
-                  <box
-                    paddingTop={1}
-                    paddingBottom={1}
-                    paddingLeft={2}
-                    paddingRight={2}
-                    backgroundColor={theme().backgroundPanel}
-                    flexShrink={0}
-                  >
-                    <text fg={theme().text}>
-                      <b>{selectedWorkflowSummary()?.title ?? ""}</b>
-                    </text>
-                    <text wrapMode="none">
-                      <span style={{ fg: statusColor(selectedWorkflowSummary()?.status ?? "") }}>
-                        {selectedWorkflowSummary()?.status ?? "unknown"}
-                      </span>
-                      <span style={{ fg: theme().textMuted }}>
-                        {" · "}
-                        {nodes().length} {nodes().length === 1 ? "node" : "nodes"} · {layers().length}{" "}
-                        {layers().length === 1 ? "wave" : "waves"}
-                      </span>
-                      <Show when={actionMessage()}>
-                        <span style={{ fg: theme().warning }}> · {actionMessage()}</span>
-                      </Show>
-                      {/* Without the sidebar the summary block is the only
-                          place the workflow position can be read. */}
-                      <Show when={!wide() && workflows().length > 1}>
-                        <span style={{ fg: theme().textMuted }}>
-                          {" · workflow "}
-                          {workflows().findIndex((workflow) => workflow.id === selectedWorkflow()) + 1}/
-                          {workflows().length}
-                        </span>
-                      </Show>
-                    </text>
-                  </box>
+                {/* Status line — state colour plus muted scale, one row. */}
+                <box flexShrink={0}>
+                  <text wrapMode="none">
+                    <span style={{ fg: statusColor(selectedWorkflowSummary()?.status ?? "") }}>
+                      {selectedWorkflowSummary()?.status ?? "unknown"}
+                    </span>
+                    <span style={{ fg: theme().textMuted }}>
+                      {" · "}
+                      {nodes().length} {nodes().length === 1 ? "node" : "nodes"} · {layers().length}{" "}
+                      {layers().length === 1 ? "wave" : "waves"}
+                    </span>
+                    <Show when={actionMessage()}>
+                      <span style={{ fg: theme().warning }}> · {actionMessage()}</span>
+                    </Show>
+                  </text>
                 </box>
                 <scrollbox
                   ref={(element: ScrollBoxRenderable) => (nodeScroll = element)}
@@ -534,141 +570,73 @@ function DagInspector(props: { api: TuiPluginApi }) {
                     )}
                   </For>
                 </scrollbox>
-                {/* Node detail — the block-tool vocabulary: soft inset rail,
-                  panel background, fixed height so selection changes never
-                  move the footer. */}
+                {/* Node detail — a distinct region on the panel surface, fixed
+                    height so selection changes never move the footer. */}
                 <box
                   flexShrink={0}
                   marginTop={1}
                   height={NODE_DETAIL_HEIGHT + 2}
-                  border={["left"]}
-                  borderColor={selectedNodeDetail()?.error_reason ? theme().error : theme().background}
-                  customBorderChars={SplitBorder.customBorderChars}
+                  flexDirection="column"
+                  paddingTop={1}
+                  paddingBottom={1}
+                  paddingLeft={2}
+                  paddingRight={2}
+                  backgroundColor={theme().backgroundPanel}
                 >
-                  <box
-                    flexGrow={1}
-                    flexDirection="column"
-                    paddingTop={1}
-                    paddingBottom={1}
-                    paddingLeft={2}
-                    paddingRight={2}
-                    backgroundColor={theme().backgroundPanel}
-                  >
-                    <Show when={selectedNodeDetail()}>
-                      {(node) => (
-                        <>
-                          <box flexDirection="row" gap={1}>
-                            <text fg={theme().text} wrapMode="none" flexShrink={0}>
-                              {node().name}
-                            </text>
-                            <text fg={theme().textMuted} wrapMode="none">
-                              {node().worker_type}
-                              {node().model_id ? ` · ${node().model_id}` : ""}
-                              {formatDagDuration(node().started_at, node().completed_at)
-                                ? ` · ${formatDagDuration(node().started_at, node().completed_at)}`
-                                : ""}
-                              {dagNodeHistoryLabel(node()) ? ` · ${dagNodeHistoryLabel(node())}` : ""}
-                            </text>
-                            <Show when={formatDagDeadline(node().status, node().deadline_ms, now())}>
-                              {(deadline) => (
-                                <text wrapMode="none" flexShrink={0}>
-                                  <span style={{ fg: theme().textMuted }}>·</span>{" "}
-                                  <span style={{ fg: deadline() === "overdue" ? theme().error : theme().warning }}>
-                                    {deadline()}
-                                  </span>
-                                </text>
-                              )}
-                            </Show>
-                          </box>
-                          <Show when={node().depends_on.length > 0}>
-                            <text fg={theme().textMuted} wrapMode="none">
-                              depends on {node().depends_on.join(", ")}
-                            </text>
+                  <Show when={selectedNodeDetail()}>
+                    {(node) => (
+                      <>
+                        <box flexDirection="row" gap={1}>
+                          <text fg={theme().text} wrapMode="none" flexShrink={0}>
+                            {node().name}
+                          </text>
+                          <text fg={theme().textMuted} wrapMode="none">
+                            {node().worker_type}
+                            {node().model_id ? ` · ${node().model_id}` : ""}
+                            {formatDagDuration(node().started_at, node().completed_at)
+                              ? ` · ${formatDagDuration(node().started_at, node().completed_at)}`
+                              : ""}
+                            {dagNodeHistoryLabel(node()) ? ` · ${dagNodeHistoryLabel(node())}` : ""}
+                          </text>
+                          <Show when={formatDagDeadline(node().status, node().deadline_ms, now())}>
+                            {(deadline) => (
+                              <text wrapMode="none" flexShrink={0}>
+                                <span style={{ fg: theme().textMuted }}>·</span>{" "}
+                                <span style={{ fg: deadline() === "overdue" ? theme().error : theme().warning }}>
+                                  {deadline()}
+                                </span>
+                              </text>
+                            )}
                           </Show>
-                          <Switch>
-                            <Match when={node().error_reason}>
-                              <text fg={theme().error} wrapMode="none">
-                                {formatDagError(node().error_reason!)}
-                              </text>
-                            </Match>
-                            <Match when={formatDagOutputPreview(node().output)}>
-                              <text fg={theme().textMuted} wrapMode="none">
-                                {formatDagOutputPreview(node().output)}
-                              </text>
-                            </Match>
-                          </Switch>
-                        </>
-                      )}
-                    </Show>
-                  </box>
+                        </box>
+                        <Show when={node().depends_on.length > 0}>
+                          <text fg={theme().textMuted} wrapMode="none">
+                            depends on {node().depends_on.join(", ")}
+                          </text>
+                        </Show>
+                        <Switch>
+                          <Match when={node().error_reason}>
+                            <text fg={theme().error} wrapMode="none">
+                              {formatDagError(node().error_reason!)}
+                            </text>
+                          </Match>
+                          <Match when={formatDagOutputPreview(node().output)}>
+                            <text fg={theme().textMuted} wrapMode="none">
+                              {formatDagOutputPreview(node().output)}
+                            </text>
+                          </Match>
+                        </Switch>
+                      </>
+                    )}
+                  </Show>
                 </box>
               </Match>
             </Switch>
           </box>
         </box>
-
-        {/* Workflow sidebar — the chat sidebar vocabulary: fixed width, panel
-          background, bold title, dot-status rows. Fixed layout: present
-          whenever the terminal is wide, empty when there is nothing to list. */}
-        <Show when={wide()}>
-          <box
-            width={SIDEBAR_WIDTH}
-            height="100%"
-            flexShrink={0}
-            backgroundColor={theme().backgroundPanel}
-            paddingTop={1}
-            paddingBottom={1}
-            paddingLeft={2}
-            paddingRight={2}
-          >
-            <box flexShrink={0}>
-              <text fg={theme().text}>
-                <b>DAG</b>
-              </text>
-              <text fg={theme().textMuted}>
-                {workflows().length} {workflows().length === 1 ? "workflow" : "workflows"}
-              </text>
-            </box>
-            <scrollbox
-              ref={(element: ScrollBoxRenderable) => (workflowScroll = element)}
-              flexGrow={1}
-              marginTop={1}
-              verticalScrollbarOptions={{ visible: false }}
-              horizontalScrollbarOptions={{ visible: false }}
-            >
-              <For each={workflows()}>
-                {(wf) => {
-                  const selected = () => selectedWorkflow() === wf.id
-                  return (
-                    <box
-                      flexDirection="row"
-                      gap={1}
-                      width="100%"
-                      backgroundColor={selected() ? theme().backgroundElement : undefined}
-                      onMouseUp={() => setSelectedWorkflow(wf.id)}
-                    >
-                      <text fg={statusColor(wf.status)} flexShrink={0}>
-                        •
-                      </text>
-                      <box flexGrow={1} minWidth={0}>
-                        <text fg={theme().text} wrapMode="none">
-                          {wf.title}
-                        </text>
-                      </box>
-                      <text fg={theme().textMuted} flexShrink={0}>
-                        {formatDagProgress(wf)}
-                      </text>
-                    </box>
-                  )
-                }}
-              </For>
-            </scrollbox>
-          </box>
-        </Show>
       </box>
 
-      {/* Footer hints — the chat footer vocabulary: a full-width bottom row
-          that the sidebar never squeezes; key in text color, label muted. */}
+      {/* Footer hints — key in text colour, label muted, full width. */}
       <box flexDirection="row" gap={2} flexShrink={0} paddingLeft={2} paddingRight={2} paddingBottom={1}>
         <For each={footerHints()}>
           {(hint) => (

--- a/packages/tui/test/feature-plugins/dag-inspector.test.tsx
+++ b/packages/tui/test/feature-plugins/dag-inspector.test.tsx
@@ -623,33 +623,23 @@ describe("DagInspector", () => {
     }
   })
 
-  test("the workflow sidebar only appears on wide terminals", async () => {
-    const wide = await renderDagInspector({
-      width: 130,
-      workflows: [wfSummary({ id: "wf-1", title: "Evidence pipeline" })],
-      nodes: [dagNode({ id: "n-1", name: "collect", status: "running" })],
-    })
-    try {
-      // The sidebar header is the marker: it renders "DAG" plus a workflow count.
-      await wide.app.waitForFrame((frame) => frame.includes("1 workflow"))
-    } finally {
-      wide.app.renderer.destroy()
-    }
-
-    const narrow = await renderDagInspector({
-      width: 100,
-      workflows: [
-        wfSummary({ id: "wf-1", title: "Evidence pipeline" }),
-        wfSummary({ id: "wf-2", title: "Second workflow" }),
-      ],
-      nodes: [dagNode({ id: "n-1", name: "collect", status: "running" })],
-    })
-    try {
-      // Sidebar dropped; the summary block carries the position instead so the
-      // left/right workflow cursor stays legible.
-      await narrow.app.waitForFrame((frame) => frame.includes("workflow 1/2") && !frame.includes("2 workflows"))
-    } finally {
-      narrow.app.renderer.destroy()
+  test("the workflow navigation pane survives every terminal width", async () => {
+    // Primary navigation must never disappear; it only narrows. A previous
+    // revision borrowed the chat sidebar's > 120 gate and lost the list here.
+    for (const width of [130, 100, 70]) {
+      const viewer = await renderDagInspector({
+        width,
+        workflows: [
+          wfSummary({ id: "wf-1", title: "alpha" }),
+          wfSummary({ id: "wf-2", title: "beta", status: "paused" }),
+        ],
+        nodes: [dagNode({ id: "n-1", name: "collect", status: "running" })],
+      })
+      try {
+        await viewer.app.waitForFrame((frame) => frame.includes("alpha") && frame.includes("beta"))
+      } finally {
+        viewer.app.renderer.destroy()
+      }
     }
   })
 })


### PR DESCRIPTION
## Summary

The previous revision (#137) **transplanted chat's structure** instead of learning its design language. This PR keeps the vocabulary and gives the inspector its own structure back.

### What was wrongly imported

| Removed | Its meaning in chat | What it was doing here |
|---|---|---|
| 42-wide right sidebar + `backgroundPanel` | container for **ambient session metadata** (MCP, todos, context) — optional | held the workflow list, which is **primary navigation** |
| `width > 120` gate | sized for that optional metadata | made primary navigation **vanish** on narrow terminals |
| `SplitBorder` rail-and-panel block | marks **one utterance in a stream** | wrapped the workflow summary, which is persistent state |

The tell was the symptom: the workflow list disappearing below 120 columns. #137 treated that as "responsive not implemented" and **copied chat's breakpoint to fix it**, entrenching the transplant rather than questioning it. Primary navigation should not have a "disappeared" state at all.

### Structure now derives from what this screen is

A full-screen inspector: title row → always-present navigation pane → content pane → detail pane → footer. Navigation width is `clamp(18, 32, width * 0.3)`, derived from the pane's own needs, so it **narrows instead of disappearing**:

```
width=110                                        width=70
|  DAG Evidence pipeline        2 workflows  |   |  DAG Evidence pipeline    2 workflows  |
|                                            |   |                                        |
|  • Evidence pipeline  1/4   running · 3 no |   |  • Evidence pi 1/4   running · 3 nodes |
|  • Second workflow    0/2                  |   |  • Second work 0/2                     |
|                       wave 1 · 1 node      |   |                wave 1 · 1 node         |
|                         ✓ collect build    |   |                  ✓ collect build       |
|                                            |   |                                        |
|                       wave 2 · 2 nodes     |   |                wave 2 · 2 nodes        |
|                         ⠋ analyze General. |   |                  ⠋ analyze GeneralPurp |
```

### Only the vocabulary is borrowed

- Regions marked by the **panel surface + padding rhythm** rather than drawn box characters — which also settles the original "the bottom rule looks misaligned" complaint by removing the rules entirely
- Token semantics: `text` body, `textMuted` metadata, `backgroundElement` secondary selection, `primary` + `selectedForeground()` for the cursor, status colours for state
- Bold reserved for identity (`DAG`) and section headers (`wave N`); body and metadata never bold

Kept from #137: cursor-key convergence (`↑↓` nodes, `←→` workflows, `return`, `escape`), the selection colour layering, the empty-state guidance, and the tightened lint ratchet.

## Test plan

- `tsgo --noEmit` clean; `prettier --check` clean
- `oxlint` on the changed component: **0 warnings**
- Lint ratchet at 4690: **PASS**
- Full TUI suite: **233 pass / 0 fail**
- The width regression test now asserts the **inverse invariant** — the workflow list is present at 130, 100 *and* 70 columns — with a comment recording why the previous gate was wrong, so the mistake cannot silently return
