### PR TITLE
feat(dag): expose node failure class for targeted wake-time repair

### DIFF
--- a/packages/core/schema.json
+++ b/packages/core/schema.json
@@ -1,9 +1,9 @@
 {
   "version": "7",
   "dialect": "sqlite",
-  "id": "a26723c8-be88-4c4e-85cf-0c1ecd3cf638",
+  "id": "937897f2-96bc-4fee-af44-bbc2accda92f",
   "prevIds": [
-    "747f1cfb-b2d5-45f6-b46b-c38e470bb2d5"
+    "a26723c8-be88-4c4e-85cf-0c1ecd3cf638"
   ],
   "ddl": [
     {
@@ -591,6 +591,16 @@
       "default": null,
       "generated": null,
       "name": "error_reason",
+      "entityType": "columns",
+      "table": "workflow_node"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error_class",
       "entityType": "columns",
       "table": "workflow_node"
     },

--- a/packages/core/src/dag/projector.ts
+++ b/packages/core/src/dag/projector.ts
@@ -282,6 +282,7 @@ export const layer = Layer.effectDiscard(
         .set({
           status: "failed",
           error_reason: event.data.reason,
+          error_class: event.data.trigger,
           completed_at: toMillis(event.data.timestamp),
           seq: event.durable!.seq,
           time_updated: toMillis(event.data.timestamp),

--- a/packages/core/src/dag/sql.ts
+++ b/packages/core/src/dag/sql.ts
@@ -62,6 +62,7 @@ export const WorkflowNodeTable = sqliteTable(
     child_session_id: text(),
     output: text({ mode: "json" }).$type<unknown>(),
     error_reason: text(),
+    error_class: text(), // dag.node.failed trigger (timeout/exec_failed/verdict_fail/push_exhausted) for failure triage
     captured_output: text({ mode: "json" }).$type<unknown>(), // durable payload from submit_result; survives a process crash, reset to null on a replan-restart via NodeStarted
     deadline_ms: integer(), // absolute deadline (spawnedAt + timeout_ms) for D0 termination boundary
     wake_eligible: integer({ mode: "boolean" }).notNull().default(false), // D6: node has report_to_parent=true

--- a/packages/core/src/dag/store.ts
+++ b/packages/core/src/dag/store.ts
@@ -39,6 +39,7 @@ export interface NodeRow {
   output: unknown
   capturedOutput: unknown
   errorReason: string | null
+  errorClass: string | null
   deadlineMs: number | null
   wakeEligible: boolean
   wakeReported: boolean
@@ -100,6 +101,7 @@ const mapNode = (r: typeof WorkflowNodeTable.$inferSelect): NodeRow => ({
   output: r.output,
   capturedOutput: r.captured_output,
   errorReason: r.error_reason,
+  errorClass: r.error_class,
   deadlineMs: r.deadline_ms,
   wakeEligible: r.wake_eligible,
   wakeReported: r.wake_reported,

--- a/packages/core/src/database/migration.gen.ts
+++ b/packages/core/src/database/migration.gen.ts
@@ -47,5 +47,6 @@ export const migrations = (
     import("./migration/20260715040000_drop_retry_count"),
     import("./migration/20260717034735_fearless_cammi"),
     import("./migration/20260720013828_dag-workflow-node-identity"),
+    import("./migration/20260803073521_workflow_node_error_class"),
   ])
 ).map((module) => module.default) satisfies DatabaseMigration.Migration[]

--- a/packages/core/src/database/migration/20260803073521_workflow_node_error_class.ts
+++ b/packages/core/src/database/migration/20260803073521_workflow_node_error_class.ts
@@ -1,0 +1,11 @@
+import { Effect } from "effect"
+import type { DatabaseMigration } from "../migration"
+
+export default {
+  id: "20260803073521_workflow_node_error_class",
+  up(tx) {
+    return Effect.gen(function* () {
+      yield* tx.run(`ALTER TABLE \`workflow_node\` ADD \`error_class\` text;`)
+    })
+  },
+} satisfies DatabaseMigration.Migration

--- a/packages/core/src/database/schema.gen.ts
+++ b/packages/core/src/database/schema.gen.ts
@@ -83,6 +83,7 @@ export default {
           \`child_session_id\` text,
           \`output\` text,
           \`error_reason\` text,
+          \`error_class\` text,
           \`captured_output\` text,
           \`deadline_ms\` integer,
           \`wake_eligible\` integer DEFAULT false NOT NULL,

--- a/packages/core/src/plugin/command/dag-flow.txt
+++ b/packages/core/src/plugin/command/dag-flow.txt
@@ -32,4 +32,14 @@ For a non-empty task:
 12. On failure, state that the workflow was not started and report the actual error. Never invent a Workflow ID or start a replacement workflow unless the user explicitly asked for automatic retries.
 13. A completed aggregate node must actually contain the requested synthesis. Never describe unresolved placeholders or an aggregate-node error message as a successful final result.
 
+## Resume-first: continue an interrupted workflow before restarting
+
+When the current task maps to a previously interrupted workflow (same task retried or resumed), the default instinct to "restart the whole graph" is usually wrong — completed node outputs are durable and reusable. First read `workflow(action=status)` on the prior workflow: every failed node carries `error_class` (runtime classes: timeout / exec_failed / verdict_fail) plus `error_reason` — except nodes cancelled via replan (failed with reason "cancelled via replan", no error_class) and rows written before the error_class migration — triage per the Node failure triage section in the workflow guidance, then recover in this order, and only fall back to a full restart when nothing reusable exists:
+
+1. **Paused recovery (crash recovery)**: if the prior workflow is `paused`, never open a new one. The failed node is terminal and immutable — add a replacement node under a NEW id, rewire its pending dependents' `depends_on` to the new id, then `control(resume)`. Downstream nodes stay pending and keep their state.
+2. **Continue from completed waves**: if the prior workflow is terminal (`failed` or `cancelled`) but has nodes that `completed` before the failure, their final outputs are still valid. Extract each completed node's output (its final text result, e.g. from the node session's persisted parts or any artifact it wrote) and compile a **continuation spec** that starts at the first unfinished wave. Inject the reused outputs as static context into the downstream node prompts (do not re-run them), add only the missing nodes, and `workflow(action=start)` it. Record `reused_nodes` in the manifest.
+3. **Full restart**: only when no completed-node output is reusable — zero completed nodes, or their outputs are empty/irrelevant to the remaining work — re-derive the full graph and start it.
+
+Fail-closed guard: before starting a continuation, verify every reused output is present and non-empty; if extraction is incomplete, fall back to the affected node's fresh run rather than silently continuing on empty input. Never discard completed work to rerun it from zero unless extraction genuinely fails.
+
 Use the orchestration guidance below to design and manage the workflow.

--- a/packages/core/src/plugin/command/workflow.md
+++ b/packages/core/src/plugin/command/workflow.md
@@ -398,6 +398,52 @@ replannable. Dispose of it in the same turn:
 Never assume a crashed workflow resumes or retries on its own — it will wait,
 paused, until you act.
 
+### Node failure triage: repair the failed node, don't restart
+
+A node-failure wake is a work order for a **targeted repair**, not a restart
+signal. Every node failed via `dag.node.failed` carries an `error_class` in
+`status` output and in the wake summary. Exception: a node cancelled via replan
+appears as `failed` with error_reason `cancelled via replan` and NO
+`error_class` — deliberate action, no triage needed. Triage on the class
+before acting:
+
+| error_class | What it means | Correct response |
+|---|---|---|
+| `timeout` | The node exceeded `timeout_ms`; the runtime cancelled its child session at the deadline. Environmental — the task is NOT wrong. | Replace and rerun ONLY that node with a larger `worker_config.timeout_ms`. Check its `child_session_id` for partial artifacts before rerunning. |
+| `exec_failed` | Runtime/session-level failure. Gate on `error_reason`: (a) unknown/wrong model, auth, rate-limit, connection, template-resolution or condition-expression errors → config/prompt errors; (b) recovery reasons ("no child session on recovery", "child session failed (recovered)") → crash ownership loss; (c) workflow-collateral reasons (`required node(s) failed: ...`, `unresolved review outcome(s): ...`, `orchestrator_unresponsive`) → the node itself was fine; it was failed because the workflow failed. | (a) Fix the config first (`dag.jsonc` tier, provider credentials, model id, template/input mapping), then replace and rerun ONLY that node. (b) Inspect the child session's artifacts, then replace and rerun. (c) Do not rerun these collateral nodes. The wake surfaces no workflow-level reason — triage from the Failed-nodes block: `required node(s) failed: <ids>` names the culprit nodes directly (repair them); `orchestrator_unresponsive` carries NO attribution (see the recipe below). |
+| `verdict_fail` | Two shapes. Ran-but-broke-contract: missing `submit_result`, schema rejection, review fingerprint mismatch. Never-ran: pre-spawn contract failures (unresolved template placeholders, review input contract). | Ran-but-broke-contract → rerun the node with the contract stated explicitly; keep the topology. Never-ran → fix the template, input_mapping, or dependency wiring first, then rerun; prompt emphasis alone does not fix broken interpolation. |
+| (cascade — see below) | Dependents of a failed node. No dedicated class. | Repair the ROOT node first, then restore the dependent subtree. |
+
+Cascade detection has two shapes:
+
+- **Required node failed** → the workflow terminalizes `failed`; still-running nodes are failed with the workflow reason and all other pending/queued/paused dependents are terminalized to `skipped` with error_reason `workflow_failed` (dependents stay untouched only while the workflow is still `paused` — terminalization happens when the scheduler evaluates). The culprit is a node in the Failed-nodes block whose `error_class` is a real failure class; collateral rows carry the workflow reason instead.
+- **Optional node failed** → dependents ran with `Dependency "X" failed: ...` / `Dependency "X" skipped: ...` interpolated into their prompt text (inspect the dependent's rendered prompt/input, not its `error_reason`). Judge per dependent whether its output is still valid with the degraded input.
+
+In both shapes, repair the root/classed node first, then re-add the failed/skipped dependents rewired onto the replacement id.
+
+`orchestrator_unresponsive` recipe (zero attribution by design — the parent
+took no mandatory action while the workflow stalled): read `status`, identify
+which nodes were `running` or stuck when the guard fired, then dispose per the
+Verdict Disposal Contract: extend/replan those nodes, or change the approach
+(see Escalation) if the stall repeats. Never repair collateral rows blindly.
+
+The value set above is what the runtime produces today; `push_exhausted`
+exists in the schema but is reserved and currently never emitted.
+
+Budget exhaustion is a separate class: `replan attempt ceiling exceeded` or
+`Total node ceiling exceeded` means the budget is spent — change the approach
+or stop, do not retry the identical plan (see Escalation).
+
+Where to apply the repair:
+
+- **Workflow still live** (running/paused/stepping): `control(pause)` → `control(replan)` adding a replacement node under a NEW id (rewire the failed node's pending dependents onto it; use `restart: true` for still-running nodes) → `control(resume)`. `extend` with the replacement node also works. Completed siblings are untouched.
+- **Workflow terminal `failed`**: terminal status is irreversible — you cannot replan it. Start a **continuation workflow** instead: reuse every completed node's output as static input (inject it into the downstream prompts; never re-run a completed node), re-add only the failed and still-pending tail, and record `reused_nodes` in the manifest.
+
+Hard rule: an environmental single-node failure (timeout, wrong model, API
+error, crash-recovery loss) never justifies restarting the workflow from zero.
+Completed node outputs are durable and reusable; a full restart wastes paid
+provider work and destroys evidence the earlier nodes already earned.
+
 ## Model Assignment Strategy
 
 Workflow definitions MUST NOT specify `node.model` or
@@ -443,12 +489,12 @@ never appear as `[object Object]`.
 
 ## Budget Declaration
 
-The engine faithfully executes declared budgets and circuit-breaks on ceiling breach. It does not adaptively adjust — declare what your task needs. Choose values based on task complexity:
+The engine faithfully executes declared budgets and circuit-breaks on ceiling breach. It does not adaptively adjust — declare what your task needs. Default values are floors for light work, not recommendations: size every timeout and ceiling to the actual task load (target size, number of upstream reports a node must consume, expected tool/test/compilation work) and never trust the defaults blindly. Choose values based on task complexity:
 
 - `max_concurrency`: default 5. For independent fan-out (e.g., generating 100 images, migrating 10 packages), declare 10–20 so nodes aren't serialized behind an artificially narrow pipe.
 - `max_node_replan_attempts`: default 5. Increase only if you expect iterative quality-driven convergence (review → revise → review cycles on a single artifact).
 - `max_total_nodes`: default 100. Increase for large-scale decompositions.
-- `worker_config.timeout_ms`: default 10 minutes. Increase for long-running nodes (compilation, large test suites).
+- `worker_config.timeout_ms`: default 10 minutes. Increase for long-running nodes (compilation, large test suites). Verifier and aggregator nodes are the most common timeout victims: a node that consumes several parallel reports and re-checks their claims against code runs sequentially and routinely needs 20–30 minutes (e.g. `timeout_ms: 1800000`) — declaring the fan-out lanes' budget for the fan-in lane is a recurring failure pattern.
 
 ## Single-Workspace Discipline
 

--- a/packages/opencode/src/dag/runtime/loop.ts
+++ b/packages/opencode/src/dag/runtime/loop.ts
@@ -849,17 +849,38 @@ export const layer = Layer.effect(
               }
               if (lastUserAt > lastAsstAt) return
 
+              const failuresByWorkflow = new Map<string, string[]>()
+              for (const workflow of batch.workflows) {
+                if (workflow.status !== "failed") continue
+                const failedNodes = yield* store.getNodes(workflow.id).pipe(
+                  Effect.map((nodes) => nodes.filter((node): node is DagStore.NodeRow & { errorClass: string } => node.status === "failed" && node.errorClass !== null)),
+                  Effect.catchCause((cause) =>
+                    Effect.gen(function* () {
+                      yield* Effect.logWarning("wake digest failed to read failed nodes", { workflowId: workflow.id, cause })
+                      return [] as (DagStore.NodeRow & { errorClass: string })[]
+                    }),
+                  ),
+                )
+                if (failedNodes.length > 0) {
+                  failuresByWorkflow.set(
+                    workflow.id,
+                    failedNodes.map((node) => `- "${node.name}" (${node.errorClass}): ${node.errorReason ?? "unknown error"}`.slice(0, 300)),
+                  )
+                }
+              }
               const summaries = [
                 ...batch.nodes.map((node) => {
                   const output = typeof node.output === "string"
                     ? node.output.slice(0, 500)
                     : node.errorReason ?? (node.output == null ? "(no output)" : JSON.stringify(node.output).slice(0, 500))
-                  return `[DAG Node Result] Node "${node.name}" ${node.status}: ${output}`
+                  const failureClass = node.status === "failed" && node.errorClass ? ` (${node.errorClass})` : ""
+                  return `[DAG Node Result] Node "${node.name}" ${node.status}${failureClass}: ${output}`
                 }),
-                ...batch.workflows.map(
-                  (workflow) =>
-                    `[DAG Workflow ${workflow.status}] Workflow "${workflow.title}" has reached terminal status.`,
-                ),
+                ...batch.workflows.map((workflow) => {
+                  const failures = failuresByWorkflow.get(workflow.id)
+                  const attribution = failures ? `\nFailed nodes:\n${failures.join("\n")}` : ""
+                  return `[DAG Workflow ${workflow.status}] Workflow "${workflow.title}" has reached terminal status.${attribution}`
+                }),
               ]
               const summary = [
                 ...summaries,

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/dag.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/dag.ts
@@ -39,6 +39,9 @@ export const NodeResponse = Schema.Struct({
   child_session_id: Schema.optional(Schema.String),
   output: Schema.optional(Schema.Unknown),
   error_reason: Schema.optional(Schema.String),
+  // Failed nodes only: the dag.node.failed trigger class
+  // (timeout/exec_failed/verdict_fail/push_exhausted) for failure triage.
+  error_class: Schema.optional(Schema.String),
   // Deadline (absolute epoch millis) fixed at admission; drives the running-
   // node countdown in the TUI inspector (P2-8).
   deadline_ms: Schema.optional(Schema.Number),

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/dag.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/dag.ts
@@ -62,6 +62,7 @@ export const dagHandlers = HttpApiBuilder.group(InstanceHttpApi, "dag", (handler
       ...(r.childSessionId !== null ? { child_session_id: r.childSessionId } : {}),
       ...(r.output !== null ? { output: r.output } : {}),
       ...(r.errorReason !== null ? { error_reason: r.errorReason } : {}),
+      ...(r.errorClass !== null ? { error_class: r.errorClass } : {}),
       ...(r.deadlineMs !== null ? { deadline_ms: r.deadlineMs } : {}),
       replan_attempts: r.replanAttempts,
       ...(r.startedAt !== null ? { started_at: r.startedAt } : {}),

--- a/packages/opencode/src/tool/workflow.ts
+++ b/packages/opencode/src/tool/workflow.ts
@@ -201,6 +201,7 @@ export const WorkflowTool = Tool.define<
                       depends_on: node.dependsOn,
                       ...(node.childSessionId ? { child_session_id: node.childSessionId } : {}),
                       ...(node.errorReason ? { error_reason: node.errorReason } : {}),
+                      ...(node.errorClass ? { error_class: node.errorClass } : {}),
                     })),
                   },
                   null,

--- a/packages/opencode/test/dag/dag-loop-recovery-integration.test.ts
+++ b/packages/opencode/test/dag/dag-loop-recovery-integration.test.ts
@@ -252,6 +252,7 @@ describe("DagLoop crash recovery integration", () => {
             trigger: "timeout",
           }))
           expect((yield* store.getNode(dagID, "n1"))?.errorReason).toBe("deadline exceeded on recovery")
+          expect((yield* store.getNode(dagID, "n1"))?.errorClass).toBe("timeout")
         }),
       ),
     )

--- a/packages/opencode/test/dag/dag-replan-stale-nodefailed.test.ts
+++ b/packages/opencode/test/dag/dag-replan-stale-nodefailed.test.ts
@@ -227,6 +227,10 @@ describe("DagLoop replan vs stale NodeFailed", () => {
             "replacement graph did not settle",
           )
           expect(state.workflow?.status).toBe("running")
+          const cancelled = yield* store.getNode(dagID, "a")
+          expect(cancelled?.status).toBe("failed")
+          expect(cancelled?.errorReason).toBe("cancelled via replan")
+          expect(cancelled?.errorClass).toBeNull()
           const replacement = yield* takeWithin(childPrompts, "replacement b did not start")
           expect(replacement.title).toBe("b")
           expect(state.replacement?.status).toBe("running")
@@ -316,6 +320,51 @@ describe("DagLoop replan vs stale NodeFailed", () => {
           // workflow-fail terminalization skipped it.
           expect((yield* store.getNode(dagID, "b"))?.status).toBe("skipped")
           expect(Option.isNone(yield* Queue.poll(childPrompts))).toBe(true)
+          const parent = yield* takeWithin(parentPrompts, "failure wake did not reach the parent")
+          yield* Deferred.succeed(parent.release, "success")
+        }),
+      ),
+    )
+  })
+
+  it("keeps dependents pending while paused; terminalizes them to skipped on resume after a required failure", async () => {
+    await Effect.runPromise(
+      runLoopTest(({ dag, store, childPrompts, parentPrompts }) =>
+        Effect.gen(function* () {
+          const dagID = yield* dag.create({
+            projectID: "project-1",
+            sessionID: "ses_parent",
+            title: "Paused required failure",
+            config: { name: "paused-required-failure", nodes: [node("a"), node("b", ["a"])] },
+          })
+          const gate = yield* takeWithin(childPrompts, "a did not start")
+          expect(gate.title).toBe("a")
+
+          // Pause first, then fail the required node. A paused workflow cannot
+          // transition to failed, so the dependent must stay pending (no
+          // skipped terminalization) until the scheduler evaluates on resume.
+          yield* dag.pause(dagID)
+          yield* Deferred.succeed(gate.release, "")
+
+          yield* pollWithTimeout(
+            store.getNode(dagID, "a").pipe(
+              Effect.map((current) => current?.status === "failed" ? current : undefined),
+            ),
+            "required node did not fail while the workflow was paused",
+          )
+          expect((yield* store.getWorkflow(dagID))?.status).toBe("paused")
+          expect((yield* store.getNode(dagID, "b"))?.status).toBe("pending")
+
+          yield* dag.resume(dagID)
+          yield* pollWithTimeout(
+            store.getWorkflow(dagID).pipe(
+              Effect.map((workflow) => workflow?.status === "failed" ? workflow : undefined),
+            ),
+            "workflow did not fail after resuming with a required failure",
+          )
+          const nodeB = yield* store.getNode(dagID, "b")
+          expect(nodeB?.status).toBe("skipped")
+          expect(nodeB?.errorReason).toBe("workflow_failed")
           const parent = yield* takeWithin(parentPrompts, "failure wake did not reach the parent")
           yield* Deferred.succeed(parent.release, "success")
         }),

--- a/packages/opencode/test/dag/dag-wake-integration.test.ts
+++ b/packages/opencode/test/dag/dag-wake-integration.test.ts
@@ -445,6 +445,7 @@ describe("DagLoop atomic wake integration", () => {
             "workflow did not complete",
           )
           expect((yield* store.getNode(dagID, "review-security"))?.status).toBe("failed")
+          expect((yield* store.getNode(dagID, "review-security"))?.errorClass).toBe("exec_failed")
         }),
       ),
     )
@@ -692,7 +693,7 @@ describe("DagLoop atomic wake integration", () => {
 
   it("fails an aggregate node before execution when template placeholders remain unresolved", async () => {
     await Effect.runPromise(
-      runWakeTest(({ dag, store, childPrompts }) =>
+      runWakeTest(({ dag, store, childPrompts, parentPrompts }) =>
         Effect.gen(function* () {
           const dagID = yield* dag.create({
             projectID: "project-1",
@@ -722,6 +723,12 @@ describe("DagLoop atomic wake integration", () => {
           )
           const summary = yield* store.getNode(dagID, "summary")
           expect(summary?.errorReason).toContain("Unresolved template placeholders")
+          expect(summary?.errorClass).toBe("verdict_fail")
+          const parent = yield* takeWithin(parentPrompts, "workflow failure did not wake the parent")
+          const wakeText = promptText(parent.input)
+          expect(wakeText).toContain('[DAG Workflow failed] Workflow "Unresolved aggregate input" has reached terminal status.')
+          expect(wakeText).toContain('Failed nodes:\n- "summary" (verdict_fail):')
+          yield* Deferred.succeed(parent.release, "success")
           expect(yield* Queue.poll(childPrompts)).toEqual(Option.none())
         }),
       ),

--- a/packages/opencode/test/dag/fixtures.ts
+++ b/packages/opencode/test/dag/fixtures.ts
@@ -15,6 +15,7 @@ export function makeNodeRow(overrides: Partial<DagStore.NodeRow> = {}): DagStore
     output: undefined,
     capturedOutput: undefined,
     errorReason: null,
+    errorClass: null,
     deadlineMs: null,
     wakeEligible: false,
     wakeReported: false,

--- a/packages/opencode/test/dag/workflow-tool.test.ts
+++ b/packages/opencode/test/dag/workflow-tool.test.ts
@@ -177,6 +177,7 @@ const store = Layer.mock(DagStore.Service, {
         output: null,
         capturedOutput: null,
         errorReason: null,
+        errorClass: null,
         deadlineMs: null,
         wakeEligible: true,
         wakeReported: false,
@@ -184,6 +185,30 @@ const store = Layer.mock(DagStore.Service, {
         seq: 1,
         startedAt: 1,
         completedAt: null,
+        timeCreated: 1,
+        timeUpdated: 2,
+          }, {
+        id: "node_failed",
+        workflowId: "dag_status",
+        name: "Failed node",
+        workerType: "build",
+        status: "failed",
+        required: false,
+        dependsOn: ["node_running"],
+        modelId: null,
+        modelProviderId: null,
+        childSessionId: "ses_failed_child",
+        output: null,
+        capturedOutput: null,
+        errorReason: "node exceeded timeout of 600000ms",
+        errorClass: "timeout",
+        deadlineMs: null,
+        wakeEligible: false,
+        wakeReported: false,
+        replanAttempts: 0,
+        seq: 2,
+        startedAt: 1,
+        completedAt: 2,
         timeCreated: 1,
         timeUpdated: 2,
           }]
@@ -385,6 +410,8 @@ describe("workflow tool execution", () => {
       expect(result.output).toContain('"id": "node_running"')
       expect(result.output).toContain('"child_session_id": "ses_child"')
       expect(result.output).toContain('"mode": "standard"')
+      expect(result.output).toContain('"id": "node_failed"')
+      expect(result.output).toContain('"error_class": "timeout"')
     }),
   )
 

--- a/packages/opencode/test/server/httpapi-exercise/index.ts
+++ b/packages/opencode/test/server/httpapi-exercise/index.ts
@@ -1816,6 +1816,9 @@ const scenarios: Scenario[] = [
             ],
           }),
         ),
+        Effect.flatMap((dag) =>
+          ctx.dagFailNode(dag.dagID, "b", "node exceeded timeout of 600000ms", "timeout").pipe(Effect.as(dag)),
+        ),
       ),
     )
     .at((ctx) => ({ path: route("/dag/{dagID}/nodes", { dagID: ctx.state.dagID }), headers: ctx.headers() }))
@@ -1829,6 +1832,14 @@ const scenarios: Scenario[] = [
         check(typeof n.status === "string", "node should have status")
         check(Array.isArray(n.depends_on), "node should have depends_on")
         check(typeof n.replan_attempts === "number", "node should have replan_attempts")
+        const failed = body.find((node: any) => node.id === "b")
+        object(failed)
+        check(failed.status === "failed", "seeded node b should be failed")
+        check(failed.error_class === "timeout", "failed node should expose error_class on the wire")
+        check(typeof failed.error_reason === "string", "failed node should expose error_reason")
+        const pristine = body.find((node: any) => node.id === "a")
+        object(pristine)
+        check(!("error_class" in pristine), "error_class should be absent on non-failed nodes")
       }),
     ),
 

--- a/packages/opencode/test/server/httpapi-exercise/runner.ts
+++ b/packages/opencode/test/server/httpapi-exercise/runner.ts
@@ -191,6 +191,7 @@ function withContext<A, E>(
           llmWait: (count) => Effect.suspend(() => llm().wait(count)),
           tuiRequest: (request) => Effect.sync(() => modules.Tui.submitTuiRequest(request)),
           dag: (input) => run(createDagFixture(input.sessionID, input.title, input.nodes)),
+          dagFailNode: (dagID, nodeID, reason, errorClass) => run(failDagNodeFixture(dagID, nodeID, reason, errorClass)),
           foreignDag: (input) => run(createForeignDagFixture(input.title, input.nodes)),
         }
         yield* trace(options, scenario, `${label} seed start`)
@@ -305,6 +306,15 @@ async function bounded(label: string, work: () => Promise<unknown>, ms = CLEANUP
   if (winner === "timeout") {
     console.error(`[cleanup] ${label} exceeded ${ms}ms — forcing continuation (resource may leak)`)
   }
+}
+
+/** Fail a seeded DAG node through the Dag service so error_class lands on the wire. */
+function failDagNodeFixture(dagID: string, nodeID: string, reason: string, errorClass: "timeout" | "exec_failed" | "verdict_fail") {
+  return Effect.gen(function* () {
+    const modules = yield* Effect.promise(() => runtime())
+    const dag = yield* modules.Dag.Service
+    yield* dag.nodeFailed(dagID, nodeID, reason, errorClass).pipe(Effect.orDie)
+  })
 }
 
 /**

--- a/packages/opencode/test/server/httpapi-exercise/types.ts
+++ b/packages/opencode/test/server/httpapi-exercise/types.ts
@@ -65,6 +65,8 @@ export type ScenarioContext = {
   tuiRequest: (request: { path: string; body: unknown }) => Effect.Effect<void>
   /** Create a DAG workflow owned by sessionID with the given node configs. Returns the dagID. */
   dag: (input: { sessionID: SessionID; title?: string; nodes: DagNodeSeed[] }) => Effect.Effect<DagWorkflowInfo>
+  /** Fail a seeded DAG node through the Dag service (projects error_class on the wire). */
+  dagFailNode: (dagID: string, nodeID: string, reason: string, errorClass: "timeout" | "exec_failed" | "verdict_fail") => Effect.Effect<void>
   /** Create a DAG workflow under a different project in the shared database. */
   foreignDag: (input: { title?: string; nodes: DagNodeSeed[] }) => Effect.Effect<DagWorkflowInfo>
 }

--- a/packages/sdk/js/.gitignore
+++ b/packages/sdk/js/.gitignore
@@ -1,0 +1,1 @@
+openapi.json

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -3906,6 +3906,7 @@ export type DagNode = {
   child_session_id?: string
   output?: unknown
   error_reason?: string
+  error_class?: string
   deadline_ms?: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
   replan_attempts: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
   started_at?: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"


### PR DESCRIPTION
## 动机

节点失败后（超时/模型配置错误等），父代理倾向于整体重启 workflow 而非定向修复。根因：失败分类只存在于事件层，决策面（status/wake）完全看不到；且指引缺失 triage 流程。

## 内容

**信息暴露**
- `workflow_node.error_class` 持久化失败分类（timeout/exec_failed/verdict_fail），迁移 `20260803073521`
- 全决策面暴露：`workflow(action=status)`、wake 节点行后缀、终态 workflow 失败归因摘要（Failed nodes 块）、httpapi NodeResponse、SDK

**指引（workflow.md / dag-flow.txt）**
- 失败 triage 表：按 error_class 分流的正确响应
- 级联检测两形态（skipped 终态化 + paused 细节；依赖注入 prompt 形态）
- `orchestrator_unresponsive` 零归因配方
- 终态 failed 的 continuation workflow 接续指引；预算声明点名聚合/验证道需 20-30min

**测试**：投射/状态/wake 归因/取消节点 null 不变量/恢复分类/paused 必挂终态化/httpapi 线上 error_class fixture

## 评审轨迹

经三轮 DAG 深度评审（round-1 LOOP→修复，round-2 联合评审 LOOP→修复，round-3 终审 PASS：5 项 HIGH 全部闭环，8/8 客观门禁，残余 LOW 均已论证处置）。

## 堆叠说明

base 为 #171（config-repo 方案，替代已关闭的 #167）：自底向上合并 #171 → 本 PR → #170（goal 恢复）。

## 验证

typecheck（core/opencode/tui）、dag 325 测试、httpapi 契约、migration check、SDK check:generated