### PR TITLE
fix(dag): close release review blockers

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -3,7 +3,8 @@
 # ----------------------------------------------------------------------------
 # Purpose : Run unit + Playwright e2e tests across Linux & Windows
 # Trigger : Push to `main`/`dev`, PRs targeting `main`, manual dispatch
-# Jobs    : unit  — `bun turbo test` on linux only (windows dropped — see
+# Jobs    : unit  — `bun turbo test` + config_assistant Go tests on linux
+#                    only (windows dropped — see
 #                    unit-tests matrix comment; free windows-latest runners
 #                    can't fit the suite in a reasonable CI budget)
 #           e2e   — Playwright chromium on linux + windows (matrix)
@@ -68,6 +69,13 @@ jobs:
         with:
           node-version: "24"
 
+      - name: Setup Go
+        if: runner.os == 'Linux'
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: config_assistant/go.mod
+          cache-dependency-path: config_assistant/go.sum
+
       - name: Setup Bun
         uses: ./.github/actions/setup-bun
         with:
@@ -108,6 +116,11 @@ jobs:
         run: GITHUB_ACTIONS=false bun turbo test
         env:
           OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER: ${{ runner.os == 'Windows' && 'true' || 'false' }}
+
+      - name: Run config assistant tests
+        if: runner.os == 'Linux'
+        working-directory: config_assistant
+        run: go test ./...
 
       - name: Check generated client
         if: runner.os == 'Linux'

--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ Each node declares:
 | `output_schema` | JSON Schema; the child agent must call `submit_result` with a matching structured payload |
 | `required` | Failure of a required node fails the workflow |
 | `report_to_parent` | Wake the parent agent when this node reaches a terminal state |
-| `model` | Optional per-node model pin; otherwise resolves node → `node_defaults` → agent → `dag.jsonc` tier → parent session |
 | `review` | `design` or `diff` review phase with an implementation-fingerprint contract (below) |
 
 Workflow-level knobs: `max_concurrency` (default 5), `max_node_replan_attempts` (5), `max_total_nodes` (100), per-node `timeout_ms` (default 10 min, queue wait counts toward the deadline).
@@ -90,6 +89,7 @@ Workflow-level knobs: `max_concurrency` (default 5), `max_node_replan_attempts` 
 - **Tool robustness**: JSON repair for broken multi-byte Unicode escapes in LLM output, structured validation errors with field-level hints, expanded tool docs, child-process pipe fixes.
 - **CJK & IME fixes**: corrections for Chinese/Japanese/Korean input in the terminal UI (IME composition flushing, full-width text handling), plus a Korean IME fix script under [`patches/`](./patches).
 - **Worktree isolation**: per-workflow `git worktree` isolation, with experimental sandbox-worktree HTTP endpoints.
+- **Configuration assistant**: a standalone Go TUI under [`config_assistant`](./config_assistant) for locating, validating, and editing opencode configuration (`cd config_assistant && go run ./cmd/ocfg`).
 - An earlier "Goal auto-loop" and the `/goal`, `/subgoal`, `/workflow` slash commands are gone; autonomous execution now goes through the `workflow` tool and its wake mechanism.
 
 All upstream capabilities (multi-provider, built-in LSP, client/server architecture, TUI/desktop/web clients) are preserved.
@@ -117,7 +117,7 @@ bun dev serve        # headless API server (port 4096)
 
 ## Quality gates
 
-- **CI**: typecheck on every PR; the `main` gate additionally runs the full unit suite (Linux), Playwright e2e (Linux + Windows), an HTTP API contract exerciser, and generated-SDK freshness checks.
+- **CI**: typecheck on every PR; the `main` gate additionally runs the Bun/Turbo unit suite and config-assistant Go tests (Linux), Playwright e2e (Linux + Windows), an HTTP API contract exerciser, and generated-SDK freshness checks.
 - **DAG-specific tests**: core scheduling unit tests, projector/state-machine drift tests, workflow lifecycle integration tests, and HTTP API exercise scenarios for every DAG route.
 
 ## License

--- a/README.zh.md
+++ b/README.zh.md
@@ -38,7 +38,6 @@
 | `output_schema` | JSON Schema；子智能体必须调用 `submit_result` 提交匹配的结构化结果 |
 | `required` | 必需节点失败会使整个工作流失败 |
 | `report_to_parent` | 节点到达终态时唤醒父智能体 |
-| `model` | 可选的节点级模型指定；否则按 节点 → `node_defaults` → agent → `dag.jsonc` 分层 → 父会话 解析 |
 | `review` | `design` 或 `diff` 审查阶段，带实现指纹契约（见下） |
 
 工作流级参数：`max_concurrency`（默认 5）、`max_node_replan_attempts`（5）、`max_total_nodes`（100）、节点级 `timeout_ms`（默认 10 分钟，排队等待计入预算）。
@@ -90,6 +89,7 @@
 - **工具健壮性**：修复 LLM 输出里损坏的多字节 Unicode 转义（JSON 修复），校验错误带字段级提示，工具文档扩充，子进程管道修复。
 - **CJK 与 IME 修复**：终端 UI 里中日韩文输入的修正（IME 组字刷新、全角文本处理），另有 [`patches/`](./patches) 下的韩文 IME 修复脚本。
 - **Worktree 隔离**：按工作流的 `git worktree` 隔离，附实验性的 sandbox-worktree HTTP 端点。
+- **配置助手**：[`config_assistant`](./config_assistant) 下提供独立 Go TUI，用于定位、校验和编辑 opencode 配置（`cd config_assistant && go run ./cmd/ocfg`）。
 - 早期的「Goal 自动循环」和 `/goal`、`/subgoal`、`/workflow` 斜杠命令已经移除，自主执行统一走 `workflow` 工具和它的唤醒机制。
 
 上游全部能力（多 Provider、内置 LSP、客户端/服务器架构、TUI/桌面/Web 客户端）均完整保留。
@@ -117,7 +117,7 @@ bun dev serve        # headless API 服务（端口 4096）
 
 ## 质量门禁
 
-- **CI**：每个 PR 跑 typecheck；`main` 门禁额外运行全量单元测试（Linux）、Playwright e2e（Linux + Windows）、HTTP API 契约测试器、以及生成 SDK 的新鲜度校验。
+- **CI**：每个 PR 跑 typecheck；`main` 门禁额外运行 Bun/Turbo 单元测试与配置助手 Go 测试（Linux）、Playwright e2e（Linux + Windows）、HTTP API 契约测试器、以及生成 SDK 的新鲜度校验。
 - **DAG 专项测试**：核心调度单元测试、投影器/状态机漂移测试、工作流生命周期集成测试、每条 DAG 路由的 HTTP API 演练场景。
 
 ## 许可证

--- a/packages/opencode/src/dag/dag.ts
+++ b/packages/opencode/src/dag/dag.ts
@@ -28,7 +28,7 @@ import {
   transitionAdmission,
   validateAdmission,
 } from "./admission"
-import { validateReviewLifecycle } from "./review-lifecycle"
+import { unresolvedReviewOutcomes, validateReviewLifecycle } from "./review-lifecycle"
 import { conditionReference } from "./runtime/eval"
 
 // Re-export domain types
@@ -85,6 +85,18 @@ export interface WorkflowConfig {
   max_total_nodes?: number
   node_defaults?: NodeDefaults
   nodes: NodeConfig[]
+}
+
+export class ReviewGateError extends Error {
+  readonly dagID: string
+  readonly reviewIDs: string[]
+
+  constructor(dagID: string, reviewIDs: string[]) {
+    super(`Cannot complete deep workflow ${dagID}: unresolved review outcome(s): ${reviewIDs.join(", ")}`)
+    this.name = "ReviewGateError"
+    this.dagID = dagID
+    this.reviewIDs = reviewIDs
+  }
 }
 
 export function normalizeModel(model: NodeConfig["model"]) {
@@ -452,6 +464,12 @@ export const layer = Layer.effect(
     })
     const complete = Effect.fn("Dag.complete")(function* (dagID: string) {
       yield* guardWorkflow(dagID, WorkflowStatus.COMPLETED)
+      const workflow = yield* store.getWorkflow(dagID).pipe(Effect.orDie)
+      const config = workflow ? parseWorkflowConfig(workflow.config) : undefined
+      const unresolvedReviews = config
+        ? unresolvedReviewOutcomes(config, yield* store.getNodes(dagID))
+        : []
+      if (unresolvedReviews.length > 0) yield* Effect.fail(new ReviewGateError(dagID, unresolvedReviews))
       yield* terminateNonTerminalNodes(dagID, "agent_complete", "", false)
       yield* events.publish(DagEvent.WorkflowCompleted, { dagID: dagID as ID, durationMs: 0 as never, timestamp: yield* DateTime.now })
     })

--- a/packages/opencode/src/dag/review-lifecycle.ts
+++ b/packages/opencode/src/dag/review-lifecycle.ts
@@ -1,16 +1,22 @@
 export * as DagReviewLifecycle from "./review-lifecycle"
 
 import type { NodeConfig, WorkflowConfig } from "./dag"
+import { evaluateCondition } from "./runtime/eval"
 
 export function validateReviewLifecycle(config: WorkflowConfig) {
   const issues = config.nodes.flatMap((node) => {
-    if (!isReviewWorker(node.worker_type)) return []
     if (!node.review) {
+      if (!isReviewWorker(node.worker_type)) return []
       if ((config.mode ?? "standard") === "standard") return []
       return [`${node.id}: deep review worker must declare review.phase as "design" or "diff"`]
     }
     if (node.review.phase === "design") return []
-    return validateDiffReview(config, node.id)
+    return [
+      ...validateDiffReview(config, node.id),
+      ...((config.mode ?? "standard") === "deep"
+        ? validateFinalReviewGate(config, node.id)
+        : []),
+    ]
   })
 
   if ((config.mode ?? "standard") === "standard") {
@@ -140,6 +146,37 @@ export function validateReviewResult(output: unknown, currentFingerprint: string
   }
 }
 
+export function unresolvedReviewOutcomes(
+  config: WorkflowConfig,
+  nodes: ReadonlyArray<{ id: string; status: string; output: unknown }>,
+) {
+  if ((config.mode ?? "standard") !== "deep") return []
+  const rows = new Map(nodes.map((node) => [node.id, node]))
+  const reviews = config.nodes.filter((node) => node.review?.phase === "diff")
+  return reviews.flatMap((review) => {
+    if (
+      isCorrectionReview(config, reviews, review)
+      && rows.get(review.id)?.status !== "completed"
+    ) return []
+    if (reviewAccepted(config, rows, review)) return []
+    const corrected = reviews.some((candidate) => {
+      const implementationID = candidate.review?.implementation_node_id
+      if (!implementationID || !dependsTransitively(config, implementationID, review.id)) return false
+      return reviewAccepted(config, rows, candidate)
+    })
+    return corrected ? [] : [review.id]
+  })
+}
+
+function isCorrectionReview(config: WorkflowConfig, reviews: NodeConfig[], review: NodeConfig) {
+  const implementationID = review.review?.implementation_node_id
+  return implementationID !== undefined
+    && reviews.some((candidate) =>
+      candidate.id !== review.id
+      && dependsTransitively(config, implementationID, candidate.id),
+    )
+}
+
 export function reviewContractForNode(node: NodeConfig) {
   if (!node.review) return undefined
   if (node.review.phase === "design") {
@@ -215,6 +252,45 @@ function validateDiffReview(config: WorkflowConfig, reviewID: string) {
   ]
 }
 
+function validateFinalReviewGate(config: WorkflowConfig, reviewID: string) {
+  const gate = finalReviewGates(config, reviewID).length > 0
+  return gate
+    ? []
+    : [`${reviewID}: deep diff review must feed a required final gate conditioned on verdict ACCEPT`]
+}
+
+function finalReviewGates(config: WorkflowConfig, reviewID: string) {
+  return config.nodes.filter((node) =>
+    node.id !== reviewID
+    && node.required
+    && dependsTransitively(config, node.id, reviewID)
+    && Object.values(node.input_mapping ?? {}).some((source) =>
+      source === `${reviewID}.output` || source.startsWith(`${reviewID}.output.`),
+    )
+    && acceptsReviewVerdict(node.condition, reviewID),
+  )
+}
+
+function reviewAccepted(
+  config: WorkflowConfig,
+  rows: ReadonlyMap<string, { status: string; output: unknown }>,
+  review: NodeConfig,
+) {
+  const row = rows.get(review.id)
+  return row?.status === "completed"
+    && reviewVerdict(row.output) === "ACCEPT"
+    && finalReviewGates(config, review.id).some((gate) => rows.get(gate.id)?.status === "completed")
+}
+
+function acceptsReviewVerdict(condition: string | undefined, reviewID: string) {
+  const output = (verdict: "ACCEPT" | "REJECT") => ({
+    [reviewID]: { output: { verdict } },
+  })
+  const accepted = evaluateCondition(condition, output("ACCEPT"))
+  const rejected = evaluateCondition(condition, output("REJECT"))
+  return accepted.ok && accepted.value && rejected.ok && !rejected.value
+}
+
 function hasReviewResultSchema(schema: Record<string, unknown> | undefined) {
   if (!schema || schema.type !== "object") return false
   const required = schema.required
@@ -240,6 +316,12 @@ function hasPassVerdict(value: unknown): boolean {
   if (value === "PASS") return true
   if (typeof value !== "object" || value === null || Array.isArray(value)) return false
   return "verdict" in value && value.verdict === "PASS"
+}
+
+function reviewVerdict(value: unknown): "ACCEPT" | "REJECT" | undefined {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return undefined
+  if (!("verdict" in value)) return undefined
+  return value.verdict === "ACCEPT" || value.verdict === "REJECT" ? value.verdict : undefined
 }
 
 function dependsTransitively(config: WorkflowConfig, startID: string, targetID: string) {

--- a/packages/opencode/src/dag/runtime/loop.ts
+++ b/packages/opencode/src/dag/runtime/loop.ts
@@ -16,6 +16,7 @@ import {
   reviewContractForNode,
   validateReviewExecutionInput,
   reviewEvidenceKeys,
+  unresolvedReviewOutcomes,
 } from "../review-lifecycle"
 import { Agent } from "@/agent/agent"
 import { Session } from "@/session/session"
@@ -252,7 +253,8 @@ export const layer = Layer.effect(
           // cancellation handler can reach this point before WorkflowReplanned
           // rebuilds the in-memory graph. Durable active nodes prove that the
           // apparent completion belongs to an obsolete graph generation.
-          const hasUnseenActiveNode = (yield* store.getNodes(dagID)).some(
+          const nodes = yield* store.getNodes(dagID)
+          const hasUnseenActiveNode = nodes.some(
             (node) => !isNodeTerminalStatus(node.status as never) && !entry.runtime.containsNode(node.id),
           )
           if (hasUnseenActiveNode) return
@@ -263,6 +265,13 @@ export const layer = Layer.effect(
           // terminal status attributes the outcome correctly (P2-1).
           if (entry.runtime.hasRequiredFailure()) {
             yield* dag.fail(dagID, `required node(s) failed: ${entry.runtime.getRequiredFailures().join(", ")}`)
+            return
+          }
+          const unresolvedReviews = entry.config
+            ? unresolvedReviewOutcomes(entry.config, nodes)
+            : []
+          if (unresolvedReviews.length > 0) {
+            yield* dag.fail(dagID, `unresolved review outcome(s): ${unresolvedReviews.join(", ")}`)
             return
           }
           yield* dag.complete(dagID)

--- a/packages/opencode/src/dag/runtime/summary-publisher.ts
+++ b/packages/opencode/src/dag/runtime/summary-publisher.ts
@@ -61,8 +61,8 @@ export const layer = Layer.effect(
     const state = yield* InstanceState.make(
       Effect.fn("DagSummaryPublisher.state")(function* (ctx) {
         const scope = yield* Scope.Scope
-        // Per-session debounce map. Keys are sessionIDs with an in-flight
-        // recompute; a bounded window collapses a burst into one read.
+        // Per workspace/session debounce map. Keys identify a routed session
+        // with an in-flight recompute; a bounded window collapses a burst.
         //
         // NOTE: This is request-coalescing state for I/O deduplication, NOT
         // a parallel projection of DAG state. The summary is always recomputed
@@ -72,19 +72,20 @@ export const layer = Layer.effect(
         // reads would occur. This satisfies the "stateless derived view"
         // contract: no cached summary is ever served from this map.
         const pending = new Set<string>()
-        // Second coalescing tier keyed by dagID: node events don't carry a
-        // sessionID, and resolving it eagerly meant one getWorkflow query PER
-        // EVENT before the debounce window could absorb the burst (P1-4).
-        // Coalesce by dagID first, resolve the sessionID once after the
-        // window, then hand off to the session-level debounce.
+        // Second coalescing tier keyed by workspace/dagID: node events don't
+        // carry a sessionID, and resolving it eagerly meant one getWorkflow
+        // query PER EVENT before the debounce window could absorb the burst
+        // (P1-4). Resolve the sessionID once after the window, then hand off
+        // to the workspace/session debounce.
         const pendingByDag = new Set<string>()
 
-        const publishForSession = (sessionID: string) =>
+        const publishForSession = (sessionID: string, workspace: string | undefined) =>
           Effect.gen(function* () {
             const summaries = yield* store.getWorkflowSummaries(sessionID)
             GlobalBus.emit("event", {
               directory: ctx.directory,
               project: ctx.project.id,
+              workspace,
               payload: {
                 type: "dag.workflow.summary.updated",
                 properties: { sessionID, summaries },
@@ -92,44 +93,52 @@ export const layer = Layer.effect(
             })
           })
 
-        const schedulePublish = (sessionID: string) =>
+        const schedulePublish = (sessionID: string, workspace: string | undefined) =>
           Effect.gen(function* () {
-            // Coalesce: if a recompute is already scheduled for this session,
+            const key = `${workspace ?? ""}\0${sessionID}`
+            // Coalesce: if a recompute is already scheduled for this route,
             // let it absorb this trigger rather than queueing a second read.
             // The coalesced early return MUST NOT touch `pending` — only the
             // owning fiber clears its own slot, otherwise a coalesced caller
             // would delete the owner's entry and reopen the window.
-            if (pending.has(sessionID)) return
-            pending.add(sessionID)
+            if (pending.has(key)) return
+            pending.add(key)
             yield* Effect.gen(function* () {
               yield* Effect.sleep("50 millis")
-              yield* publishForSession(sessionID)
-            }).pipe(Effect.ensuring(Effect.sync(() => pending.delete(sessionID))))
+              yield* publishForSession(sessionID, workspace)
+            }).pipe(Effect.ensuring(Effect.sync(() => pending.delete(key))))
           })
 
-        const schedulePublishByDag = (dagID: string) =>
+        const schedulePublishByDag = (dagID: string, workspace: string | undefined) =>
           Effect.gen(function* () {
-            if (pendingByDag.has(dagID)) return
-            pendingByDag.add(dagID)
+            const key = `${workspace ?? ""}\0${dagID}`
+            if (pendingByDag.has(key)) return
+            pendingByDag.add(key)
             yield* Effect.gen(function* () {
               yield* Effect.sleep("50 millis")
               const wf = yield* store.getWorkflow(dagID)
+              if (wf?.projectId !== ctx.project.id) return
               // Hand off to the session-level debounce (not publishForSession
               // directly) so a concurrent session-keyed window absorbs this
               // trigger instead of producing a duplicate read.
-              if (wf) yield* schedulePublish(wf.sessionId)
-            }).pipe(Effect.ensuring(Effect.sync(() => pendingByDag.delete(dagID))))
+              yield* schedulePublish(wf.sessionId, workspace)
+            }).pipe(Effect.ensuring(Effect.sync(() => pendingByDag.delete(key))))
           })
 
         const unsubscribe = yield* events.listen((evt) => {
           if (!SUMMARY_TRIGGER_EVENTS.some((def) => def.type === evt.type)) return Effect.void
-          const data = evt.data as { dagID: string; sessionID?: string }
-          const publish = data.sessionID
-            ? schedulePublish(data.sessionID)
-            : schedulePublishByDag(data.dagID)
-          return publish.pipe(
+          if (evt.location?.directory !== ctx.directory) return Effect.void
+          const data = evt.data
+          if (
+            typeof data !== "object"
+            || data === null
+            || !("dagID" in data)
+            || typeof data.dagID !== "string"
+          ) return Effect.void
+          const dagID = data.dagID
+          return schedulePublishByDag(dagID, evt.location.workspaceID).pipe(
             Effect.catchCause((cause) =>
-              Effect.logWarning("DagSummaryPublisher: failed to publish summaries", { dagID: data.dagID, cause }),
+              Effect.logWarning("DagSummaryPublisher: failed to publish summaries", { dagID, cause }),
             ),
             Effect.forkIn(scope),
             Effect.asVoid,

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/dag.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/dag.ts
@@ -5,6 +5,7 @@ import { InvalidRequestError, ConflictError, notFound } from "../errors"
 import { Dag } from "@/dag/dag"
 import { Session } from "@/session/session"
 import { SessionID } from "@/session/schema"
+import { InstanceState } from "@/effect/instance-state"
 import { InvalidTransitionError, TerminalViolationError } from "@opencode-ai/core/dag/core/types"
 import type { DagStore } from "@opencode-ai/core/dag/store"
 
@@ -12,7 +13,11 @@ import type { DagStore } from "@opencode-ai/core/dag/store"
 function mapTransitionConflict<Success>(effect: Effect.Effect<Success, Error>) {
   return effect.pipe(
     Effect.catch((error: unknown) => {
-      if (error instanceof InvalidTransitionError || error instanceof TerminalViolationError) {
+      if (
+        error instanceof InvalidTransitionError
+        || error instanceof TerminalViolationError
+        || error instanceof Dag.ReviewGateError
+      ) {
         return Effect.fail(new ConflictError({ message: error.message, resource: "workflow" }))
       }
       // Any other Error is re-thrown as a defect (truly unexpected — surfaces as 500).
@@ -63,17 +68,42 @@ export const dagHandlers = HttpApiBuilder.group(InstanceHttpApi, "dag", (handler
       ...(r.completedAt !== null ? { completed_at: r.completedAt } : {}),
     })
 
+    const workflowInProject = Effect.fn("DagHttpApi.workflowInProject")(function* (dagID: string) {
+      const row = yield* dag.store.getWorkflow(dagID).pipe(Effect.orDie)
+      if (row?.projectId !== (yield* InstanceState.context).project.id) return undefined
+      return row
+    })
+
+    const requireWorkflow = Effect.fn("DagHttpApi.requireWorkflow")(function* (dagID: string) {
+      const row = yield* workflowInProject(dagID)
+      if (!row) return yield* Effect.fail(notFound(`Workflow not found: ${dagID}`))
+      return row
+    })
+
+    const requireSession = Effect.fn("DagHttpApi.requireSession")(function* (sessionID: string) {
+      const session = yield* sessions.get(SessionID.make(sessionID)).pipe(
+        Effect.catch(() => Effect.fail(notFound(`Session not found: ${sessionID}`))),
+      )
+      if (session.projectID !== (yield* InstanceState.context).project.id) {
+        return yield* Effect.fail(notFound(`Session not found: ${sessionID}`))
+      }
+      return session
+    })
+
     const list = Effect.fn("DagHttpApi.list")(function* () {
       const rows = yield* dag.store.listWorkflows().pipe(Effect.orDie)
-      return rows.map(wf)
+      const projectID = (yield* InstanceState.context).project.id
+      return rows.filter((row) => row.projectId === projectID).map(wf)
     })
 
     const bySession = Effect.fn("DagHttpApi.bySession")(function* (ctx: { params: { sessionID: string } }) {
+      yield* requireSession(ctx.params.sessionID)
       const rows = yield* dag.store.listBySession(ctx.params.sessionID).pipe(Effect.orDie)
       return rows.map(wf)
     })
 
     const summary = Effect.fn("DagHttpApi.summary")(function* (ctx: { params: { sessionID: string } }) {
+      yield* requireSession(ctx.params.sessionID)
       const summaries = yield* dag.store.getWorkflowSummaries(ctx.params.sessionID).pipe(Effect.orDie)
       return summaries.map((s) => ({
         id: s.id,
@@ -89,17 +119,17 @@ export const dagHandlers = HttpApiBuilder.group(InstanceHttpApi, "dag", (handler
     })
 
     const detail = Effect.fn("DagHttpApi.detail")(function* (ctx: { params: { dagID: string } }) {
-      const row = yield* dag.store.getWorkflow(ctx.params.dagID).pipe(Effect.orDie)
-      if (!row) return yield* Effect.fail(notFound(`Workflow not found: ${ctx.params.dagID}`))
-      return wf(row)
+      return wf(yield* requireWorkflow(ctx.params.dagID))
     })
 
     const nodes = Effect.fn("DagHttpApi.nodes")(function* (ctx: { params: { dagID: string } }) {
+      yield* requireWorkflow(ctx.params.dagID)
       const rows = yield* dag.store.getNodes(ctx.params.dagID).pipe(Effect.orDie)
       return rows.map(node)
     })
 
     const nodeDetail = Effect.fn("DagHttpApi.nodeDetail")(function* (ctx: { params: { dagID: string; nodeID: string } }) {
+      yield* requireWorkflow(ctx.params.dagID)
       const row = yield* dag.store.getNode(ctx.params.dagID, ctx.params.nodeID).pipe(Effect.orDie)
       if (!row) return yield* Effect.fail(notFound(`Node not found: ${ctx.params.nodeID}`))
       return node(row)
@@ -110,9 +140,7 @@ export const dagHandlers = HttpApiBuilder.group(InstanceHttpApi, "dag", (handler
       if (!config || typeof config !== "object" || !Array.isArray((config as Record<string, unknown>).nodes)) {
         return yield* Effect.fail(new InvalidRequestError({ message: "start requires 'config' with a 'nodes' array" }))
       }
-      const session = yield* sessions.get(SessionID.make(ctx.payload.session_id)).pipe(
-        Effect.catch(() => Effect.fail(notFound(`Session not found: ${ctx.payload.session_id}`))),
-      )
+      const session = yield* requireSession(ctx.payload.session_id)
       const cfg = config as Dag.WorkflowConfig
       // Same code path as the workflow tool's start action — create validates
       // the config (duplicate ids / dangling deps / condition refs / ceiling)
@@ -135,8 +163,7 @@ export const dagHandlers = HttpApiBuilder.group(InstanceHttpApi, "dag", (handler
       const op = ctx.payload.operation
 
       // Pre-check existence so non-existent workflows return 404, not a 500 defect.
-      const existing = yield* dag.store.getWorkflow(dagID).pipe(Effect.orDie)
-      if (!existing) return yield* Effect.fail(notFound(`Workflow not found: ${dagID}`))
+      yield* requireWorkflow(dagID)
 
       // Control ops may fail with InvalidTransitionError/TerminalViolationError for
       // semantically invalid operations (e.g. pause on a completed workflow). Map those

--- a/packages/opencode/test/dag/dag-review-lifecycle.test.ts
+++ b/packages/opencode/test/dag/dag-review-lifecycle.test.ts
@@ -6,6 +6,7 @@ import {
   validateReviewExecutionInput,
   validateReviewLifecycle,
   validateReviewResult,
+  unresolvedReviewOutcomes,
 } from "@/dag/review-lifecycle"
 
 function node(id: string, overrides: Partial<NodeConfig> = {}): NodeConfig {
@@ -96,6 +97,12 @@ function validDiffFlow() {
         required: ["verdict", "implementation_fingerprint"],
       },
     }),
+    node("final-audit", {
+      worker_type: "audit",
+      depends_on: ["review-diff"],
+      input_mapping: { review: "review-diff.output" },
+      condition: 'review-diff.output.verdict == "ACCEPT"',
+    }),
   ]
 }
 
@@ -135,10 +142,49 @@ describe("DAG review lifecycle", () => {
     ]))).toEqual({ valid: true, errors: [], warnings: [] })
   })
 
-  it("accepts implementation to verification PASS to diff review", () => {
+  it("accepts implementation to verification PASS to diff review to final audit", () => {
     expect(validateReviewLifecycle(workflow("deep", validDiffFlow()))).toEqual({
       valid: true,
       errors: [],
+      warnings: [],
+    })
+  })
+
+  it("rejects a deep diff review without a downstream final ACCEPT gate", () => {
+    const nodes = validDiffFlow().filter((item) => item.id !== "final-audit")
+    expect(validateReviewLifecycle(workflow("deep", nodes))).toEqual({
+      valid: false,
+      errors: [
+        "review-diff: deep diff review must feed a required final gate conditioned on verdict ACCEPT",
+      ],
+      warnings: [],
+    })
+  })
+
+  it("validates explicit diff-review metadata even on a non-review worker", () => {
+    const nodes = validDiffFlow().filter((item) => item.id !== "final-audit")
+    const review = nodes[2]
+    if (!review) throw new Error("fixture is incomplete")
+    review.worker_type = "general"
+    expect(validateReviewLifecycle(workflow("deep", nodes))).toEqual({
+      valid: false,
+      errors: [
+        "review-diff: deep diff review must feed a required final gate conditioned on verdict ACCEPT",
+      ],
+      warnings: [],
+    })
+  })
+
+  it("rejects a final gate that mentions ACCEPT but runs only for REJECT", () => {
+    const nodes = validDiffFlow()
+    const gate = nodes[3]
+    if (!gate) throw new Error("fixture is incomplete")
+    gate.condition = 'review-diff.output.verdict != "ACCEPT"'
+    expect(validateReviewLifecycle(workflow("deep", nodes))).toEqual({
+      valid: false,
+      errors: [
+        "review-diff: deep diff review must feed a required final gate conditioned on verdict ACCEPT",
+      ],
       warnings: [],
     })
   })
@@ -319,6 +365,90 @@ describe("DAG review lifecycle", () => {
     })
   })
 
+  it("keeps a deep workflow from succeeding with an unresolved review outcome", () => {
+    const rejected = workflow("deep", validDiffFlow())
+    expect(unresolvedReviewOutcomes(rejected, [
+      {
+        id: "review-diff",
+        status: "completed",
+        output: { verdict: "REJECT", implementation_fingerprint: "sha256:revision-1" },
+      },
+    ])).toEqual(["review-diff"])
+    expect(unresolvedReviewOutcomes(rejected, [
+      { id: "review-diff", status: "skipped", output: undefined },
+      { id: "final-audit", status: "skipped", output: undefined },
+    ])).toEqual(["review-diff"])
+    expect(unresolvedReviewOutcomes(rejected, [
+      {
+        id: "review-diff",
+        status: "completed",
+        output: { verdict: "ACCEPT", implementation_fingerprint: "sha256:revision-1" },
+      },
+      { id: "final-audit", status: "skipped", output: undefined },
+    ])).toEqual(["review-diff"])
+
+    const corrected = [
+      ...rejected.nodes,
+      node("implement-fix", {
+        depends_on: ["review-diff"],
+        condition: 'review-diff.output.verdict == "REJECT"',
+      }),
+      node("verify-fix", { depends_on: ["implement-fix"] }),
+      node("review-diff-2", {
+        worker_type: "review",
+        depends_on: ["verify-fix"],
+        review: {
+          phase: "diff",
+          implementation_node_id: "implement-fix",
+          verification_node_id: "verify-fix",
+        },
+      }),
+      node("final-audit-2", {
+        worker_type: "audit",
+        depends_on: ["review-diff-2"],
+        input_mapping: { review: "review-diff-2.output" },
+        condition: 'review-diff-2.output.verdict == "ACCEPT"',
+      }),
+    ]
+    expect(unresolvedReviewOutcomes(workflow("deep", corrected), [
+      {
+        id: "review-diff",
+        status: "completed",
+        output: { verdict: "REJECT", implementation_fingerprint: "sha256:revision-1" },
+      },
+      {
+        id: "review-diff-2",
+        status: "completed",
+        output: { verdict: "ACCEPT", implementation_fingerprint: "sha256:revision-2" },
+      },
+      { id: "final-audit-2", status: "completed", output: "audited" },
+    ])).toEqual([])
+    expect(unresolvedReviewOutcomes(workflow("deep", corrected), [
+      {
+        id: "review-diff",
+        status: "completed",
+        output: { verdict: "ACCEPT", implementation_fingerprint: "sha256:revision-1" },
+      },
+      { id: "final-audit", status: "completed", output: "audited" },
+      { id: "review-diff-2", status: "skipped", output: undefined },
+      { id: "final-audit-2", status: "skipped", output: undefined },
+    ])).toEqual([])
+    expect(unresolvedReviewOutcomes(workflow("deep", corrected), [
+      {
+        id: "review-diff",
+        status: "completed",
+        output: { verdict: "ACCEPT", implementation_fingerprint: "sha256:revision-1" },
+      },
+      { id: "final-audit", status: "completed", output: "audited" },
+      {
+        id: "review-diff-2",
+        status: "completed",
+        output: { verdict: "REJECT", implementation_fingerprint: "sha256:revision-2" },
+      },
+      { id: "final-audit-2", status: "skipped", output: undefined },
+    ])).toEqual(["review-diff-2"])
+  })
+
   it("accepts a rejected-review correction wave only after reimplementation and verification", () => {
     const first = validDiffFlow()
     const correction = [
@@ -364,6 +494,12 @@ describe("DAG review lifecycle", () => {
           },
           required: ["verdict", "implementation_fingerprint"],
         },
+      }),
+      node("final-audit-2", {
+        worker_type: "audit",
+        depends_on: ["review-diff-2"],
+        input_mapping: { review: "review-diff-2.output" },
+        condition: 'review-diff-2.output.verdict == "ACCEPT"',
       }),
     ]
 

--- a/packages/opencode/test/dag/dag-summary-publisher-behavior.test.ts
+++ b/packages/opencode/test/dag/dag-summary-publisher-behavior.test.ts
@@ -5,6 +5,7 @@ import { DagEvent } from "@opencode-ai/schema/dag-event"
 import { EventV2Bridge } from "@/event-v2-bridge"
 import { DagSummaryPublisher } from "@/dag/runtime/summary-publisher"
 import { GlobalBus } from "@/bus/global"
+import { InstanceState } from "@/effect/instance-state"
 import { it, pollWithTimeout } from "../lib/effect"
 
 const ts = (n: number) => DateTime.makeUnsafe(n)
@@ -12,12 +13,14 @@ const ts = (n: number) => DateTime.makeUnsafe(n)
 interface SummaryEmission {
   sessionID: string
   summaries: WorkflowSummary[]
+  workspace?: string
 }
 
 interface StoreControl {
   failures: number
   reads: Map<string, number>
   lookups: Map<string, number>
+  projects: Map<string, string>
   sessions: Map<string, string>
   summaries: Map<string, WorkflowSummary[]>
 }
@@ -31,15 +34,16 @@ function control() {
     failures: 0,
     reads: new Map<string, number>(),
     lookups: new Map<string, number>(),
+    projects: new Map<string, string>(),
     sessions: new Map<string, string>(),
     summaries: new Map<string, WorkflowSummary[]>(),
   } satisfies StoreControl
 }
 
-function workflow(id: string, sessionId: string): WorkflowRow {
+function workflow(id: string, sessionId: string, projectId: string): WorkflowRow {
   return {
     id,
-    projectId: "global",
+    projectId,
     sessionId,
     title: id,
     status: "running",
@@ -73,7 +77,7 @@ function runtime(state: StoreControl, bus: EventControl) {
       Effect.sync(() => {
         state.lookups.set(dagID, (state.lookups.get(dagID) ?? 0) + 1)
         const sid = state.sessions.get(dagID)
-        return sid ? workflow(dagID, sid) : undefined
+        return sid ? workflow(dagID, sid, state.projects.get(dagID) ?? "global") : undefined
       }),
     getWorkflowSummaries: (sessionID) =>
       Effect.sync(() => {
@@ -101,36 +105,51 @@ function runtime(state: StoreControl, bus: EventControl) {
 function startCollector() {
   const emissions: SummaryEmission[] = []
   const handler = (event: {
+    workspace?: string
     payload?: { type?: string; properties?: { sessionID?: string; summaries?: WorkflowSummary[] } }
   }) => {
     if (event.payload?.type !== "dag.workflow.summary.updated") return
     emissions.push({
       sessionID: event.payload.properties!.sessionID!,
       summaries: event.payload.properties!.summaries!,
+      ...(event.workspace ? { workspace: event.workspace } : {}),
     })
   }
   GlobalBus.on("event", handler)
   return { emissions, stop: () => GlobalBus.off("event", handler) }
 }
 
-function publishNodeEvents(bus: EventControl, dagID: string, count: number) {
+function publishNodeEvents(
+  bus: EventControl,
+  dagID: string,
+  count: number,
+  foreignDirectory = false,
+  workspaceID?: string,
+) {
   if (!bus.listener) return Effect.die(new Error("publisher listener is not ready"))
-  return Effect.forEach(
-    Array.from({ length: count }, (_, index) => index),
-    (index) => bus.listener!({
-      type: DagEvent.NodeRegistered.type,
-      data: {
-        dagID,
-        nodeID: `${dagID}-node-${index}`,
-        name: `Node ${index}`,
-        workerType: "build",
-        dependsOn: [],
-        required: true,
-        timestamp: ts(index),
-      },
-    } as never),
-    { discard: true },
-  )
+  return Effect.gen(function* () {
+    const instance = yield* InstanceState.context
+    yield* Effect.forEach(
+      Array.from({ length: count }, (_, index) => index),
+      (index) => bus.listener!({
+        type: DagEvent.NodeRegistered.type,
+        data: {
+          dagID,
+          nodeID: `${dagID}-node-${index}`,
+          name: `Node ${index}`,
+          workerType: "build",
+          dependsOn: [],
+          required: true,
+          timestamp: ts(index),
+        },
+        location: {
+          directory: foreignDirectory ? `${instance.directory}-foreign` : instance.directory,
+          ...(workspaceID ? { workspaceID } : {}),
+        },
+      } as never),
+      { discard: true },
+    )
+  })
 }
 
 function withCollector<A, E, R>(use: (collector: ReturnType<typeof startCollector>) => Effect.Effect<A, E, R>) {
@@ -240,6 +259,69 @@ describe("DagSummaryPublisher behavior", () => {
 
         expect(state.reads.get("ses-retry")).toBe(2)
         expect(collector.emissions[0].summaries).toEqual([summary("dag-retry", 2)])
+      }),
+    ).pipe(Effect.provide(runtime(state, bus)))
+  })
+
+  it.instance("ignores DAG events emitted by another project instance", () => {
+    const state = control()
+    const bus = {} satisfies EventControl
+    state.sessions.set("dag-foreign", "ses-foreign")
+    state.summaries.set("ses-foreign", [summary("dag-foreign", 1)])
+
+    return withCollector((collector) =>
+      Effect.gen(function* () {
+        yield* (yield* DagSummaryPublisher.Service).init()
+        yield* publishNodeEvents(bus, "dag-foreign", 1, true)
+        yield* Effect.sleep("150 millis")
+
+        expect(state.lookups.size).toBe(0)
+        expect(state.reads.size).toBe(0)
+        expect(collector.emissions).toEqual([])
+      }),
+    ).pipe(Effect.provide(runtime(state, bus)))
+  })
+
+  it.instance("ignores another project even when its event uses the same directory", () => {
+    const state = control()
+    const bus = {} satisfies EventControl
+    state.sessions.set("dag-foreign-project", "ses-foreign-project")
+    state.projects.set("dag-foreign-project", "foreign-project")
+    state.summaries.set("ses-foreign-project", [summary("dag-foreign-project", 1)])
+
+    return withCollector((collector) =>
+      Effect.gen(function* () {
+        yield* (yield* DagSummaryPublisher.Service).init()
+        yield* publishNodeEvents(bus, "dag-foreign-project", 1)
+        yield* Effect.sleep("150 millis")
+
+        expect(state.lookups.get("dag-foreign-project")).toBe(1)
+        expect(state.reads.size).toBe(0)
+        expect(collector.emissions).toEqual([])
+      }),
+    ).pipe(Effect.provide(runtime(state, bus)))
+  })
+
+  it.instance("routes summary emissions to the workspace carried by the DAG event", () => {
+    const state = control()
+    const bus = {} satisfies EventControl
+    state.sessions.set("dag-workspace", "ses-workspace")
+    state.summaries.set("ses-workspace", [summary("dag-workspace", 1)])
+
+    return withCollector((collector) =>
+      Effect.gen(function* () {
+        yield* (yield* DagSummaryPublisher.Service).init()
+        yield* publishNodeEvents(bus, "dag-workspace", 1, false, "wrk-origin")
+        yield* pollWithTimeout(
+          Effect.sync(() => collector.emissions[0]),
+          "workspace summary was not emitted",
+        )
+
+        expect(collector.emissions[0]).toEqual({
+          sessionID: "ses-workspace",
+          summaries: [summary("dag-workspace", 1)],
+          workspace: "wrk-origin",
+        })
       }),
     ).pipe(Effect.provide(runtime(state, bus)))
   })

--- a/packages/opencode/test/dag/dag-wake-integration.test.ts
+++ b/packages/opencode/test/dag/dag-wake-integration.test.ts
@@ -561,6 +561,104 @@ describe("DagLoop atomic wake integration", () => {
     ),
   )
 
+  integration.live("rejects early completion while a deep diff review is unresolved", () =>
+    runWakeTest(({ dag, store, childPrompts }) =>
+      Effect.gen(function* () {
+        const brief = {
+          goal: "Keep explicit completion behind the deep review gate",
+          scope: { in: ["DAG completion"], out: ["standard workflow semantics"] },
+          constraints: ["review rejection cannot become success"],
+          assumptions: ["the review graph is valid"],
+          acceptance_criteria: ["complete rejects unresolved reviews"],
+          evidence_required: ["integration test"],
+          risks: ["manual completion bypass"],
+          review_plan: ["verify the final ACCEPT gate"],
+          open_questions: [],
+          blocking_questions: [],
+        }
+        const dagID = yield* dag.create({
+          projectID: "project-1",
+          sessionID: "ses_parent",
+          title: "Deep early completion",
+          config: {
+            name: "deep-early-completion",
+            mode: "deep",
+            admission: {
+              protocol_version: 1,
+              brief_revision: 1,
+              qa_mode: "STANDARD",
+              verdict: "READY",
+              state: "READY",
+              fingerprint: fingerprintBrief(brief),
+              brief,
+            },
+            nodes: [
+              {
+                ...node("implement"),
+                output_schema: {
+                  type: "object",
+                  properties: {
+                    diff: { type: "string" },
+                    fingerprint: { type: "string" },
+                  },
+                  required: ["diff", "fingerprint"],
+                },
+              },
+              {
+                ...node("verify", ["implement"]),
+                output_schema: {
+                  type: "object",
+                  properties: { verdict: { enum: ["PASS", "FAIL"] } },
+                  required: ["verdict"],
+                },
+              },
+              {
+                ...node("review-diff", ["verify"]),
+                worker_type: "review",
+                review: {
+                  phase: "diff",
+                  implementation_node_id: "implement",
+                  verification_node_id: "verify",
+                },
+                input_mapping: {
+                  diff: "implement.output.diff",
+                  implementation_fingerprint: "implement.output.fingerprint",
+                  verification: "verify.output",
+                },
+                condition: 'verify.output.verdict == "PASS"',
+                output_schema: {
+                  type: "object",
+                  properties: {
+                    verdict: { enum: ["ACCEPT", "REJECT"] },
+                    implementation_fingerprint: { type: "string" },
+                  },
+                  required: ["verdict", "implementation_fingerprint"],
+                },
+              },
+              {
+                ...node("final-audit", ["review-diff"]),
+                worker_type: "audit",
+                input_mapping: { review: "review-diff.output" },
+                condition: 'review-diff.output.verdict == "ACCEPT"',
+              },
+            ],
+          },
+        })
+
+        yield* takeWithin(childPrompts, "implementation did not start")
+        const completion = yield* dag.complete(dagID).pipe(
+          Effect.as(undefined),
+          Effect.catch((error) => Effect.succeed(error)),
+        )
+        expect(completion).toBeInstanceOf(Error)
+        if (!(completion instanceof Error)) throw new Error("deep completion unexpectedly succeeded")
+        expect(completion.message).toContain("unresolved review outcome")
+        expect((yield* store.getWorkflow(dagID))?.status).toBe("running")
+        expect((yield* store.getNode(dagID, "review-diff"))?.status).toBe("pending")
+      }),
+    ),
+  )
+
   integration.live("keeps a completed non-reporting leaf workflow terminal", () =>
     runWakeTest(({ dag, store, childPrompts }) =>
       Effect.gen(function* () {
@@ -940,6 +1038,151 @@ describe("DagLoop atomic wake integration", () => {
                   wake_eligible: false,
                   wake_reported: false,
                   seq: 1,
+                },
+              ]).run()
+            }),
+          ).pipe(Effect.orDie),
+      ),
+    )
+  })
+
+  it("fails a recovered deep workflow when verification skips every diff review", async () => {
+    await Effect.runPromise(
+      runWakeTest(
+        ({ store, parentPrompts }) =>
+          Effect.gen(function* () {
+            const workflow = yield* pollWithTimeout(
+              store.getWorkflow("dag_recovered_review_rejection").pipe(
+                Effect.map((row) => row?.status === "failed" ? row : undefined),
+              ),
+              "recovered workflow without an accepted review did not fail",
+            )
+            expect((yield* store.getNode(workflow.id, "review-diff"))?.status).toBe("skipped")
+            expect((yield* store.getNode(workflow.id, "final-audit"))?.status).toBe("skipped")
+
+            const parent = yield* takeWithin(parentPrompts, "review rejection failure did not wake the parent")
+            expect(promptText(parent.input)).toContain(
+              '[DAG Workflow failed] Workflow "Recovered review rejection" has reached terminal status.',
+            )
+            yield* Deferred.succeed(parent.release, "success")
+          }),
+        ({ database }) =>
+          database.db.transaction((tx) =>
+            Effect.gen(function* () {
+              const nodes = [
+                {
+                  ...node("implement"),
+                  output_schema: {
+                    type: "object",
+                    properties: {
+                      diff: { type: "string" },
+                      fingerprint: { type: "string" },
+                    },
+                    required: ["diff", "fingerprint"],
+                  },
+                },
+                {
+                  ...node("verify", ["implement"]),
+                  output_schema: {
+                    type: "object",
+                    properties: { verdict: { enum: ["PASS", "FAIL"] } },
+                    required: ["verdict"],
+                  },
+                },
+                {
+                  ...node("review-diff", ["verify"]),
+                  worker_type: "review",
+                  review: {
+                    phase: "diff" as const,
+                    implementation_node_id: "implement",
+                    verification_node_id: "verify",
+                  },
+                  input_mapping: {
+                    diff: "implement.output.diff",
+                    implementation_fingerprint: "implement.output.fingerprint",
+                    verification: "verify.output",
+                  },
+                  condition: 'verify.output.verdict == "PASS"',
+                  output_schema: {
+                    type: "object",
+                    properties: {
+                      verdict: { enum: ["ACCEPT", "REJECT"] },
+                      implementation_fingerprint: { type: "string" },
+                    },
+                    required: ["verdict", "implementation_fingerprint"],
+                  },
+                },
+                {
+                  ...node("final-audit", ["review-diff"]),
+                  worker_type: "audit",
+                  input_mapping: { review: "review-diff.output" },
+                  condition: 'review-diff.output.verdict == "ACCEPT"',
+                },
+              ]
+              yield* tx.insert(WorkflowTable).values({
+                id: "dag_recovered_review_rejection",
+                project_id: "project-1" as never,
+                session_id: "ses_parent" as never,
+                title: "Recovered review rejection",
+                status: "running",
+                config: JSON.stringify({
+                  name: "dag_recovered_review_rejection",
+                  mode: "deep",
+                  nodes,
+                }),
+                seq: 10,
+                wake_reported: false,
+              }).run()
+              yield* tx.insert(WorkflowNodeTable).values([
+                {
+                  id: "implement",
+                  workflow_id: "dag_recovered_review_rejection",
+                  name: "implement",
+                  worker_type: "build",
+                  status: "completed",
+                  required: true,
+                  depends_on: [],
+                  output: { diff: "diff --git a/a b/a", fingerprint: "fp-1" },
+                  wake_eligible: false,
+                  wake_reported: true,
+                  seq: 6,
+                },
+                {
+                  id: "verify",
+                  workflow_id: "dag_recovered_review_rejection",
+                  name: "verify",
+                  worker_type: "build",
+                  status: "completed",
+                  required: true,
+                  depends_on: ["implement"],
+                  output: { verdict: "FAIL" },
+                  wake_eligible: false,
+                  wake_reported: true,
+                  seq: 5,
+                },
+                {
+                  id: "review-diff",
+                  workflow_id: "dag_recovered_review_rejection",
+                  name: "review-diff",
+                  worker_type: "review",
+                  status: "pending",
+                  required: true,
+                  depends_on: ["verify"],
+                  wake_eligible: false,
+                  wake_reported: false,
+                  seq: 4,
+                },
+                {
+                  id: "final-audit",
+                  workflow_id: "dag_recovered_review_rejection",
+                  name: "final-audit",
+                  worker_type: "audit",
+                  status: "pending",
+                  required: true,
+                  depends_on: ["review-diff"],
+                  wake_eligible: false,
+                  wake_reported: false,
+                  seq: 3,
                 },
               ]).run()
             }),

--- a/packages/opencode/test/dag/dag-workflow-lock.test.ts
+++ b/packages/opencode/test/dag/dag-workflow-lock.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "bun:test"
+import { Effect, Layer } from "effect"
+import { DagStore } from "@opencode-ai/core/dag/store"
+import { Dag } from "@/dag/dag"
+import { EventV2Bridge } from "@/event-v2-bridge"
+
+describe("Dag.Service workflow lock", () => {
+  it("serializes concurrent extend operations for the same workflow", async () => {
+    let activeReads = 0
+    let maxActiveReads = 0
+    const config = JSON.stringify({ name: "lock-test", nodes: [] })
+    const store = Layer.mock(DagStore.Service, {
+      getWorkflow: () =>
+        Effect.gen(function* () {
+          yield* Effect.sync(() => {
+            activeReads += 1
+            maxActiveReads = Math.max(maxActiveReads, activeReads)
+          })
+          yield* Effect.sleep("25 millis").pipe(
+            Effect.ensuring(
+              Effect.sync(() => {
+                activeReads -= 1
+              }),
+            ),
+          )
+          return { id: "wf1", status: "running", config }
+        }) as never,
+      getNodes: () => Effect.succeed([]) as never,
+    })
+    const events = Layer.succeed(
+      EventV2Bridge.Service,
+      EventV2Bridge.Service.of({
+        publish: () => Effect.succeed({ seq: 1 }),
+      } as never),
+    )
+    const layer = Dag.layer.pipe(Layer.provide(events), Layer.provide(store))
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const dag = yield* Dag.Service
+        const node = (id: string) => ({
+          id,
+          name: id,
+          worker_type: "build",
+          depends_on: [],
+          required: true,
+          prompt_template: { inline: id },
+        })
+
+        yield* Effect.all(
+          [dag.extend("wf1", [node("first")]), dag.extend("wf1", [node("second")])],
+          { concurrency: "unbounded" },
+        )
+
+        expect(maxActiveReads).toBe(1)
+      }).pipe(Effect.provide(layer)) as Effect.Effect<never>,
+    )
+  })
+})

--- a/packages/opencode/test/server/httpapi-exercise/index.ts
+++ b/packages/opencode/test/server/httpapi-exercise/index.ts
@@ -1920,6 +1920,142 @@ const scenarios: Scenario[] = [
       }),
     ),
 
+  // Project-isolation regressions: the instance API must treat foreign
+  // sessions/workflows as nonexistent even though they share the same DB.
+  http.protected
+    .get("/dag", "dag.list.isolation")
+    .seeded((ctx) =>
+      ctx.foreignDag({
+        title: "Foreign list workflow",
+        nodes: [{ id: "foreign", name: "Foreign", worker_type: "general", depends_on: [], required: true }],
+      }),
+    )
+    .jsonEffect(200, (body, ctx) =>
+      Effect.sync(() => {
+        array(body)
+        check(
+          !body.some((item) => isRecord(item) && item.id === ctx.state.dagID),
+          "dag.list must not expose workflows owned by another project",
+        )
+      }),
+    ),
+
+  http.protected
+    .get("/dag/{dagID}", "dag.detail.isolation")
+    .seeded((ctx) =>
+      ctx.foreignDag({
+        title: "Foreign detail workflow",
+        nodes: [{ id: "foreign", name: "Foreign", worker_type: "general", depends_on: [], required: true }],
+      }),
+    )
+    .at((ctx) => ({
+      path: route("/dag/{dagID}", { dagID: ctx.state.dagID }),
+      headers: ctx.headers(),
+    }))
+    .status(404),
+
+  http.protected
+    .get("/dag/session/{sessionID}", "dag.bySession.isolation")
+    .seeded((ctx) =>
+      ctx.foreignDag({
+        title: "Foreign session workflows",
+        nodes: [{ id: "foreign", name: "Foreign", worker_type: "general", depends_on: [], required: true }],
+      }),
+    )
+    .at((ctx) => ({
+      path: route("/dag/session/{sessionID}", { sessionID: ctx.state.sessionID }),
+      headers: ctx.headers(),
+    }))
+    .status(404),
+
+  http.protected
+    .get("/dag/session/{sessionID}/summary", "dag.summary.isolation")
+    .seeded((ctx) =>
+      ctx.foreignDag({
+        title: "Foreign session summary",
+        nodes: [{ id: "foreign", name: "Foreign", worker_type: "general", depends_on: [], required: true }],
+      }),
+    )
+    .at((ctx) => ({
+      path: route("/dag/session/{sessionID}/summary", { sessionID: ctx.state.sessionID }),
+      headers: ctx.headers(),
+    }))
+    .status(404),
+
+  http.protected
+    .get("/dag/{dagID}/nodes", "dag.nodes.isolation")
+    .seeded((ctx) =>
+      ctx.foreignDag({
+        title: "Foreign workflow nodes",
+        nodes: [{ id: "foreign", name: "Foreign", worker_type: "general", depends_on: [], required: true }],
+      }),
+    )
+    .at((ctx) => ({
+      path: route("/dag/{dagID}/nodes", { dagID: ctx.state.dagID }),
+      headers: ctx.headers(),
+    }))
+    .status(404),
+
+  http.protected
+    .get("/dag/{dagID}/nodes/{nodeID}", "dag.nodeDetail.isolation")
+    .seeded((ctx) =>
+      ctx.foreignDag({
+        title: "Foreign workflow node detail",
+        nodes: [{ id: "foreign", name: "Foreign", worker_type: "general", depends_on: [], required: true }],
+      }),
+    )
+    .at((ctx) => ({
+      path: route("/dag/{dagID}/nodes/{nodeID}", { dagID: ctx.state.dagID, nodeID: "foreign" }),
+      headers: ctx.headers(),
+    }))
+    .status(404),
+
+  http.protected
+    .post("/dag/{dagID}/control", "dag.control.isolation")
+    .mutating()
+    .seeded((ctx) =>
+      ctx.foreignDag({
+        title: "Foreign control workflow",
+        nodes: [{ id: "foreign", name: "Foreign", worker_type: "general", depends_on: [], required: true }],
+      }),
+    )
+    .at((ctx) => ({
+      path: route("/dag/{dagID}/control", { dagID: ctx.state.dagID }),
+      headers: ctx.headers(),
+      body: { operation: "pause" },
+    }))
+    .status(404),
+
+  http.protected
+    .post("/dag", "dag.start.isolation")
+    .mutating()
+    .seeded((ctx) =>
+      ctx.foreignDag({
+        title: "Foreign start owner",
+        nodes: [{ id: "foreign", name: "Foreign", worker_type: "general", depends_on: [], required: true }],
+      }),
+    )
+    .at((ctx) => ({
+      path: "/dag",
+      headers: ctx.headers(),
+      body: {
+        session_id: ctx.state.sessionID,
+        title: "Cross-project start",
+        config: {
+          name: "cross-project-start",
+          nodes: [{
+            id: "n1",
+            name: "N1",
+            worker_type: "general",
+            depends_on: [],
+            required: true,
+            prompt_template: { inline: "noop" },
+          }],
+        },
+      },
+    }))
+    .status(404),
+
   // 404 scenarios (pre-existing, retained)
   http.protected
     .get("/dag/{dagID}", "dag.detail")
@@ -1928,7 +2064,7 @@ const scenarios: Scenario[] = [
   http.protected
     .get("/dag/{dagID}/nodes", "dag.nodes")
     .at(() => ({ path: route("/dag/{dagID}/nodes", { dagID: "dag_nonexistent" }), headers: {} as Record<string, string> }))
-    .json(200, (body) => { array(body); check(body.length === 0, "nonexistent workflow should have no nodes") }),
+    .status(404),
   http.protected
     .get("/dag/{dagID}/nodes/{nodeID}", "dag.nodeDetail")
     .at(() => ({ path: route("/dag/{dagID}/nodes/{nodeID}", { dagID: "dag_nonexistent", nodeID: "n1" }), headers: {} as Record<string, string> }))

--- a/packages/opencode/test/server/httpapi-exercise/runner.ts
+++ b/packages/opencode/test/server/httpapi-exercise/runner.ts
@@ -1,19 +1,21 @@
 import { Flag } from "@opencode-ai/core/flag/flag"
 import { ConfigV1 } from "@opencode-ai/core/v1/config/config"
+import { Database } from "@opencode-ai/core/database/database"
+import { Project } from "@opencode-ai/core/project"
+import { ProjectTable } from "@opencode-ai/core/project/sql"
+import { AbsolutePath } from "@opencode-ai/core/schema"
+import { SessionTable } from "@opencode-ai/core/session/sql"
 import { SessionV1 } from "@opencode-ai/core/v1/session"
 import { Cause, Duration, Effect, Layer, Scope } from "effect"
 import { TestLLMServer } from "../../lib/llm-server"
-import type { Config } from "../../../src/config/config"
 
-import type { MessageV2 } from "../../../src/session/message-v2"
-import { MessageID, PartID } from "../../../src/session/schema"
+import { MessageID, PartID, SessionID } from "../../../src/session/schema"
 import { call, callAuthProbe, disposeApps } from "./backend"
 import { original } from "./environment"
 import { runtime } from "./runtime"
 import type { ActiveScenario, Options, ProjectOptions, Result, Scenario, ScenarioContext, SeededContext, DagNodeSeed } from "./types"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 import { ModelV2 } from "@opencode-ai/core/model"
-import type { SessionID } from "../../../src/session/schema"
 
 export function runScenario(options: Options) {
   return (scenario: Scenario) => {
@@ -189,6 +191,7 @@ function withContext<A, E>(
           llmWait: (count) => Effect.suspend(() => llm().wait(count)),
           tuiRequest: (request) => Effect.sync(() => modules.Tui.submitTuiRequest(request)),
           dag: (input) => run(createDagFixture(input.sessionID, input.title, input.nodes)),
+          foreignDag: (input) => run(createForeignDagFixture(input.title, input.nodes)),
         }
         yield* trace(options, scenario, `${label} seed start`)
         const state = yield* scenario.seed(base)
@@ -327,6 +330,46 @@ function createDagFixture(sessionID: SessionID, title: string | undefined, nodes
           depends_on: n.depends_on,
           required: n.required,
           prompt_template: { inline: n.id },
+        })),
+      },
+    }).pipe(Effect.orDie)
+    return { dagID, sessionID } as const
+  })
+}
+
+function createForeignDagFixture(title: string | undefined, nodes: DagNodeSeed[]) {
+  return Effect.gen(function* () {
+    const modules = yield* Effect.promise(() => runtime())
+    const dag = yield* modules.Dag.Service
+    const { db } = yield* Database.Service
+    const projectID = Project.ID.make("prj_httpapi_foreign")
+    const sessionID = SessionID.make("ses_httpapi_foreign")
+    yield* db.insert(ProjectTable).values({
+      id: projectID,
+      worktree: AbsolutePath.make("/foreign-httpapi-project"),
+      sandboxes: [],
+    }).onConflictDoNothing().run().pipe(Effect.orDie)
+    yield* db.insert(SessionTable).values({
+      id: sessionID,
+      project_id: projectID,
+      slug: "foreign-httpapi",
+      directory: AbsolutePath.make("/foreign-httpapi-project"),
+      title: "Foreign HTTP API session",
+      version: "test",
+    }).run().pipe(Effect.orDie)
+    const dagID = yield* dag.create({
+      projectID,
+      sessionID,
+      title: title ?? "Foreign DAG fixture",
+      config: {
+        name: title ?? "Foreign DAG fixture",
+        nodes: nodes.map((item) => ({
+          id: item.id,
+          name: item.name,
+          worker_type: item.worker_type,
+          depends_on: item.depends_on,
+          required: item.required,
+          prompt_template: { inline: item.id },
         })),
       },
     }).pipe(Effect.orDie)

--- a/packages/opencode/test/server/httpapi-exercise/types.ts
+++ b/packages/opencode/test/server/httpapi-exercise/types.ts
@@ -1,10 +1,8 @@
 import type { Duration, Effect } from "effect"
 import { ConfigV1 } from "@opencode-ai/core/v1/config/config"
 import { SessionV1 } from "@opencode-ai/core/v1/session"
-import type { Config } from "../../../src/config/config"
 import type { Project } from "../../../src/project/project"
 import type { Worktree } from "../../../src/worktree"
-import type { MessageV2 } from "../../../src/session/message-v2"
 import type { SessionID } from "../../../src/session/schema"
 export const OpenApiMethods = ["get", "post", "put", "delete", "patch"] as const
 export const Methods = ["GET", "POST", "PUT", "DELETE", "PATCH"] as const
@@ -67,6 +65,8 @@ export type ScenarioContext = {
   tuiRequest: (request: { path: string; body: unknown }) => Effect.Effect<void>
   /** Create a DAG workflow owned by sessionID with the given node configs. Returns the dagID. */
   dag: (input: { sessionID: SessionID; title?: string; nodes: DagNodeSeed[] }) => Effect.Effect<DagWorkflowInfo>
+  /** Create a DAG workflow under a different project in the shared database. */
+  foreignDag: (input: { title?: string; nodes: DagNodeSeed[] }) => Effect.Effect<DagWorkflowInfo>
 }
 
 /** Scenario context after `.seeded(...)`; `state` preserves the seed return type in the DSL. */

--- a/packages/tui/src/context/sync.tsx
+++ b/packages/tui/src/context/sync.tsx
@@ -262,6 +262,7 @@ export const {
         // WorkflowSummary[] for a session whenever any dag.* event changes
         // its visible progress. We just store it — no client-side aggregation.
         case "dag.workflow.summary.updated":
+          if (workspace !== undefined && workspace !== project.workspace.current()) break
           setStore("dag", event.properties.sessionID, event.properties.summaries)
           break
 

--- a/packages/tui/test/cli/cmd/tui/sync-dag.test.tsx
+++ b/packages/tui/test/cli/cmd/tui/sync-dag.test.tsx
@@ -8,10 +8,11 @@ import type { DagWorkflowSummary } from "@opencode-ai/sdk/v2"
 
 const sid = "ses_dag_1"
 
-function summaryEvent(summaries: DagWorkflowSummary[], sessionID = sid): GlobalEvent {
+function summaryEvent(summaries: DagWorkflowSummary[], sessionID = sid, workspace?: string): GlobalEvent {
   return {
     directory,
     project: "proj_test",
+    ...(workspace ? { workspace } : {}),
     payload: {
       id: `evt_dag_summary_${Date.now()}_${Math.random()}`,
       type: "dag.workflow.summary.updated",
@@ -69,6 +70,24 @@ describe("tui sync dag slice", () => {
 
       expect(sync.data.dag[sid]).toHaveLength(1)
       expect(sync.data.dag[sid][0].completedNodes).toBe(3)
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+
+  test("ignores summary events routed to another workspace", async () => {
+    await using tmp = await tmpdir()
+    await Bun.write(`${tmp.path}/kv.json`, "{}")
+    const { app, emit, project, sync } = await mount(undefined, tmp.path)
+
+    try {
+      project.workspace.set("wrk-current")
+      emit(summaryEvent([summary(1, 2)], sid, "wrk-foreign"))
+      await Bun.sleep(50)
+      expect(sync.data.dag[sid] ?? []).toEqual([])
+
+      emit(summaryEvent([summary(2, 2)], sid, "wrk-current"))
+      await wait(() => sync.data.dag[sid]?.[0]?.completedNodes === 2)
     } finally {
       app.renderer.destroy()
     }


### PR DESCRIPTION
## 变更
- 为 DAG HTTP API 与摘要事件补齐 project/workspace 隔离
- 为 deep diff review 增加结构化最终门禁，并阻止显式 complete 绕过
- 将 config_assistant Go 测试纳入 Linux CI
- 增加 workflow 锁、跨项目 API、摘要路由和 review 生命周期回归测试

## 验证
- DAG tests: 276/276
- TUI DAG sync: 5/5
- HttpAPI contract: 225/225, 0 missing, 0 extra
- packages/opencode 与 packages/tui typecheck
- go test ./...
- YAML parse、git diff --check、oxlint 0 errors
- Standards/Spec 双轴复核：无 CRITICAL/HIGH

Fixes #145
Fixes #146
Fixes #147

本 PR 不触发 release。