### PR TITLE
fix(dag): harden recovery and replan races

### DIFF
--- a/packages/core/src/dag/core/scheduling.ts
+++ b/packages/core/src/dag/core/scheduling.ts
@@ -136,6 +136,11 @@ export class WorkflowRuntime {
     return false
   }
 
+  /** Returns true when the current runtime graph contains the node. */
+  containsNode(nodeID: string): boolean {
+    return this.graph.hasNode(nodeID)
+  }
+
   /** Returns true if the node is in running or pending (not yet terminal) state. */
   isActive(nodeID: string): boolean {
     return (

--- a/packages/core/src/dag/core/types.ts
+++ b/packages/core/src/dag/core/types.ts
@@ -106,6 +106,11 @@ export class TerminalViolationError extends DagCoreError {
   }
 }
 
+/** Returns true when a concurrent status change made the requested transition obsolete. */
+export function isTransitionRejection(error: unknown): error is InvalidTransitionError | TerminalViolationError {
+  return error instanceof InvalidTransitionError || error instanceof TerminalViolationError
+}
+
 export class StateNotPersistedError extends DagCoreError {
   constructor(workflowId: string, reason?: string) {
     super(

--- a/packages/core/test/dag-core.test.ts
+++ b/packages/core/test/dag-core.test.ts
@@ -617,6 +617,8 @@ describe("WorkflowRuntime", () => {
 
   it("rebuildGraph reflects new topology", () => {
     const rt = new WorkflowRuntime(linearNodes(), 4)
+    expect(rt.containsNode("a")).toBe(true)
+    expect(rt.containsNode("x")).toBe(false)
     rt.markSatisfied("a")
     rt.markSatisfied("b")
     const newNodes: SchedulingNode[] = [
@@ -624,6 +626,8 @@ describe("WorkflowRuntime", () => {
       { id: "y", dependsOn: ["x"], status: "pending", required: false },
     ]
     rt.rebuildGraph(newNodes)
+    expect(rt.containsNode("a")).toBe(false)
+    expect(rt.containsNode("x")).toBe(true)
     expect(rt.getReadyNodes()).toEqual(["x"])
     expect(rt.isComplete()).toBe(false)
   })

--- a/packages/opencode/src/dag/runtime/loop.ts
+++ b/packages/opencode/src/dag/runtime/loop.ts
@@ -1,6 +1,6 @@
 export * as DagLoop from "./loop"
 
-import { Effect, Layer, Context, Stream, Semaphore, Fiber, Option } from "effect"
+import { Cause, Effect, Layer, Context, Stream, Semaphore, Fiber, Option } from "effect"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { InstanceState } from "@/effect/instance-state"
 import { EventV2Bridge } from "@/event-v2-bridge"
@@ -8,7 +8,7 @@ import { DagEvent } from "@opencode-ai/schema/dag-event"
 import { SessionStatusEvent } from "@opencode-ai/schema/session-status-event"
 import { DagStore } from "@opencode-ai/core/dag/store"
 import { WorkflowRuntime, toSchedulingNodes } from "@opencode-ai/core/dag/core/scheduling"
-import { isWorkflowTerminalStatus } from "@opencode-ai/core/dag/core/types"
+import { isNodeTerminalStatus, isWorkflowTerminalStatus } from "@opencode-ai/core/dag/core/types"
 import { Dag, type WorkflowConfig, parseWorkflowConfig } from "../dag"
 import { projectBriefForNode } from "../admission"
 import {
@@ -236,7 +236,7 @@ export const layer = Layer.effect(
               Effect.provideService(Session.Service, sessionSvc),
               Effect.provideService(SessionPrompt.Service, promptSvc),
               Effect.catchCause((cause) =>
-                dag.nodeFailed(dagID, nodeID, String(cause), "exec_failed"),
+                dag.nodeFailed(dagID, nodeID, Cause.pretty(cause), "exec_failed"),
               ),
               Effect.ignore,
             )
@@ -247,6 +247,15 @@ export const layer = Layer.effect(
           const entry = runtimes.get(dagID)
           if (!entry) return
           if (!entry.runtime.isComplete()) return
+          // Replan registers replacement nodes before cancelling nodes from the
+          // old runtime graph. Event types are consumed independently, so the
+          // cancellation handler can reach this point before WorkflowReplanned
+          // rebuilds the in-memory graph. Durable active nodes prove that the
+          // apparent completion belongs to an obsolete graph generation.
+          const hasUnseenActiveNode = (yield* store.getNodes(dagID)).some(
+            (node) => !isNodeTerminalStatus(node.status as never) && !entry.runtime.containsNode(node.id),
+          )
+          if (hasUnseenActiveNode) return
           const wf = yield* store.getWorkflow(dagID).pipe(Effect.orDie)
           if (wf && isWorkflowTerminalStatus(wf.status as never)) return
           // A required-node failure is a workflow FAILURE, not a cancellation —

--- a/packages/opencode/src/dag/runtime/recovery.ts
+++ b/packages/opencode/src/dag/runtime/recovery.ts
@@ -22,6 +22,7 @@ import { Dag } from "../dag"
 import { Session } from "@/session/session"
 import { SessionID } from "@/session/schema"
 import type { DagStore } from "@opencode-ai/core/dag/store"
+import { isTransitionRejection } from "@opencode-ai/core/dag/core/types"
 
 export function reconcileWorkflow(
   dagID: string,
@@ -32,6 +33,18 @@ export function reconcileWorkflow(
   return Effect.gen(function* () {
     const dag = yield* Dag.Service
     const nodes = yield* dag.store.getNodes(dagID)
+    const settle = (nodeID: string, action: Effect.Effect<void, Error>) =>
+      action.pipe(
+        Effect.catchIf(
+          isTransitionRejection,
+          (error) =>
+            Effect.logDebug("DAG recovery ignored a concurrent transition rejection", {
+              dagID,
+              nodeID,
+              error,
+            }),
+        ),
+      )
     let reconciled = 0
     let ownershipLost = 0
 
@@ -55,7 +68,10 @@ export function reconcileWorkflow(
         // Crash landed between admission and session creation — no durable
         // outcome exists, so this is an invented failure like ownership loss.
         ownershipLost++
-        yield* dag.nodeFailed(dagID, node.id, "node was running but had no child session on recovery", "exec_failed")
+        yield* settle(
+          node.id,
+          dag.nodeFailed(dagID, node.id, "node was running but had no child session on recovery", "exec_failed"),
+        )
         reconciled++
         continue
       }
@@ -68,16 +84,27 @@ export function reconcileWorkflow(
         const nodeConfig = workflowConfig?.nodes.find((n) => n.id === node.id)
         if (nodeConfig?.output_schema) {
           if (node.capturedOutput !== undefined && node.capturedOutput !== null) {
-            yield* dag.nodeCompleted(dagID, node.id, node.capturedOutput)
+            yield* settle(node.id, dag.nodeCompleted(dagID, node.id, node.capturedOutput))
           } else {
-            yield* dag.nodeFailed(dagID, node.id, "output_schema declared but submit_result was never successfully called (recovered)", "verdict_fail")
+            yield* settle(
+              node.id,
+              dag.nodeFailed(
+                dagID,
+                node.id,
+                "output_schema declared but submit_result was never successfully called (recovered)",
+                "verdict_fail",
+              ),
+            )
           }
         } else {
-          yield* dag.nodeCompleted(dagID, node.id, undefined)
+          yield* settle(node.id, dag.nodeCompleted(dagID, node.id, undefined))
         }
         reconciled++
       } else if (sessionStatus === "failed") {
-        yield* dag.nodeFailed(dagID, node.id, "child session failed (recovered)", "exec_failed")
+        yield* settle(
+          node.id,
+          dag.nodeFailed(dagID, node.id, "child session failed (recovered)", "exec_failed"),
+        )
         reconciled++
       } else {
         ownershipLost++
@@ -96,16 +123,22 @@ export function reconcileWorkflow(
         if (node.deadlineMs !== null) {
           const now = yield* Clock.currentTimeMillis
           if (now >= node.deadlineMs) {
-            yield* dag.nodeFailed(dagID, node.id, "deadline exceeded on recovery", "timeout")
+            yield* settle(
+              node.id,
+              dag.nodeFailed(dagID, node.id, "deadline exceeded on recovery", "timeout"),
+            )
             reconciled++
             continue
           }
         }
-        yield* dag.nodeFailed(
-          dagID,
+        yield* settle(
           node.id,
-          "execution ownership lost on recovery",
-          "exec_failed",
+          dag.nodeFailed(
+            dagID,
+            node.id,
+            "execution ownership lost on recovery",
+            "exec_failed",
+          ),
         )
         reconciled++
       }

--- a/packages/opencode/src/dag/runtime/spawn.ts
+++ b/packages/opencode/src/dag/runtime/spawn.ts
@@ -29,16 +29,13 @@ import { SessionPrompt } from "@/session/prompt"
 import { Dag } from "../dag"
 import { DagModel } from "../model"
 import { validateReviewResult } from "../review-lifecycle"
-import { InvalidTransitionError, TerminalViolationError } from "@opencode-ai/core/dag/core/types"
+import { isTransitionRejection } from "@opencode-ai/core/dag/core/types"
 import type { DagStore } from "@opencode-ai/core/dag/store"
 import { ModelV2 } from "@opencode-ai/core/model"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 import { registerCaptureSlot, clearCaptureSlot } from "./capture"
 
 type PromptParts = SessionPrompt.PromptInput["parts"]
-
-const isTransitionRejection = (err: unknown): err is InvalidTransitionError | TerminalViolationError =>
-  err instanceof InvalidTransitionError || err instanceof TerminalViolationError
 
 export interface NodeSpawnInput {
   dagID: string
@@ -315,7 +312,7 @@ export function spawnNode(
         Effect.catchCause((cause) =>
           Effect.gen(function* () {
             if (Cause.interruptors(cause).size > 0) return
-            yield* dag.nodeFailed(input.dagID, input.nodeID, String(cause), "exec_failed").pipe(
+            yield* dag.nodeFailed(input.dagID, input.nodeID, Cause.pretty(cause), "exec_failed").pipe(
               Effect.catchIf(
                 isTransitionRejection,
                 () => Effect.logWarning("nodeFailed guard rejected — node already terminal"),

--- a/packages/opencode/test/dag/dag-recovery.test.ts
+++ b/packages/opencode/test/dag/dag-recovery.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from "bun:test"
-import { Effect, Layer } from "effect"
+import { Effect, Exit, Layer } from "effect"
 import { reconcileWorkflow } from "@/dag/runtime/recovery"
 import { Dag } from "@/dag/dag"
 import type { DagStore } from "@opencode-ai/core/dag/store"
 import { WorkflowRuntime, toSchedulingNodes } from "@opencode-ai/core/dag/core/scheduling"
+import { TerminalViolationError } from "@opencode-ai/core/dag/core/types"
 import { makeNodeRow } from "./fixtures"
 
 type TrackedEvent = {
@@ -302,6 +303,40 @@ describe("reconcileWorkflow", () => {
       reason: "output_schema declared but submit_result was never successfully called (recovered)",
       trigger: "verdict_fail",
     })
+  })
+
+  it("continues recovery when a concurrent settlement already terminalized the node", async () => {
+    const nodes = [makeNodeRow({ id: "n1", status: "running", childSessionId: "ses_1" })]
+    const dagLayer = Layer.mock(Dag.Service, {
+      store: {
+        getNodes: () => Effect.succeed(nodes),
+      } as unknown as DagStore.Interface,
+      nodeCompleted: () => Effect.fail(new TerminalViolationError("n1", "failed", "completed")),
+    })
+    const checkStatus = () => Effect.succeed("completed" as const)
+
+    const exit = await Effect.runPromiseExit(
+      reconcileWorkflow("wf-1", checkStatus).pipe(Effect.provide(dagLayer)),
+    )
+
+    expect(Exit.isSuccess(exit)).toBe(true)
+  })
+
+  it("does not hide non-transition settlement failures", async () => {
+    const nodes = [makeNodeRow({ id: "n1", status: "running", childSessionId: "ses_1" })]
+    const dagLayer = Layer.mock(Dag.Service, {
+      store: {
+        getNodes: () => Effect.succeed(nodes),
+      } as unknown as DagStore.Interface,
+      nodeCompleted: () => Effect.fail(new Error("database unavailable")),
+    })
+    const checkStatus = () => Effect.succeed("completed" as const)
+
+    const exit = await Effect.runPromiseExit(
+      reconcileWorkflow("wf-1", checkStatus).pipe(Effect.provide(dagLayer)),
+    )
+
+    expect(Exit.isFailure(exit)).toBe(true)
   })
 })
 

--- a/packages/opencode/test/dag/dag-replan-stale-nodefailed.test.ts
+++ b/packages/opencode/test/dag/dag-replan-stale-nodefailed.test.ts
@@ -189,6 +189,53 @@ function runLoopTest<A>(
 }
 
 describe("DagLoop replan vs stale NodeFailed", () => {
+  it("does not terminalize the old graph while a replacement graph is being applied", async () => {
+    await Effect.runPromise(
+      runLoopTest(({ dag, store, childPrompts }) =>
+        Effect.gen(function* () {
+          const dagID = yield* dag.create({
+            projectID: "project-1",
+            sessionID: "ses_parent",
+            title: "Replan completion guard",
+            config: {
+              name: "replan-completion-guard",
+              nodes: [{ ...node("a"), required: false }],
+            },
+          })
+          expect((yield* takeWithin(childPrompts, "a did not start")).title).toBe("a")
+
+          const plan = yield* dag.replan(dagID, {
+            nodes: [
+              { ...node("a"), required: false, cancel: true },
+              node("b"),
+            ],
+          })
+          expect(plan.cancel).toEqual(["a"])
+          expect(plan.add).toEqual(["b"])
+
+          const state = yield* pollWithTimeout(
+            Effect.all({
+              workflow: store.getWorkflow(dagID),
+              replacement: store.getNode(dagID, "b"),
+            }).pipe(
+              Effect.map((current) =>
+                current.workflow?.status !== "running" || current.replacement?.status === "running"
+                  ? current
+                  : undefined,
+              ),
+            ),
+            "replacement graph did not settle",
+          )
+          expect(state.workflow?.status).toBe("running")
+          const replacement = yield* takeWithin(childPrompts, "replacement b did not start")
+          expect(replacement.title).toBe("b")
+          expect(state.replacement?.status).toBe("running")
+          yield* Deferred.succeed(replacement.release, "done")
+        }),
+      ),
+    )
+  })
+
   it("interrupts the replan-restarted node's old fiber so its timeout cannot poison the new generation", async () => {
     await Effect.runPromise(
       runLoopTest(({ dag, store, childPrompts, parentPrompts }) =>

--- a/packages/opencode/test/dag/spawn-completion.test.ts
+++ b/packages/opencode/test/dag/spawn-completion.test.ts
@@ -246,7 +246,8 @@ describe("spawnNode completion bridge", () => {
 
     const failed = findEvent(events, "nodeFailed")
     expect(failed).toBeDefined()
-    expect(failed!.reason).toContain("LLM exploded")
+    expect(failed!.reason).toContain("Error: LLM exploded")
+    expect(failed!.reason).not.toContain("Cause([Die(")
 
     expect(findEvent(events, "nodeCompleted")).toBeUndefined()
   })


### PR DESCRIPTION
## Summary

- tolerate only validated transition rejections when recovery races with a concurrent node settlement, while preserving unrelated failures
- prevent an obsolete runtime graph from terminalizing a workflow while durable replacement nodes from replan are already active
- format Effect failures with Cause.pretty so persisted failure reasons retain useful context

## Diagnosis

The original deep-review verdict mixed correctness defects with architecture preferences. Two claims were reproduced as runtime bugs: recovery could abort on an already-settled node, and independent replan/cancellation event streams could complete the old graph before the replacement graph was installed. The proposed wholesale extraction of InstanceState.make was not applied: DagLoop already has an integration-test seam and duplicating its state machine would not fix either race.

An initially broader completion guard was rejected by regression testing because it prevented a genuine required-node failure from settling when durable dependents remained pending. The final guard blocks only active durable nodes that are absent from the current runtime generation.

## Tests

- packages/opencode: bun test test/dag --timeout 30000 (265 pass)
- packages/core: bun test test/dag --timeout 30000 (89 pass)
- packages/opencode: bun typecheck
- packages/core: bun typecheck