### PR TITLE
feat(goal): restore autonomous goal module with state management and tool registration

### DIFF
--- a/packages/core/schema.json
+++ b/packages/core/schema.json
@@ -1,9 +1,9 @@
 {
   "version": "7",
   "dialect": "sqlite",
-  "id": "937897f2-96bc-4fee-af44-bbc2accda92f",
+  "id": "442cdbd5-86a8-41a9-86d6-5361dbac90e0",
   "prevIds": [
-    "a26723c8-be88-4c4e-85cf-0c1ecd3cf638"
+    "a953899b-bb63-497e-8e2e-86eb5e0fdeed"
   ],
   "ddl": [
     {
@@ -48,6 +48,10 @@
     },
     {
       "name": "event",
+      "entityType": "tables"
+    },
+    {
+      "name": "goal_state",
       "entityType": "tables"
     },
     {
@@ -993,6 +997,36 @@
       "name": "data",
       "entityType": "columns",
       "table": "event"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "table": "goal_state"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "payload",
+      "entityType": "columns",
+      "table": "goal_state"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "goal_state"
     },
     {
       "type": "text",
@@ -2312,6 +2346,15 @@
     },
     {
       "columns": [
+        "session_id"
+      ],
+      "nameExplicit": false,
+      "name": "goal_state_pk",
+      "table": "goal_state",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
         "id"
       ],
       "nameExplicit": false,
@@ -2576,6 +2619,20 @@
       "name": "event_aggregate_type_seq_idx",
       "entityType": "indexes",
       "table": "event"
+    },
+    {
+      "columns": [
+        {
+          "value": "updated_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "goal_state_updated_at_idx",
+      "entityType": "indexes",
+      "table": "goal_state"
     },
     {
       "columns": [

--- a/packages/core/src/database/migration.gen.ts
+++ b/packages/core/src/database/migration.gen.ts
@@ -48,5 +48,6 @@ export const migrations = (
     import("./migration/20260717034735_fearless_cammi"),
     import("./migration/20260720013828_dag-workflow-node-identity"),
     import("./migration/20260803073521_workflow_node_error_class"),
+    import("./migration/20260803083938_restore_goal_state"),
   ])
 ).map((module) => module.default) satisfies DatabaseMigration.Migration[]

--- a/packages/core/src/database/migration/20260803083938_restore_goal_state.ts
+++ b/packages/core/src/database/migration/20260803083938_restore_goal_state.ts
@@ -1,0 +1,20 @@
+import { Effect } from "effect"
+import type { DatabaseMigration } from "../migration"
+
+export default {
+  id: "20260803083938_restore_goal_state",
+  up(tx) {
+    return Effect.gen(function* () {
+      // IF NOT EXISTS: databases built while goal_state was still in the
+      // baseline snapshot (pre-retire window) already have the table.
+      yield* tx.run(`
+        CREATE TABLE IF NOT EXISTS \`goal_state\` (
+          \`session_id\` text PRIMARY KEY,
+          \`payload\` text NOT NULL,
+          \`updated_at\` integer NOT NULL
+        );
+      `)
+      yield* tx.run(`CREATE INDEX IF NOT EXISTS \`goal_state_updated_at_idx\` ON \`goal_state\` (\`updated_at\`);`)
+    })
+  },
+} satisfies DatabaseMigration.Migration

--- a/packages/core/src/database/schema.gen.ts
+++ b/packages/core/src/database/schema.gen.ts
@@ -148,6 +148,13 @@ export default {
         );
       `)
       yield* tx.run(`
+        CREATE TABLE \`goal_state\` (
+          \`session_id\` text PRIMARY KEY,
+          \`payload\` text NOT NULL,
+          \`updated_at\` integer NOT NULL
+        );
+      `)
+      yield* tx.run(`
         CREATE TABLE \`permission\` (
           \`id\` text PRIMARY KEY,
           \`project_id\` text NOT NULL,
@@ -314,6 +321,7 @@ export default {
       )
       yield* tx.run(`CREATE UNIQUE INDEX \`event_aggregate_seq_idx\` ON \`event\` (\`aggregate_id\`,\`seq\`);`)
       yield* tx.run(`CREATE INDEX \`event_aggregate_type_seq_idx\` ON \`event\` (\`aggregate_id\`,\`type\`,\`seq\`);`)
+      yield* tx.run(`CREATE INDEX \`goal_state_updated_at_idx\` ON \`goal_state\` (\`updated_at\`);`)
       yield* tx.run(
         `CREATE UNIQUE INDEX \`permission_project_action_resource_idx\` ON \`permission\` (\`project_id\`,\`action\`,\`resource\`);`,
       )

--- a/packages/core/src/goal/sql.ts
+++ b/packages/core/src/goal/sql.ts
@@ -1,0 +1,11 @@
+import { index, integer, sqliteTable, text } from "drizzle-orm/sqlite-core"
+
+export const GoalStateTable = sqliteTable(
+  "goal_state",
+  {
+    session_id: text().primaryKey(),
+    payload: text().notNull(),
+    updated_at: integer().notNull(),
+  },
+  (t) => [index("goal_state_updated_at_idx").on(t.updated_at)],
+)

--- a/packages/opencode/src/command/index.ts
+++ b/packages/opencode/src/command/index.ts
@@ -48,6 +48,8 @@ export function hints(template: string) {
 export const Default = {
   INIT: "init",
   REVIEW: "review",
+  GOAL: "goal",
+  SUBGOAL: "subgoal",
   DAG_FLOW: "dag-flow",
   IMPORT_HOOKS: "import-claude-hooks",
   CREATE_HOOK: "create-hook",
@@ -90,6 +92,20 @@ export const layer = Layer.effect(
         },
         subtask: true,
         hints: hints(PROMPT_REVIEW),
+      }
+      commands[Default.GOAL] = {
+        name: Default.GOAL,
+        description: "设定持久目标，自动循环执行直到完成 [status|pause|resume|done|clear|stop]",
+        source: "command",
+        template: "",
+        hints: ["$ARGUMENTS"],
+      }
+      commands[Default.SUBGOAL] = {
+        name: Default.SUBGOAL,
+        description: "管理子目标 [list|<text>|remove <n>|clear]",
+        source: "command",
+        template: "",
+        hints: ["$ARGUMENTS"],
       }
       commands[Default.DAG_FLOW] = {
         name: Default.DAG_FLOW,

--- a/packages/opencode/src/effect/app-runtime.ts
+++ b/packages/opencode/src/effect/app-runtime.ts
@@ -54,6 +54,8 @@ import { EventV2Bridge } from "@/event-v2-bridge"
 import { HookStartContext } from "@/hook/start-context"
 import { SettingsHook } from "@/hook/settings"
 import { HookRewakeLive } from "@/hook/rewake-live"
+import { Goal } from "@/goal/goal"
+import { GoalLoop } from "@/goal/loop"
 import { Dag } from "@/dag/dag"
 import { DagStore } from "@opencode-ai/core/dag/store"
 import { DagLoop } from "@/dag/runtime/loop"
@@ -80,6 +82,7 @@ export const AppLayer = Layer.mergeAll(
     Question.defaultLayer,
     Permission.defaultLayer,
     Todo.defaultLayer,
+    Goal.defaultLayer,
     Session.defaultLayer,
     SessionStatus.defaultLayer,
     BackgroundJob.defaultLayer,
@@ -118,10 +121,13 @@ export const AppLayer = Layer.mergeAll(
   Layer.provideMerge(Ripgrep.defaultLayer),
   Layer.provideMerge(InstanceLayer.layer),
   Layer.provideMerge(Observability.layer),
-  // SettingsHook goes in provideMerge (NOT mergeAll) because it needs
+  // GoalLoop + SettingsHook go in provideMerge (NOT mergeAll) because they need
   // services from BOTH group1 and group2. mergeAll siblings cannot see each
   // other's outputs, but provideMerge gives the layer access to the full
-  // accumulated context (group1 + group2 merged).
+  // accumulated context (group1 + group2 merged). Both self-provide part of
+  // their transitive chain (GoalLoop in loop.ts, SettingsHook via
+  // SessionHooks.defaultLayer); the remainder resolves from this ambient context.
+  Layer.provideMerge(GoalLoop.defaultLayer),
   Layer.provideMerge(DagLoop.defaultLayer),
   Layer.provideMerge(DagSummaryPublisher.defaultLayer),
   Layer.provideMerge(SettingsHook.defaultLayer),

--- a/packages/opencode/src/effect/bootstrap-runtime.ts
+++ b/packages/opencode/src/effect/bootstrap-runtime.ts
@@ -7,6 +7,7 @@ import { ShareNext } from "@/share/share-next"
 import { Vcs } from "@/project/vcs"
 import { Snapshot } from "@/snapshot"
 import { Config } from "@/config/config"
+import { GoalLoop } from "@/goal/loop"
 import * as Observability from "@opencode-ai/core/observability"
 import { memoMap } from "@opencode-ai/core/effect/memo-map"
 
@@ -18,6 +19,7 @@ export const BootstrapLayer = Layer.mergeAll(
   LSP.defaultLayer,
   Vcs.defaultLayer,
   Snapshot.defaultLayer,
+  GoalLoop.defaultLayer,
 ).pipe(Layer.provide(Observability.layer))
 
 export const BootstrapRuntime = ManagedRuntime.make(

--- a/packages/opencode/src/goal/events.ts
+++ b/packages/opencode/src/goal/events.ts
@@ -1,0 +1,9 @@
+export * as GoalEvent from "./events"
+
+// Re-export schema-level events — the single source of truth for event types.
+// The TUI subscribes to these via the standard SSE event stream.
+export { SessionGoal as GoalSchema } from "@opencode-ai/schema/session-goal"
+import { SessionGoal } from "@opencode-ai/schema/session-goal"
+
+export const Updated = SessionGoal.Event.Updated
+export const Cleared = SessionGoal.Event.Cleared

--- a/packages/opencode/src/goal/goal.ts
+++ b/packages/opencode/src/goal/goal.ts
@@ -1,0 +1,708 @@
+export * as Goal from "./goal"
+
+import { Effect, Layer, Context, Schema, Fiber } from "effect"
+import { eq } from "drizzle-orm"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { Database } from "@opencode-ai/core/database/database"
+import { EventV2Bridge } from "@/event-v2-bridge"
+import { GoalState } from "./state"
+import { GoalStateTable } from "@opencode-ai/core/goal/sql"
+import { GoalEvent } from "./events"
+import { GoalPrompts } from "./prompts"
+import { SessionID } from "@/session/schema"
+import { SessionStatus } from "@/session/status"
+
+export interface Interface {
+  readonly load: (sessionID: SessionID) => Effect.Effect<GoalState.Info | undefined>
+  readonly set: (sessionID: SessionID, goal: string, maxTurns?: number) => Effect.Effect<GoalState.Info>
+  readonly pause: (sessionID: SessionID, reason: string) => Effect.Effect<GoalState.Info | undefined>
+  readonly resume: (sessionID: SessionID) => Effect.Effect<GoalState.Info | undefined>
+  readonly clear: (sessionID: SessionID) => Effect.Effect<void>
+  readonly markDone: (sessionID: SessionID, reason: string) => Effect.Effect<GoalState.Info | undefined>
+  readonly addSubgoal: (sessionID: SessionID, subgoal: string) => Effect.Effect<GoalState.Info | undefined>
+  readonly removeSubgoal: (
+    sessionID: SessionID,
+    /** 1-based index of the subgoal to remove (1 = first subgoal). */
+    index: number,
+  ) => Effect.Effect<
+    | { tag: "ok"; removed: string; state: GoalState.Info }
+    | { tag: "noState" }
+    | { tag: "outOfBounds"; size: number }
+  >
+  readonly clearSubgoals: (sessionID: SessionID) => Effect.Effect<GoalState.Info | undefined>
+  readonly statusLine: (sessionID: SessionID) => Effect.Effect<string | undefined>
+  readonly dispatch: (sessionID: SessionID, args: string) => Effect.Effect<{
+    type: "message" | "kick"
+    text: string
+    announce?: string
+  }>
+  readonly dispatchSubgoal: (sessionID: SessionID, args: string) => Effect.Effect<{
+    type: "message"
+    text: string
+  }>
+  readonly updateAfterJudge: (
+    sessionID: SessionID,
+    verdict: "done" | "continue",
+    reason: string,
+    parseFailed: boolean,
+  ) => Effect.Effect<
+    | {
+        state: GoalState.Info
+        shouldContinue: boolean
+        message: string
+      }
+    | undefined
+  >
+    readonly registerLoopFiber: (sessionID: SessionID, fiber: Fiber.Fiber<unknown, unknown>) => Effect.Effect<void>
+    readonly clearLoopFiber: (sessionID: SessionID) => Effect.Effect<void>
+    /**
+     * Identity-scoped loop-fiber cleanup. Removes the fibers-Map entry for
+     * `sessionID` ONLY if it currently still points at `fiber` (a newer idle
+     * event may have already registered a fresh fiber via registerLoopFiber,
+     * which interrupts and overwrites). MUST NOT interrupt the fiber — callers
+     * invoke this once the fiber has already completed its work (natural
+     * completion via the GoalLoop idle watcher). Without the identity check, a
+     * naturally-completing old fiber would evict a freshly-registered new fiber
+     * and silently stall the goal loop.
+     */
+    readonly clearLoopFiberIf: (
+      sessionID: SessionID,
+      fiber: Fiber.Fiber<unknown, unknown>,
+    ) => Effect.Effect<void>
+    /**
+     * Terminal cleanup for the "done" transition: publishes goal.updated(status=done)
+     * with a transient snapshot, deletes the row, then publishes goal.cleared.
+     *
+     * Safe to call from ANY context — including inside the loop fiber itself
+     * (loop.ts done branch) — because it does NOT manage the fiber map. Callers
+     * that need to stop a running loop from outside (user slash commands,
+     * goal.complete tool calls) should call `clearFiber()` FIRST, e.g. markDone.
+     *
+     * Constructing the done-state snapshot (instead of publishing the raw
+     * row, whose status is still "active") preserves the documented bus
+     * contract: goal.updated(done) → goal.cleared.
+     */
+    readonly deleteAndPublishDone: (sessionID: SessionID, reason: string) => Effect.Effect<GoalState.Info | undefined>
+    /**
+     * Pause transition that does NOT touch the fiber map. Mirrors
+     * deleteAndPublishDone's safety property: safe to call from inside the
+     * loop fiber (loop.ts shouldPreempt branch) because goal.pause()
+     * internally calls clearFiber which would self-interrupt before
+     * publishGoal(paused) reaches the event bus.
+     *
+     * Callers that need to stop a running loop from outside (user slash
+     * commands) should call `pause()` instead — it interrupts the loop
+     * fiber AND publishes the paused event.
+     */
+    readonly pauseAndPublish: (sessionID: SessionID, reason: string) => Effect.Effect<GoalState.Info | undefined>
+  }
+
+export class Service extends Context.Service<Service, Interface>()("@opencode/Goal") {}
+
+export const layer = Layer.effect(
+  Service,
+  Effect.gen(function* () {
+    const events = yield* EventV2Bridge.Service
+    const { db } = yield* Database.Service
+    const sessionStatus = yield* SessionStatus.Service
+
+    // Unified event publisher — every state change publishes goal.updated
+    // with the full snapshot, identical to Todo's todo.updated pattern.
+    const publishGoal = (sessionID: SessionID, state: GoalState.Info) =>
+      events.publish(GoalEvent.Updated, {
+        sessionID,
+        goal: {
+          goal: state.goal,
+          status: state.status as "active" | "paused" | "done",
+          turnsUsed: Number(state.turns_used),
+          maxTurns: Number(state.max_turns),
+          subgoals: state.subgoals ?? [],
+          ...(state.paused_reason !== undefined ? { pausedReason: state.paused_reason } : {}),
+        },
+      })
+
+    const fibers = new Map<SessionID, Fiber.Fiber<unknown, unknown>>()
+
+    const registerFiber = Effect.fnUntraced(function* (
+      sessionID: SessionID,
+      fiber: Fiber.Fiber<unknown, unknown>,
+    ) {
+      const existing = fibers.get(sessionID)
+      if (existing) yield* Fiber.interrupt(existing)
+      fibers.set(sessionID, fiber)
+    })
+
+    const clearFiber = Effect.fnUntraced(function* (sessionID: SessionID) {
+      const existing = fibers.get(sessionID)
+      if (existing) {
+        yield* Fiber.interrupt(existing)
+        fibers.delete(sessionID)
+      }
+    })
+
+    // Identity-scoped self-clean for naturally-completing loop fibers. Deletes
+    // the map entry only when it still references THIS fiber — a subsequent
+    // idle event's registerFiber may have already interrupted the old fiber and
+    // installed a new one, and deleting unconditionally would evict the new
+    // fiber. Never interrupts: the calling fiber has already finished its work.
+    const clearFiberIf = Effect.fnUntraced(function* (
+      sessionID: SessionID,
+      fiber: Fiber.Fiber<unknown, unknown>,
+    ) {
+      if (fibers.get(sessionID) === fiber) {
+        fibers.delete(sessionID)
+      }
+    })
+
+    // Terminal cleanup for "done" transitions. Loads current state (if any),
+    // constructs a transient snapshot with status="done" + the given reason,
+    // emits goal.updated(done), deletes the row, then emits goal.cleared.
+    //
+    // Does NOT touch the fiber map. This is the key safety property:
+    //   - markDone (user-initiated from slash command or goal.complete
+    //     tool) calls clearFiber FIRST, then deleteAndPublishDone — the
+    //     loop fiber is already stopped when this runs.
+    //   - loop.ts done branch calls deleteAndPublishDone DIRECTLY from
+    //     inside the loop fiber — so it must not self-interrupt.
+    //
+    // Without this separation, calling goal.clear() from within afterIdle
+    // would interrupt ourselves before goal.cleared was published (the
+    // event bus would miss the terminal event, and TUI/SSE consumers
+    // polling state would never see the transition).
+    //
+    // The whole terminal sequence (load → publish(done) → delete →
+    // publish(cleared)) runs inside Effect.uninterruptible. This is
+    // defense-in-depth (F1): even if a future caller arranges for the loop
+    // fiber to be interrupted mid-call, the terminal event contract still
+    // completes atomically — goal.cleared cannot be skipped by an interrupt
+    // landing between publish(done) and publish(cleared). The operations are
+    // short synchronous DB + event publishes, so there is no deadlock risk.
+    const deleteAndPublishDone = Effect.fnUntraced(function* (sessionID: SessionID, reason: string) {
+      return yield* Effect.uninterruptible(
+        Effect.gen(function* () {
+          const state = yield* loadState(sessionID)
+          if (state) {
+            const doneState = new GoalState.Info({
+              ...state,
+              status: "done",
+              last_verdict: "done",
+              last_reason: reason,
+            })
+            yield* publishGoal(sessionID, doneState)
+          }
+          yield* deleteState(sessionID)
+          yield* events.publish(GoalEvent.Cleared, { sessionID })
+          return state
+        }),
+      )
+    })
+
+    function loadState(sessionID: SessionID) {
+      return db
+        .select()
+        .from(GoalStateTable)
+        .where(eq(GoalStateTable.session_id, sessionID))
+        .get()
+        .pipe(
+          Effect.orDie,
+          Effect.map((row) => {
+            if (!row) return undefined
+            return Schema.decodeUnknownSync(GoalState.Info)(JSON.parse(row.payload))
+          }),
+        )
+    }
+
+    function saveState(sessionID: SessionID, state: GoalState.Info) {
+      const payload = JSON.stringify(Schema.encodeSync(GoalState.Info)(state))
+      return db
+        .insert(GoalStateTable)
+        .values({ session_id: sessionID, payload, updated_at: Date.now() })
+        .onConflictDoUpdate({
+          target: GoalStateTable.session_id,
+          set: { payload, updated_at: Date.now() },
+        })
+        .run()
+        .pipe(Effect.orDie)
+    }
+
+    function deleteState(sessionID: SessionID) {
+      return db
+        .delete(GoalStateTable)
+        .where(eq(GoalStateTable.session_id, sessionID))
+        .run()
+        .pipe(Effect.orDie)
+    }
+
+    const load = Effect.fn("Goal.load")(function* (sessionID: SessionID) {
+      return yield* loadState(sessionID)
+    })
+
+    const set = Effect.fn("Goal.set")(function* (sessionID: SessionID, goal: string, maxTurns?: number) {
+      const now = Date.now()
+      const state = new GoalState.Info({
+        goal,
+        status: "active",
+        turns_used: GoalState.nni(0),
+        max_turns: GoalState.nni(maxTurns ?? GoalPrompts.DEFAULT_MAX_TURNS),
+        created_at: now,
+        last_turn_at: now,
+        consecutive_parse_failures: GoalState.nni(0),
+        subgoals: [],
+      })
+      yield* saveState(sessionID, state)
+      yield* publishGoal(sessionID, state)
+      return state
+    })
+
+    const pause = Effect.fn("Goal.pause")(function* (sessionID: SessionID, reason: string) {
+      const state = yield* loadState(sessionID)
+      if (!state || state.status !== "active") return undefined
+      const updated = new GoalState.Info({
+        ...state,
+        status: "paused",
+        paused_reason: reason,
+        last_turn_at: Date.now(),
+      })
+      yield* saveState(sessionID, updated)
+      yield* clearFiber(sessionID)
+      yield* publishGoal(sessionID, updated)
+      return updated
+    })
+
+    // Loop-fiber-safe pause: same DB + event effects as pause(), but skips
+    // clearFiber so it can be called from inside the loop fiber itself
+    // (loop.ts shouldPreempt branch). The fiber naturally terminates when
+    // afterIdle returns; no explicit interrupt needed.
+    //
+    // Wrapped in Effect.uninterruptible (F1): the save → publish sequence
+    // is atomic, so an interrupt landing between persisting the paused row
+    // and publishing goal.updated(paused) can never leave a paused DB row
+    // with no corresponding event on the bus.
+    const pauseAndPublish = Effect.fnUntraced(function* (sessionID: SessionID, reason: string) {
+      return yield* Effect.uninterruptible(
+        Effect.gen(function* () {
+          const state = yield* loadState(sessionID)
+          if (!state || state.status !== "active") return undefined
+          const updated = new GoalState.Info({
+            ...state,
+            status: "paused",
+            paused_reason: reason,
+            last_turn_at: Date.now(),
+          })
+          yield* saveState(sessionID, updated)
+          yield* publishGoal(sessionID, updated)
+          return updated
+        }),
+      )
+    })
+
+    const resume = Effect.fn("Goal.resume")(function* (sessionID: SessionID) {
+      const state = yield* loadState(sessionID)
+      if (!state || state.status !== "paused") return undefined
+      // Preserve turns_used so the original max_turns budget is respected.
+      // Resetting to 0 would silently grant another full budget, defeating
+      // `max_turns` as a runaway guard — a paused goal that exhausted its
+      // budget would immediately re-exhaust the new budget on resume.
+      // Users wanting a fresh budget should /goal clear and /goal <text>.
+      const updated = new GoalState.Info({
+        ...state,
+        status: "active",
+        consecutive_parse_failures: GoalState.nni(0),
+        paused_reason: undefined,
+        last_turn_at: Date.now(),
+      })
+      yield* saveState(sessionID, updated)
+      yield* publishGoal(sessionID, updated)
+      return updated
+    })
+
+    const clear = Effect.fn("Goal.clear")(function* (sessionID: SessionID) {
+      yield* deleteState(sessionID)
+      yield* clearFiber(sessionID)
+      yield* events.publish(GoalEvent.Cleared, { sessionID })
+    })
+
+    const markDone = Effect.fn("Goal.markDone")(function* (sessionID: SessionID, reason: string) {
+      // User/tool-initiated completion: stop the running loop fiber, then
+      // perform terminal cleanup (publish done-updated → delete → publish cleared).
+      // State transitions are budget-neutral — turns_used counts continuation
+      // dispatches only (see spec: turn-budget-counts-continuation-dispatches-only),
+      // so markDone does NOT increment. deleteAndPublishDone loads the current
+      // row (preserving whatever turns_used a prior continue dispatch set) and
+      // re-renders the done snapshot from it.
+      yield* clearFiber(sessionID)
+      return yield* deleteAndPublishDone(sessionID, reason)
+    })
+
+    const addSubgoal = Effect.fn("Goal.addSubgoal")(function* (sessionID: SessionID, subgoal: string) {
+      const state = yield* loadState(sessionID)
+      if (!state) return undefined
+      const updated = new GoalState.Info({
+        ...state,
+        subgoals: [...(state.subgoals ?? []), subgoal],
+        last_turn_at: Date.now(),
+      })
+      yield* saveState(sessionID, updated)
+      yield* publishGoal(sessionID, updated)
+      return updated
+    })
+
+    const removeSubgoal = Effect.fn("Goal.removeSubgoal")(function* (sessionID: SessionID, index: number) {
+      const state = yield* loadState(sessionID)
+      if (!state) return { tag: "noState" as const }
+      const subgoals = state.subgoals ?? []
+      const idx = index - 1
+      if (idx < 0 || idx >= subgoals.length) return { tag: "outOfBounds" as const, size: subgoals.length }
+      const removed = subgoals[idx]
+      const updated = new GoalState.Info({
+        ...state,
+        subgoals: subgoals.filter((_, i) => i !== idx),
+        last_turn_at: Date.now(),
+      })
+      yield* saveState(sessionID, updated)
+      yield* publishGoal(sessionID, updated)
+      return { tag: "ok" as const, removed, state: updated }
+    })
+
+    const clearSubgoals = Effect.fn("Goal.clearSubgoals")(function* (sessionID: SessionID) {
+      const state = yield* loadState(sessionID)
+      if (!state) return undefined
+      const updated = new GoalState.Info({
+        ...state,
+        subgoals: [],
+        last_turn_at: Date.now(),
+      })
+      yield* saveState(sessionID, updated)
+      yield* publishGoal(sessionID, updated)
+      return updated
+    })
+
+    const statusLine = Effect.fn("Goal.statusLine")(function* (sessionID: SessionID) {
+      const state = yield* loadState(sessionID)
+      if (!state) return undefined
+      const subgoals = state.subgoals ?? []
+      const sub = subgoals.length > 0 ? `，${subgoals.length} 个子目标` : ""
+      if (state.status === "active")
+        return `⊙ 目标（进行中，${state.turns_used}/${state.max_turns} 轮${sub}）：${state.goal}`
+      if (state.status === "paused") {
+        const reason = state.paused_reason ? ` — ${state.paused_reason}` : ""
+        return `⏸ 目标（已暂停，${state.turns_used}/${state.max_turns} 轮${reason}）：${state.goal}`
+      }
+      if (state.status === "done")
+        return `✓ 目标已完成（${state.turns_used}/${state.max_turns} 轮）：${state.goal}`
+      return undefined
+    })
+
+    const updateAfterJudge = Effect.fn("Goal.updateAfterJudge")(function* (
+      sessionID: SessionID,
+      verdict: "done" | "continue",
+      reason: string,
+      parseFailed: boolean,
+    ) {
+      const state = yield* loadState(sessionID)
+      if (!state || state.status !== "active") return undefined
+
+      const now = Date.now()
+      const newParseFailures = parseFailed ? state.consecutive_parse_failures + 1 : 0
+
+      if (verdict === "done") {
+        const updated = new GoalState.Info({
+          ...state,
+          status: "done",
+          // State transitions are budget-neutral — a `done` verdict drives no
+          // continuation dispatch, so it must NOT consume budget. turns_used
+          // reflects only continuation dispatches (see spec:
+          // turn-budget-counts-continuation-dispatches-only).
+          turns_used: state.turns_used,
+          last_turn_at: now,
+          last_verdict: "done",
+          last_reason: reason,
+          consecutive_parse_failures: GoalState.nni(newParseFailures),
+        })
+        yield* saveState(sessionID, updated)
+        // Do NOT publish goal.updated here. deleteAndPublishDone is the SOLE
+        // owner of the terminal event sequence (goal.updated(done) → delete →
+        // goal.cleared); publishing here would double-fire goal.updated(done)
+        // on every judge-declared completion (see spec:
+        // terminal-event-contract-publishes-exactly-once). We still saveState
+        // so deleteAndPublishDone can load the done row and re-render the
+        // snapshot. loop.ts invokes deleteAndPublishDone after this returns.
+        return {
+          state: updated,
+          shouldContinue: false,
+          message: `✓ 目标已达成：${reason}`,
+        }
+      }
+
+      const turnsUsed = GoalState.nni(Number(state.turns_used) + 1)
+
+      if (newParseFailures >= GoalPrompts.MAX_CONSECUTIVE_PARSE_FAILURES) {
+        const pauseReason =
+          "judge 模型未返回有效 JSON 判定。请检查模型配置或换用更可靠的模型，然后 /goal resume。"
+        const updated = new GoalState.Info({
+          ...state,
+          status: "paused",
+          turns_used: turnsUsed,
+          last_turn_at: now,
+          last_verdict: "continue",
+          last_reason: reason,
+          paused_reason: pauseReason,
+          consecutive_parse_failures: GoalState.nni(newParseFailures),
+        })
+        // Do NOT call clearFiber here. updateAfterJudge is inlined into
+        // GoalLoop.afterIdle (loop.ts:122), so the fiber running this code
+        // IS the one registered in the fibers map — clearFiber would
+        // self-interrupt before publishGoal reaches the event bus, leaving
+        // the pause invisible to SSE/TUI and aborting the rest of afterIdle.
+        // The fiber naturally terminates when afterIdle returns; no explicit
+        // interrupt is needed (same rationale as pauseAndPublish /
+        // deleteAndPublishDone).
+        yield* saveState(sessionID, updated)
+        yield* publishGoal(sessionID, updated)
+        return {
+          state: updated,
+          shouldContinue: false,
+          message: `⏸ 目标已暂停 — ${pauseReason}`,
+        }
+      }
+
+      if (turnsUsed >= state.max_turns) {
+        const pauseReason = `已用 ${turnsUsed}/${state.max_turns} 轮。使用 /goal resume 继续，或 /goal clear 停止。`
+        const updated = new GoalState.Info({
+          ...state,
+          status: "paused",
+          turns_used: turnsUsed,
+          last_turn_at: now,
+          last_verdict: "continue",
+          last_reason: reason,
+          paused_reason: pauseReason,
+          consecutive_parse_failures: GoalState.nni(newParseFailures),
+        })
+        // Same self-interrupt hazard as the parse-failure branch above: we
+        // are running inside the afterIdle loop fiber, so clearFiber would
+        // interrupt ourselves before publishGoal(paused) fires.
+        yield* saveState(sessionID, updated)
+        yield* publishGoal(sessionID, updated)
+        return {
+          state: updated,
+          shouldContinue: false,
+          message: `⏸ 目标已暂停 — ${pauseReason}`,
+        }
+      }
+
+      const updated = new GoalState.Info({
+        ...state,
+        status: "active",
+        turns_used: turnsUsed,
+        last_turn_at: now,
+        last_verdict: "continue",
+        last_reason: reason,
+        consecutive_parse_failures: GoalState.nni(newParseFailures),
+      })
+      yield* saveState(sessionID, updated)
+      yield* publishGoal(sessionID, updated)
+      return {
+        state: updated,
+        shouldContinue: true,
+        message: `↻ 继续推进目标（${updated.turns_used}/${updated.max_turns}）：${reason}`,
+      }
+    })
+
+    const dispatch = Effect.fn("Goal.dispatch")(function* (sessionID: SessionID, args: string) {
+      const trimmed = args.trim()
+      const lower = trimmed.toLowerCase()
+
+      const isControlCommand =
+        lower === "" ||
+        lower === "status" ||
+        lower === "pause" ||
+        lower === "resume" ||
+        lower === "clear" ||
+        lower === "stop" ||
+        lower === "done"
+      if (!isControlCommand) {
+        const status = yield* sessionStatus.get(sessionID)
+        if (status.type === "busy") {
+          return {
+            type: "message" as const,
+            text: "Session 正在执行中。请先 /stop 中断后再设定新目标。",
+          }
+        }
+        // Known TOCTOU: `get` above then goal.set + continuation dispatch below
+        // is not atomic — the session could flip to busy in between. Accepted:
+        // the loop's idle gating and judge-preempt guard handle that case
+        // gracefully; an atomic check-and-set would need a session-level lock
+        // outside this module's scope.
+      }
+
+      if (lower === "" || lower === "status") {
+        const line = yield* statusLine(sessionID)
+        return { type: "message" as const, text: line ?? "没有活跃的目标。使用 /goal <text> 设定一个目标。" }
+      }
+
+      if (lower === "pause") {
+        const result = yield* pause(sessionID, "user-paused")
+        return {
+          type: "message" as const,
+          text: result
+            ? `⏸ 目标已暂停。/goal resume 继续。`
+            : "没有活跃的目标可以暂停。",
+        }
+      }
+
+      if (lower === "resume") {
+        // Busy guard, symmetric with the set-new-goal guard above. `resume` is a
+        // control command so it bypasses the generic busy check; without this,
+        // resuming a goal on a busy session would return `kick`, prompting
+        // prompt.ts to start a second agent loop concurrently with the running
+        // one. Keep the goal paused and ask the user to /stop first instead.
+        const resumeStatus = yield* sessionStatus.get(sessionID)
+        if (resumeStatus.type === "busy") {
+          return {
+            type: "message" as const,
+            text: "Session 正在执行中。请先 /stop 中断后再 /goal resume。",
+          }
+        }
+        const result = yield* resume(sessionID)
+        if (!result) return { type: "message" as const, text: "没有已暂停的目标可以恢复。" }
+        // Warning UX for budget-exhaustion pauses: we kept turns_used intact
+        // (see resume()), so a goal paused because turns >= max will resume
+        // only to get immediately re-paused by the next judge iteration.
+        // Without a warning the user sees "已恢复" then the same pause
+        // text a second later, which looks like resume didn't work.
+        const announceMsg =
+          Number(result.turns_used) >= Number(result.max_turns)
+            ? `⚠ 目标已恢复，但预算已耗尽（${result.turns_used}/${result.max_turns} 轮）。下一轮 judge 会立刻再次判定超预算暂停。建议 /goal clear 后重新 /goal <text>，或在 /goal set 时传更大的 maxTurns。`
+            : undefined
+        return {
+          type: "kick" as const,
+          text: result.goal,
+          announce: announceMsg,
+        }
+      }
+
+      if (lower === "done") {
+        // /goal done is explicit "I finished this" — distinct from
+        // /goal clear (/stop), which just tears it down without marking
+        // completion. Both remove the row because done is transient.
+        yield* markDone(sessionID, "/goal done")
+        return { type: "message" as const, text: "✓ 目标已标记为完成并清除。" }
+      }
+
+      if (lower === "clear" || lower === "stop") {
+        yield* clear(sessionID)
+        return { type: "message" as const, text: "目标已清除。" }
+      }
+
+      const existing = yield* loadState(sessionID)
+      if (existing) {
+        if (existing.status === "active") {
+          return {
+            type: "message" as const,
+            text: "已有活跃目标。请先 /goal clear 再设定新目标。",
+          }
+        }
+        if (existing.status === "paused") {
+          return {
+            type: "message" as const,
+            text: `有暂停的目标（${existing.turns_used}/${existing.max_turns} 轮）。使用 /goal resume 继续，/goal clear 后再设定新目标。`,
+          }
+        }
+        // done row leftover (loop.ts usually auto-clears; defensive guard)
+        yield* clear(sessionID)
+      }
+      const maxTurns = GoalPrompts.DEFAULT_MAX_TURNS
+      const state = yield* set(sessionID, trimmed, maxTurns)
+      return {
+        type: "kick" as const,
+        text: state.goal,
+        announce: `⊙ 目标已设定（${state.max_turns} 轮预算）：${state.goal}`,
+      }
+    })
+
+    const dispatchSubgoal = Effect.fn("Goal.dispatchSubgoal")(function* (sessionID: SessionID, args: string) {
+      const trimmed = args.trim()
+      const lower = trimmed.toLowerCase()
+
+      if (lower === "" || lower === "list") {
+        const state = yield* loadState(sessionID)
+        const subgoals = state?.subgoals ?? []
+        if (!state || subgoals.length === 0)
+          return { type: "message" as const, text: "没有子目标。使用 /subgoal add <text> 添加。" }
+        const lines = subgoals.map((s, i) => `${i + 1}. ${s}`)
+        return { type: "message" as const, text: `子目标：\n${lines.join("\n")}` }
+      }
+
+      if (lower === "clear") {
+        const result = yield* clearSubgoals(sessionID)
+        return {
+          type: "message" as const,
+          text: result ? "子目标已清除。" : "没有活跃的目标。",
+        }
+      }
+
+      if (lower.startsWith("remove ") || lower.startsWith("rm ")) {
+        const indexStr = trimmed.replace(/^(?:remove|rm)\s+/i, "")
+        const index = parseInt(indexStr, 10)
+        if (isNaN(index) || index < 1) return { type: "message" as const, text: "用法：/subgoal remove <编号>" }
+        const result = yield* removeSubgoal(sessionID, index)
+        if (result.tag === "noState") return { type: "message" as const, text: "没有活跃的目标。" }
+        if (result.tag === "outOfBounds") {
+          return {
+            type: "message" as const,
+            text:
+              result.size === 0
+                ? "当前没有子目标。"
+                : `索引越界：当前只有 ${result.size} 个子目标，#1 至 #${result.size}。`,
+          }
+        }
+        return { type: "message" as const, text: `子目标 #${index} 已移除：${result.removed}` }
+      }
+
+      if (lower.startsWith("add ")) {
+        const subgoal = trimmed.slice(4).trim()
+        if (!subgoal) return { type: "message" as const, text: "用法：/subgoal add <text>" }
+        const result = yield* addSubgoal(sessionID, subgoal)
+        return {
+          type: "message" as const,
+          text: result ? `子目标已添加：${subgoal}` : "没有活跃的目标。先使用 /goal <text> 设定一个目标。",
+        }
+      }
+
+      const result = yield* addSubgoal(sessionID, trimmed)
+      return {
+        type: "message" as const,
+        text: result ? `子目标已添加：${trimmed}` : "没有活跃的目标。先使用 /goal <text> 设定一个目标。",
+      }
+    })
+
+    return Service.of({
+      load,
+      set,
+      pause,
+      resume,
+      clear,
+      markDone,
+      addSubgoal,
+      removeSubgoal,
+      clearSubgoals,
+      statusLine,
+      dispatch,
+      dispatchSubgoal,
+      updateAfterJudge,
+      registerLoopFiber: registerFiber,
+      clearLoopFiber: clearFiber,
+      clearLoopFiberIf: clearFiberIf,
+      deleteAndPublishDone,
+      pauseAndPublish,
+    })
+  }),
+)
+
+export const defaultLayer = layer.pipe(
+  Layer.provide(SessionStatus.defaultLayer),
+  Layer.provide(EventV2Bridge.defaultLayer),
+  Layer.provide(Database.defaultLayer),
+)
+
+export const node = LayerNode.make(layer, [EventV2Bridge.node, Database.node, SessionStatus.node])

--- a/packages/opencode/src/goal/judge.ts
+++ b/packages/opencode/src/goal/judge.ts
@@ -1,0 +1,74 @@
+export * as GoalJudge from "./judge"
+
+import { Effect } from "effect"
+import { GoalPrompts } from "./prompts"
+
+export interface JudgeResult {
+  readonly verdict: "done" | "continue"
+  readonly reason: string
+  readonly parseFailed: boolean
+}
+
+export function parseJudgeResponse(raw: string): JudgeResult {
+  // Step 1: strip markdown fences
+  const stripped = raw.replace(/```(?:json)?\s*([\s\S]*?)```/g, "$1").trim()
+
+  // Step 2: try JSON.parse whole string
+  try {
+    const obj = JSON.parse(stripped)
+    if (typeof obj.done === "boolean" && typeof obj.reason === "string")
+      return { verdict: obj.done ? "done" : "continue", reason: obj.reason, parseFailed: false }
+  } catch {}
+
+  // Step 3: regex extract first {...}
+  const match = stripped.match(/\{[^{}]*\}/)
+  if (match) {
+    try {
+      const obj = JSON.parse(match[0])
+      if (typeof obj.done === "boolean" && typeof obj.reason === "string")
+        return { verdict: obj.done ? "done" : "continue", reason: obj.reason, parseFailed: false }
+    } catch {}
+  }
+
+  // Step 4: parse failed
+  return { verdict: "continue", reason: "无法解析 judge 输出", parseFailed: true }
+}
+
+export const run = Effect.fn("Goal.Judge.run")(function* (
+  goal: string,
+  response: string,
+  subgoals: ReadonlyArray<string>,
+  callLLM: (opts: {
+    system: string
+    user: string
+    temperature: number
+    maxTokens: number
+    timeout: number
+  }) => Effect.Effect<string, Error>,
+) {
+  const userPrompt = GoalPrompts.renderJudgeUserPrompt(goal, response, subgoals)
+
+  return yield* callLLM({
+    system: GoalPrompts.JUDGE_SYSTEM_PROMPT,
+    user: userPrompt,
+    temperature: 0,
+    maxTokens: 200,
+    timeout: GoalPrompts.DEFAULT_JUDGE_TIMEOUT_SECONDS,
+  }).pipe(
+    Effect.map((text) => parseJudgeResponse(text)),
+    // Transport errors (timeout, network, non-JSON transport-level failure)
+    // count toward the pause budget (D5). Previously they returned
+    // parseFailed: false, which reset consecutive_parse_failures and let a
+    // flaky provider alternate bad-JSON and timeout indefinitely without
+    // ever hitting MAX_CONSECUTIVE_PARSE_FAILURES. Returning parseFailed: true
+    // feeds them through the same auto-pause path as parse failures, treating
+    // "judge is unreliable" uniformly regardless of failure mode. The verdict
+    // stays "continue" so a single transient blip does not stall the loop;
+    // it only pauses after MAX_CONSECUTIVE_PARSE_FAILURES in a row.
+    Effect.orElseSucceed((): JudgeResult => ({
+      verdict: "continue",
+      reason: "judge transport error (timeout or network) — counting toward pause budget",
+      parseFailed: true,
+    })),
+  )
+})

--- a/packages/opencode/src/goal/loop.ts
+++ b/packages/opencode/src/goal/loop.ts
@@ -1,0 +1,389 @@
+export * as GoalLoop from "./loop"
+
+import { Effect, Layer, Context, Option, Stream, Scope, Fiber, Cause } from "effect"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { InstanceState } from "@/effect/instance-state"
+import { EventV2Bridge } from "@/event-v2-bridge"
+import { SessionStatus } from "@/session/status"
+import { Session } from "@/session/session"
+import { SessionPrompt } from "@/session/prompt"
+import { Provider } from "@/provider/provider"
+import { Goal } from "./goal"
+import { GoalJudge } from "./judge"
+import { GoalPrompts } from "./prompts"
+import { generateText } from "ai"
+import { SessionID } from "@/session/schema"
+
+export interface Interface {
+  readonly init: () => Effect.Effect<void>
+}
+
+export class Service extends Context.Service<Service, Interface>()("@opencode/GoalLoop") {}
+
+/**
+ * Test-only injection point for the judge LLM call (D5). When provided in the
+ * Effect context, `afterIdle` uses `call` instead of the production
+ * Provider → generateText path, so e2e tests can script judge verdicts
+ * (continue→done) with no network or Provider credentials. Production never
+ * provides it, so the Provider path is byte-for-byte unchanged.
+ */
+export type JudgeCallLLM = (opts: {
+  system: string
+  user: string
+  temperature: number
+  maxTokens: number
+  timeout: number
+}) => Effect.Effect<string, Error>
+
+export interface GoalLoopJudgeLLMInterface {
+  readonly call: JudgeCallLLM
+}
+
+export class GoalLoopJudgeLLM extends Context.Service<GoalLoopJudgeLLM, GoalLoopJudgeLLMInterface>()(
+  "@opencode/GoalLoop/JudgeLLM",
+) {}
+
+/**
+ * Pure predicate: returns true when the most recent user message in `msgs`
+ * is newer than the most recent assistant message.
+ *
+ * Used by GoalLoop.afterIdle as a strict-preempt guard: if the user has
+ * inserted a new turn after the last assistant response, we must abandon
+ * the pending continuation and pause the goal instead of re-prompting.
+ *
+ * Defensive fallback: if either side is missing, returns false (no preempt).
+ *
+ * Operates on MessageV2 shape (`info.time.created`).
+ */
+export function shouldPreempt(
+  msgs: ReadonlyArray<{ info: { role: "user" | "assistant"; time: { created: number } } }>,
+): boolean {
+  let lastUserAt = -1
+  let lastAsstAt = -1
+  for (const m of msgs) {
+    const t = m.info.time?.created
+    if (typeof t !== "number") continue
+    if (m.info.role === "user" && t > lastUserAt) lastUserAt = t
+    else if (m.info.role === "assistant" && t > lastAsstAt) lastAsstAt = t
+  }
+  if (lastUserAt < 0 || lastAsstAt < 0) return false
+  return lastUserAt > lastAsstAt
+}
+
+/**
+ * Pure predicate for the zombie-goal freshness guard (D6). Returns true when a
+ * goal is "orphaned": active, has run zero continuations (turns_used === 0),
+ * was created more than FRESHNESS_THRESHOLD ago, and the initial kick never
+ * produced an assistant message (provider error, model refusal, empty response).
+ *
+ * Used by GoalLoop.afterIdle to convert the silent orphan state into a visible,
+ * recoverable pause. Without it, every subsequent afterIdle would abort at the
+ * `if (!lastAssistant) return` line and the goal would sit permanently "active"
+ * with no progress.
+ *
+ * `now` defaults to Date.now() for production; tests pass an explicit value for
+ * determinism.
+ */
+export function isStaleZombie(
+  state: { status: string; turns_used: number; created_at: number },
+  hasAssistant: boolean,
+  now: number = Date.now(),
+): boolean {
+  return (
+    state.status === "active" &&
+    Number(state.turns_used) === 0 &&
+    !hasAssistant &&
+    now - state.created_at > GoalPrompts.FRESHNESS_THRESHOLD
+  )
+}
+
+export const layer = Layer.effect(
+  Service,
+  Effect.gen(function* () {
+    const events = yield* EventV2Bridge.Service
+    const sessions = yield* Session.Service
+    const promptSvc = yield* SessionPrompt.Service
+    const provider = yield* Provider.Service
+    const goal = yield* Goal.Service
+    const status = yield* SessionStatus.Service
+
+    const state = yield* InstanceState.make(
+      Effect.fn("GoalLoop.state")(function* (_ctx) {
+        const scope = yield* Scope.Scope
+        yield* events.subscribe(SessionStatus.Event.Status).pipe(
+          Stream.filter((evt) => evt.data.status.type === "idle"),
+          Stream.runForEach((evt) =>
+            Effect.gen(function* () {
+              const sid = evt.data.sessionID
+              // D4 (fiber lifecycle): do NOT fork or register a fiber for
+              // sessions without an active goal. Without this pre-check the
+              // fibers Map grows once per idle event for every session that
+              // ever went idle — including ones that never set a goal. afterIdle
+              // re-checks goal state internally too; that internal check stays
+              // as a TOCTOU guard (goal could be cleared between this load and
+              // the fork). v1.17.11: idle has no cause field; afterIdle handles
+              // abort detection via shouldPreempt (user message after cancel).
+              const goalState = yield* goal.load(sid)
+              if (!goalState || goalState.status !== "active") return
+              const fiber = yield* afterIdle(sid).pipe(Effect.ignore, Effect.forkIn(scope))
+              yield* goal.registerLoopFiber(sid, fiber)
+              // D4 self-clean: when this afterIdle fiber completes naturally,
+              // remove it from the fibers Map IF it is still the registered one.
+              // A newer idle event may have already registered a fresh fiber
+              // (registerLoopFiber interrupts + overwrites the old one);
+              // clearLoopFiberIf's identity check avoids evicting the new fiber.
+              // The watcher never interrupts and completes right after its
+              // target, so it does not accumulate across idle events.
+              yield* Fiber.await(fiber).pipe(
+                Effect.flatMap(() => goal.clearLoopFiberIf(sid, fiber)),
+                Effect.ignore,
+                Effect.forkIn(scope),
+              )
+            }).pipe(Effect.ignore),
+          ),
+          Effect.forkScoped,
+        )
+        return {}
+      }),
+    )
+
+    const afterIdle = Effect.fn("GoalLoop.afterIdle")(function* (sessionID: SessionID) {
+      const goalState = yield* goal.load(sessionID)
+      if (!goalState || goalState.status !== "active") return
+
+      // Zombie-goal freshness guard (D6). If the goal is active but has run
+      // zero continuations and is older than FRESHNESS_THRESHOLD, the initial
+      // kick may have failed silently (provider error, model refusal, empty
+      // response). Without this guard every subsequent afterIdle aborts at the
+      // `if (!lastAssistant) return` line below, leaving the goal permanently
+      // "active" with no progress — a silent orphan. Convert that into a
+      // visible, recoverable pause so the user can /goal resume.
+      //
+      // The probe loads only 1 message (not the full 20) so we don't pay for
+      // the whole message window just to discover staleness; the stale path
+      // returns early so the limit:20 load below never runs when the guard
+      // fires. Uses pauseAndPublish (fiber-safe) — NOT goal.pause — because
+      // we ARE the loop fiber tracked in the fibers map (same self-interrupt
+      // hazard discipline as the done / shouldPreempt branches below).
+      if (
+        Number(goalState.turns_used) === 0 &&
+        Date.now() - goalState.created_at > GoalPrompts.FRESHNESS_THRESHOLD
+      ) {
+        const probeMsgs = yield* sessions.messages({ sessionID, limit: 1 })
+        const hasAssistant = probeMsgs.some((m) => m.info.role === "assistant")
+        if (isStaleZombie(goalState, hasAssistant)) {
+          yield* goal
+            .pauseAndPublish(
+              sessionID,
+              `initial kick produced no assistant response within ${GoalPrompts.FRESHNESS_THRESHOLD / 1000}s — likely provider error or model refusal. Use /goal resume to retry.`,
+            )
+            .pipe(Effect.ignore)
+          return
+        }
+      }
+
+      const msgs = yield* sessions.messages({ sessionID, limit: 20 })
+      const lastAssistant = [...msgs].reverse().find((m) => m.info.role === "assistant")
+      if (!lastAssistant) return
+      const responseText = lastAssistant.parts
+        .filter((p): p is Extract<(typeof lastAssistant.parts)[number], { type: "text" }> => p.type === "text")
+        .map((p) => p.text)
+        .join("\n")
+        .slice(-4000)
+      if (!responseText) return
+
+      // Judge LLM call: prefer the test-injected callable (D5) so e2e tests
+      // can script verdicts without Provider/network; otherwise build the
+      // production Provider → generateText path. The verdict logic below is
+      // unchanged — only the callLLM construction point moved.
+      const injected = Option.getOrUndefined(yield* Effect.serviceOption(GoalLoopJudgeLLM))
+      const callLLM: JudgeCallLLM =
+        injected?.call ??
+        ((opts) =>
+          Effect.gen(function* () {
+            const defaultM = yield* provider.defaultModel()
+            // Judge is a ~200-token JSON binary classification — prefer the
+            // provider's small/fast model (config `small_model`, plugin hint,
+            // or the built-in haiku/flash/nano priority list). Fall back to
+            // the default model when no small model is resolvable, keeping
+            // the prior behavior byte-for-byte for those providers.
+            const small = yield* provider.getSmallModel(defaultM.providerID)
+            const model = small ?? (yield* provider.getModel(defaultM.providerID, defaultM.modelID))
+            const language = yield* provider.getLanguage(model)
+            const result = yield* Effect.tryPromise({
+              try: (signal) =>
+                generateText({
+                  model: language,
+                  system: opts.system,
+                  prompt: opts.user,
+                  temperature: opts.temperature,
+                  maxOutputTokens: opts.maxTokens,
+                  abortSignal: signal,
+                }),
+              catch: (e) => new Error(`judge LLM call failed: ${e}`),
+            }).pipe(Effect.timeout(`${opts.timeout} seconds`))
+            if (!result) return ""
+            return result.text
+          }))
+
+      const verdict = yield* GoalJudge.run(
+        goalState.goal,
+        responseText,
+        goalState.subgoals ?? [],
+        callLLM,
+      )
+
+      const updateResult = yield* goal.updateAfterJudge(sessionID, verdict.verdict, verdict.reason, verdict.parseFailed)
+      if (!updateResult) return
+
+      if (!updateResult.shouldContinue) {
+        // Inject visible completion message when goal is achieved, then
+        // auto-clear the goal state. `updateAfterJudge` already persisted
+        // a done snapshot and published goal.updated — that snapshot is
+        // only kept long enough to emit the completion message, then the
+        // row is removed so done is a transient visual-only state (mirrors
+        // how /goal clear behaves). This is what makes goal completion
+        // not require a manual /goal clear afterwards.
+        if (verdict.verdict === "done") {
+          // Run the terminal event sequence FIRST (F1): publish(done) →
+          // delete → publish(cleared) is the contract SSE/TUI consumers
+          // rely on, so it must complete before any other effect that could
+          // race the loop fiber. deleteAndPublishDone is uninterruptible and
+          // fiber-safe (no clearFiber), so this ordering is pure
+          // defense-in-depth — the completion message text is computed from
+          // updateResult.message (pre-deletion state) and is unaffected by
+          // running after the delete. The noReply path returns before any
+          // status transition today, but completing the terminal sequence
+          // first makes the contract structurally enforced rather than
+          // dependent on that noReply implementation detail.
+          yield* goal.deleteAndPublishDone(sessionID, verdict.reason).pipe(Effect.ignore)
+          yield* promptSvc.prompt({
+            sessionID,
+            noReply: true,
+            parts: [{ type: "text", text: updateResult.message }],
+          }).pipe(Effect.ignore)
+        } else {
+          // Auto-pause branch: updateAfterJudge paused the goal due to
+          // judge-parse-failure or budget exhaustion (verdict.verdict is
+          // still "continue"). Without surfacing the message here, these
+          // automatic pauses would be invisible to the user — updateAfterJudge
+          // already saved the paused state and published goal.updated, but
+          // nothing rendered the "⏸ 目标已暂停 — …" line into the transcript.
+          // Emit it as a noReply part so it shows up without spawning a new
+          // agent turn; the fiber then naturally terminates (no clearFiber
+          // needed, see updateAfterJudge).
+          yield* promptSvc.prompt({
+            sessionID,
+            noReply: true,
+            parts: [{ type: "text", text: updateResult.message }],
+          }).pipe(Effect.ignore)
+        }
+        return
+      }
+
+      const currentStatus = yield* status.get(sessionID)
+      if (currentStatus.type !== "idle") {
+        return // session no longer idle, skip continuation
+      }
+
+      // Reload messages after judge LLM call — the snapshot from before judge
+      // may be stale if user sent messages during the 5-30s judge latency
+      const freshMsgs = yield* sessions.messages({ sessionID, limit: 20 })
+
+      if (shouldPreempt(freshMsgs)) {
+        // Same self-interrupt hazard as the done branch above: we ARE the
+        // fiber tracked in the fibers map, so goal.pause() (which internally
+        // calls clearFiber) would interrupt ourselves before
+        // publishGoal(paused) reaches the event bus. Use pauseAndPublish
+        // which skips fiber management — the fiber naturally terminates
+        // when this function returns.
+        yield* goal.pauseAndPublish(sessionID, "当前轮被中断").pipe(Effect.ignore) // user preempted
+        return
+      }
+
+      const reloadedState = yield* goal.load(sessionID)
+      if (!reloadedState || reloadedState.status !== "active") return
+
+      // Single merged continuation injection (D4.2). This replaces the former
+      // two-call sequence (a `noReply` progress line + an `ignored:true`
+      // continuation). The merged prompt carries goal text, subgoals, the
+      // turns/budget line, and the last judge reason, plus the autonomous-mode
+      // frame — and it is BOTH the user-visible per-turn progress line AND the
+      // prompt that drives the next agent turn.
+      //
+      // It is deliberately a plain text part: no `noReply` (so it spawns the
+      // next agent turn) and no `ignored` (so it renders in the transcript AND
+      // reaches the model — `ignored:true` text parts are filtered out of model
+      // messages in MessageV2.toModelMessagesEffect). Driving + visibility +
+      // model-reachability are all required by D4.2.
+      const continuationText = GoalPrompts.renderContinuation({
+        goal: reloadedState.goal,
+        subgoals: reloadedState.subgoals ?? [],
+        turnsUsed: Number(reloadedState.turns_used),
+        maxTurns: Number(reloadedState.max_turns),
+        lastJudgeReason: reloadedState.last_reason,
+      })
+
+      // Continuation dispatch can fail (provider fault, session write error,
+      // …). Previously the error escaped to the fork-point Effect.ignore and
+      // was swallowed, leaving the goal silently `active` with no idle event
+      // to drive the next turn — a permanent, invisible stall. Catch the full
+      // cause (recoverable failures + defects) and transition to a recoverable
+      // paused state via the fiber-safe pauseAndPublish (goal.pause would
+      // clearFiber — us — mid-publish; see the preempt branches above).
+      yield* promptSvc
+        .prompt({
+          sessionID,
+          parts: [{ type: "text", text: continuationText }],
+        })
+        .pipe(
+          Effect.catchCause((cause) =>
+            Effect.gen(function* () {
+              yield* Effect.logWarning("goal continuation dispatch failed", { error: Cause.pretty(cause) })
+              yield* goal.pauseAndPublish(sessionID, `continuation dispatch failed: ${Cause.pretty(cause)}`).pipe(
+                Effect.ignore,
+              )
+            }),
+          ),
+        )
+
+      // NOTE: We deliberately DO NOT call goal.clearLoopFiber here. The
+      // promptSvc.prompt above triggers a fresh agent loop, which when it
+      // goes idle will cause the SessionStatus idle subscription to fork
+      // a NEW afterIdle fiber and registerLoopFiber will auto-override the
+      // (naturally completed) current fiber in the map. An explicit
+      // clearLoopFiber from within ourselves would race with that override
+      // and could interrupt the newly registered fiber C, silently
+      // stalling the goal loop.
+    })
+
+    const init = Effect.fn("GoalLoop.init")(function* () {
+      yield* InstanceState.get(state)
+    })
+
+    return Service.of({ init })
+  }),
+)
+
+// GoalLoop.defaultLayer self-provides its construction deps. Because
+// Layer.provideMerge(self, layer) requires `layer` (GoalLoop) to be
+// self-contained — self's context is NOT fed into layer — every dep in the
+// chain must be provided here, transitively. memoMap dedups these with the
+// AppLayer's own instances so no duplicate services are created.
+export const defaultLayer = layer.pipe(
+  Layer.provide(EventV2Bridge.defaultLayer),
+  Layer.provide(Session.defaultLayer),
+  Layer.provide(SessionPrompt.defaultLayer),
+  Layer.provide(Provider.defaultLayer),
+  Layer.provide(Goal.defaultLayer),
+  Layer.provide(SessionStatus.defaultLayer),
+)
+
+export const node = LayerNode.make(layer, [
+  EventV2Bridge.node,
+  Session.node,
+  SessionPrompt.node,
+  Provider.node,
+  Goal.node,
+  SessionStatus.node,
+])

--- a/packages/opencode/src/goal/prompts.ts
+++ b/packages/opencode/src/goal/prompts.ts
@@ -1,0 +1,146 @@
+import { GoalState } from "./state"
+
+export * as GoalPrompts from "./prompts"
+
+export const DEFAULT_MAX_TURNS = 20
+// Seconds — used as `Effect.timeout(`${timeout} seconds`)` in loop.ts.
+// Was 30_000 (ms) which produced "30000 seconds" = 8.3h (effectively no timeout).
+export const DEFAULT_JUDGE_TIMEOUT_SECONDS = 30
+export const MAX_CONSECUTIVE_PARSE_FAILURES = 3
+// Known tradeoff: the judge only sees the last JUDGE_RESPONSE_SNIPPET_CHARS of
+// the final assistant message. This bounds judge cost/latency but means a long
+// response that buries a problem in an earlier section can pass review. The
+// budget is generous for normal replies; the limit is also surfaced in
+// tool/goal.txt so operators know the judge's view is tail-bounded.
+export const JUDGE_RESPONSE_SNIPPET_CHARS = 4000
+// Zombie-goal freshness guard threshold (D6). A goal that is still active with
+// turns_used 0 after this many ms, and whose initial kick produced no assistant
+// message, is treated as orphaned and auto-paused so the user can recover via
+// /goal resume instead of the goal sitting silently "active" forever.
+export const FRESHNESS_THRESHOLD = 120_000
+
+export const JUDGE_SYSTEM_PROMPT = `You are an autonomous-goal completion judge.
+You will receive:
+1. The user's original goal.
+2. The agent's most recent response.
+
+Return ONLY a JSON object (no markdown, no explanation):
+{"done": true/false, "reason": "one sentence explanation"}
+
+"done" = true means ONE of:
+  - The agent explicitly confirmed the goal is complete with evidence.
+  - The goal produced a clear, verifiable deliverable (file created, test passed, etc.).
+  - The goal is unachievable or blocked and the agent said so.
+
+"done" = false means the agent is still making progress or has more steps.
+
+Be conservative: if in doubt, return "done": false.`
+
+export const JUDGE_USER_PROMPT_TEMPLATE = `Goal: {goal}
+
+Agent's most recent response (last {snippetChars} chars):
+---
+{response}
+---
+
+Is the goal done?`
+
+export const JUDGE_USER_PROMPT_WITH_SUBGOALS_TEMPLATE = `Goal: {goal}
+
+Additional criteria:
+{subgoals}
+
+Agent's most recent response (last {snippetChars} chars):
+---
+{response}
+---
+
+Is the goal done? For each sub-goal, provide concrete evidence it was met. Do not accept vague claims like "all requirements met".`
+
+export interface ContinuationInput {
+  readonly goal: string
+  readonly subgoals: ReadonlyArray<string>
+  readonly turnsUsed: number
+  readonly maxTurns: number
+  readonly lastJudgeReason?: string
+}
+
+// Renders the single merged continuation injection (D4.2). Carries goal text,
+// subgoals, turns/budget, the last judge reason (labeled), and the autonomous-mode
+// frame. This is both the user-visible per-turn progress line AND the prompt that
+// drives the next agent turn — it must reach the model (no `ignored` flag at the
+// call site) and render in the transcript (no `noReply`).
+export function renderContinuation(input: ContinuationInput): string {
+  const remaining = Math.max(0, input.maxTurns - input.turnsUsed)
+  const lines = [
+    "[Continuing toward your standing goal]",
+    `Goal: ${input.goal}`,
+    `Turns: ${input.turnsUsed}/${input.maxTurns} (${remaining} remaining)`,
+  ]
+  if (input.subgoals.length > 0) {
+    lines.push("Subgoals:")
+    lines.push(...input.subgoals.map((s, i) => `${i + 1}. ${s}`))
+  }
+  if (input.lastJudgeReason) lines.push(`Judge feedback: ${input.lastJudgeReason}`)
+  lines.push("")
+  lines.push(
+    "You are in autonomous mode — interactive questions are disabled and will not receive answers. Do not ask the user for clarification or confirmation. Make all decisions independently based on your best judgment.",
+  )
+  lines.push("")
+  lines.push("Continue working toward this goal. Take the next concrete step.")
+  lines.push("If you believe the goal is complete, state so explicitly and stop.")
+  lines.push(
+    "If you are completely blocked and cannot make any progress, state the blocker explicitly and stop.",
+  )
+  return lines.join("\n")
+}
+
+// Renders the dynamic system-prompt fragment for an active/paused goal (D4.1).
+// Pure: injected into the system prompt by SystemPrompt.goal(sessionID).
+export function renderGoalSystemBlock(state: GoalState.Info): string {
+  const turnsUsed = Number(state.turns_used)
+  const maxTurns = Number(state.max_turns)
+  const remaining = Math.max(0, maxTurns - turnsUsed)
+  const subgoals = state.subgoals ?? []
+  const lines = [
+    "## Current Goal (autonomous loop)",
+    `Goal: ${state.goal}`,
+    `Status: ${state.status}`,
+    `Turns: ${turnsUsed}/${maxTurns} (${remaining} remaining)`,
+  ]
+  if (subgoals.length > 0) {
+    lines.push("Subgoals:")
+    lines.push(...subgoals.map((s, i) => `  ${i + 1}. ${s}`))
+  } else {
+    lines.push("Subgoals: none")
+  }
+  if (state.status === "paused" && state.paused_reason) {
+    lines.push(`Paused because: ${state.paused_reason}`)
+  }
+  if (state.last_verdict) {
+    lines.push(
+      state.last_reason
+        ? `Last judge verdict: ${state.last_verdict} — ${state.last_reason}`
+        : `Last judge verdict: ${state.last_verdict}`,
+    )
+  }
+  return lines.join("\n")
+}
+
+export function renderJudgeUserPrompt(
+  goal: string,
+  response: string,
+  subgoals: ReadonlyArray<string>,
+): string {
+  const snippet = response.slice(-JUDGE_RESPONSE_SNIPPET_CHARS)
+  if (subgoals.length === 0)
+    return JUDGE_USER_PROMPT_TEMPLATE
+      .replace("{goal}", goal)
+      .replace("{snippetChars}", String(JUDGE_RESPONSE_SNIPPET_CHARS))
+      .replace("{response}", snippet)
+  return JUDGE_USER_PROMPT_WITH_SUBGOALS_TEMPLATE
+    .replace("{goal}", goal)
+    .replace("{subgoals}", subgoals.map((s, i) => `${i + 1}. ${s}`).join("\n"))
+    .replace("{snippetChars}", String(JUDGE_RESPONSE_SNIPPET_CHARS))
+    .replace("{response}", snippet)
+}

--- a/packages/opencode/src/goal/state.ts
+++ b/packages/opencode/src/goal/state.ts
@@ -1,0 +1,35 @@
+export * as GoalState from "./state"
+
+import { Effect, Schema } from "effect"
+import { NonNegativeInt } from "@opencode-ai/schema/schema"
+
+export const Status = Schema.Literals(["active", "paused", "done"])
+export type Status = Schema.Schema.Type<typeof Status>
+
+// `skipped` was a dead enum value with no production write path — removed.
+export const Verdict = Schema.Literals(["done", "continue"])
+export type Verdict = Schema.Schema.Type<typeof Verdict>
+
+export class Info extends Schema.Class<Info>("GoalState")({
+  goal: Schema.String,
+  status: Status,
+  turns_used: NonNegativeInt,
+  max_turns: NonNegativeInt,
+  created_at: Schema.Number,
+  last_turn_at: Schema.Number,
+  last_verdict: Schema.optional(Verdict),
+  last_reason: Schema.optional(Schema.String),
+  paused_reason: Schema.optional(Schema.String),
+  consecutive_parse_failures: NonNegativeInt,
+  subgoals: Schema.Array(Schema.String).pipe(Schema.optional, Schema.withDecodingDefault(Effect.succeed([] as ReadonlyArray<string>))),
+}) {}
+
+/**
+ * Construct a goal NonNegativeInt field from a plain number, centralizing the
+ * one unavoidable cast. Every call site computes these from validated
+ * arithmetic (0, prev+1, clamped parse-failure counters) so the runtime ≥0
+ * filter is redundant here; this keeps the escape hatch at a single audited
+ * site instead of `as any` scattered across goal.ts.
+ */
+export const nni = (value: number): Schema.Schema.Type<typeof NonNegativeInt> =>
+  value as Schema.Schema.Type<typeof NonNegativeInt>

--- a/packages/opencode/src/hook/settings.ts
+++ b/packages/opencode/src/hook/settings.ts
@@ -1729,7 +1729,7 @@ export const layer = Layer.effect(
         // InstanceState.get on every call, and the cache returns the SAME
         // state object, so the mutation is visible without invalidating the
         // cache. The finalizer closes the watcher when the instance scope is
-        // disposed (same scope-based cleanup discipline as DagLoop.state).
+        // disposed (same scope-based cleanup discipline as GoalLoop.state).
         //
         // The reload Effect computes both merged settings and scope-tagged
         // summaries in one pass; lastSummaries carries the summaries into the

--- a/packages/opencode/src/project/bootstrap.ts
+++ b/packages/opencode/src/project/bootstrap.ts
@@ -9,6 +9,7 @@ import { InstanceState } from "@/effect/instance-state"
 import { ShareNext } from "@/share/share-next"
 import { Effect, Layer } from "effect"
 import { Config } from "@/config/config"
+import { GoalLoop } from "@/goal/loop"
 import { DagLoop } from "@/dag/runtime/loop"
 import { DagSummaryPublisher } from "@/dag/runtime/summary-publisher"
 import { SettingsHook } from "@/hook/settings"
@@ -23,6 +24,11 @@ export const layer = Layer.effect(
     // Yield each bootstrap dep at layer init so `run` itself has R = never.
     // InstanceStore imports only the lightweight tag from bootstrap-service.ts,
     // so it can depend on bootstrap without importing this implementation graph.
+    //
+    // GoalLoop is intentionally NOT yielded here: it pulls heavyweight transitive
+    // deps (Provider/SessionPrompt → HttpClient) that don't belong in bootstrap's
+    // construction context. It is resolved lazily via serviceOption in `run`,
+    // mirroring how SettingsHook consumers treat their optional dep.
     const config = yield* Config.Service
     const dagLoop = yield* DagLoop.Service
     const dagPublisher = yield* DagSummaryPublisher.Service
@@ -56,6 +62,14 @@ export const layer = Layer.effect(
         (s) => s.init().pipe(Effect.catchCause((cause) => Effect.logWarning("init failed", { cause }))),
         { concurrency: "unbounded", discard: true },
       ).pipe(Effect.withSpan("InstanceBootstrap.init"))
+      // GoalLoop is provided by AppLayer (provideMerge). Activate its idle-event
+      // subscription only when available; skipped in test/standalone contexts.
+      const goalLoop = yield* Effect.serviceOption(GoalLoop.Service)
+      if (goalLoop._tag === "Some") {
+        yield* goalLoop.value
+          .init()
+          .pipe(Effect.catchCause((cause) => Effect.logWarning("goal loop init failed", { cause })))
+      }
       yield* dagLoop.init().pipe(Effect.catchCause((cause) => Effect.logWarning("dag loop init failed", { cause })))
       // DagSummaryPublisher: same lifecycle pattern. Stateless derived-view
       // publisher that pushes per-session workflow summaries to the TUI.

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
@@ -9,6 +9,7 @@ import { SessionRevert } from "@/session/revert"
 import { SessionStatus } from "@/session/status"
 import { SessionSummary } from "@/session/summary"
 import { Todo } from "@/session/todo"
+import { SessionGoal } from "@opencode-ai/schema/session-goal"
 import { MessageID, PartID, SessionID } from "@/session/schema"
 import { Snapshot } from "@/snapshot"
 import { Schema, Struct } from "effect"
@@ -113,6 +114,7 @@ export const SessionPaths = {
   get: `${root}/:sessionID`,
   children: `${root}/:sessionID/children`,
   todo: `${root}/:sessionID/todo`,
+  goal: `${root}/:sessionID/goal`,
   hook: `${root}/:sessionID/hook`,
   hookRemove: `${root}/:sessionID/hook/:hookID`,
   diff: `${root}/:sessionID/diff`,
@@ -197,6 +199,18 @@ export const SessionApi = HttpApi.make("session")
             identifier: "session.todo",
             summary: "Get session todos",
             description: "Retrieve the todo list associated with a specific session, showing tasks and action items.",
+          }),
+        ),
+        HttpApiEndpoint.get("goal", SessionPaths.goal, {
+          params: { sessionID: SessionID },
+          query: WorkspaceRoutingQuery,
+          success: described(Schema.optional(SessionGoal.Info), "Goal state"),
+          error: [HttpApiError.BadRequest, ApiNotFoundError],
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "session.goal",
+            summary: "Get session goal",
+            description: "Retrieve the autonomous goal state for a session, if one is set.",
           }),
         ),
         HttpApiEndpoint.post("hookAdd", SessionPaths.hook, {

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
@@ -14,6 +14,7 @@ import { SessionRunState } from "@/session/run-state"
 import { SessionStatus } from "@/session/status"
 import { SessionSummary } from "@/session/summary"
 import { Todo } from "@/session/todo"
+import { Goal } from "@/goal/goal"
 import { SessionHooks, type SessionHookCommand } from "@/hook/session-hooks"
 import { type HookEvent } from "@/hook/settings"
 import { MessageID, PartID, SessionID } from "@/session/schema"
@@ -38,7 +39,7 @@ import {
   UpdatePayload,
   SessionHookAddPayload,
 } from "../groups/session"
-import { PermissionNotFoundError } from "../errors"
+import { PermissionNotFoundError, notFound } from "../errors"
 import * as SessionError from "./session-errors"
 
 const tryParseJson = (text: string) =>
@@ -59,6 +60,7 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
     const permissionSvc = yield* Permission.Service
     const statusSvc = yield* SessionStatus.Service
     const todoSvc = yield* Todo.Service
+    const goalSvc = yield* Goal.Service
     const sessionHooks = yield* SessionHooks.Service
     const summary = yield* SessionSummary.Service
     const events = yield* EventV2Bridge.Service
@@ -96,6 +98,24 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
     const todo = Effect.fn("SessionHttpApi.todo")(function* (ctx: { params: { sessionID: SessionID } }) {
       yield* requireSession(ctx.params.sessionID)
       return yield* todoSvc.get(ctx.params.sessionID)
+    })
+
+    const goal = Effect.fn("SessionHttpApi.goal")(function* (ctx: { params: { sessionID: SessionID } }) {
+      yield* requireSession(ctx.params.sessionID)
+      const state = yield* goalSvc.load(ctx.params.sessionID)
+      // Goal.clear deletes the row outright, so a missing row means "no goal".
+      // (done is also transient in practice — auto-cleared after the completion
+      // message is emitted — so the only states returned are active / paused.)
+      // 404 keeps the response schema honest: a 200 body always carries Goal.
+      if (!state) return yield* Effect.fail(notFound(`No goal for session: ${ctx.params.sessionID}`))
+      return {
+        goal: state.goal,
+        status: state.status,
+        turnsUsed: Number(state.turns_used),
+        maxTurns: Number(state.max_turns),
+        subgoals: state.subgoals ?? [],
+        ...(state.paused_reason !== undefined ? { pausedReason: state.paused_reason } : {}),
+      }
     })
 
     const diff = Effect.fn("SessionHttpApi.diff")(function* (ctx: {
@@ -448,6 +468,7 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
       .handle("get", get)
       .handle("children", children)
       .handle("todo", todo)
+      .handle("goal", goal)
       .handle("hookAdd", hookAdd)
       .handle("hookList", hookList)
       .handle("hookRemove", hookRemove)

--- a/packages/opencode/src/server/routes/instance/httpapi/server.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/server.ts
@@ -46,6 +46,7 @@ import { Skill } from "@/skill"
 import { Discovery } from "@/skill/discovery"
 import { Snapshot } from "@/snapshot"
 import { Storage } from "@/storage/storage"
+import { Goal } from "@/goal/goal"
 import { SettingsHook } from "@/hook/settings"
 import { HookRewakeLive } from "@/hook/rewake-live"
 import { SessionHooks } from "@/hook/session-hooks"
@@ -263,6 +264,7 @@ const app = LayerNode.group([
   ProjectV2.node,
   ProjectCopy.node,
   PtyTicket.node,
+  Goal.node,
   // SettingsHook + SessionHooks: previously defined but never wired into
   // the server app graph, so every consumer using
   // `Option.getOrUndefined(yield* Effect.serviceOption(SettingsHook.Service))`

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -64,6 +64,7 @@ import { SettingsHook, HOOK_REWAKE_SENTINEL, type TriggerResult } from "@/hook/s
 import { applyPreHookDecision } from "@/hook/pre-hook-decision"
 import { dispatchTrust } from "@/hook/workspace-trust"
 import { HookStartContext } from "@/hook/start-context"
+import { Goal } from "@/goal/goal"
 import { KeyedMutex } from "@opencode-ai/core/effect/keyed-mutex"
 
 // @ts-ignore
@@ -153,6 +154,7 @@ export const layer = Layer.effect(
     const { db } = database
     const settingsHook = Option.getOrUndefined(yield* Effect.serviceOption(SettingsHook.Service))
     const startContext = Option.getOrUndefined(yield* Effect.serviceOption(HookStartContext.Service))
+    const goal = Option.getOrUndefined(yield* Effect.serviceOption(Goal.Service))
     const promptLocks = KeyedMutex.makeUnsafe<SessionID>()
     const ops = Effect.fn("SessionPrompt.ops")(function* () {
       return {
@@ -1711,12 +1713,13 @@ export const layer = Layer.effect(
 
             yield* plugin.trigger("experimental.chat.messages.transform", {}, { messages: msgs })
 
-            const [skills, env, instructions, mcpInstructions, hooksDocs, modelMsgs] = yield* Effect.all(
+            const [skills, env, instructions, mcpInstructions, goalDocs, hooksDocs, modelMsgs] = yield* Effect.all(
               [
                 sys.skills(agent),
                 sys.environment(model),
                 instruction.system().pipe(Effect.orDie),
                 sys.mcp(agent, session.permission),
+                sys.goal(sessionID),
                 sys.hooks(),
                 MessageV2.toModelMessagesEffect(msgs, model),
               ],
@@ -1727,6 +1730,7 @@ export const layer = Layer.effect(
               ...instructions,
               ...(mcpInstructions ? [mcpInstructions] : []),
               ...(skills ? [skills] : []),
+              ...goalDocs,
               ...hooksDocs,
             ]
             const format = lastUser.format ?? { type: "text" as const }
@@ -1861,6 +1865,93 @@ export const layer = Layer.effect(
         }
         yield* sessions.updatePart(responsePart)
         yield* sessions.touch(input.sessionID)
+        return { info: userMsg, parts: [cmdText, responsePart] }
+      }
+      // Goal/Subgoal command dispatch — early return BEFORE command registry lookup
+      if (goal && (input.command === "goal" || input.command === "subgoal")) {
+        const dispatch = input.command === "goal" ? goal.dispatch : goal.dispatchSubgoal
+        const dispatchResult = yield* dispatch(input.sessionID, input.arguments).pipe(
+          Effect.catchCause((cause) =>
+            Effect.gen(function* () {
+              yield* Effect.logError("goal dispatch failed", { command: input.command, cause: String(cause) })
+              return undefined
+            }),
+          ),
+        )
+        if (!dispatchResult) {
+          // Dispatch failed — return error message to user instead of silent fallthrough
+          const m = yield* currentModel(input.sessionID)
+          const agentName = input.agent ?? (yield* agents.defaultAgent())
+          const userMsg: SessionV1.User = {
+            id: input.messageID ?? MessageID.ascending(),
+            role: "user",
+            sessionID: input.sessionID,
+            time: { created: Date.now() },
+            agent: agentName,
+            model: { providerID: m.providerID, modelID: m.modelID },
+          }
+          yield* sessions.updateMessage(userMsg)
+          const errorPart: SessionV1.TextPart = {
+            id: PartID.ascending(),
+            messageID: userMsg.id,
+            sessionID: input.sessionID,
+            type: "text",
+            text: `⚠️ /${input.command} 执行失败，请检查日志。`,
+            synthetic: true,
+          }
+          yield* sessions.updatePart(errorPart)
+          yield* sessions.touch(input.sessionID)
+          return { info: userMsg, parts: [errorPart] }
+        }
+        const dispatchText = dispatchResult.announce ?? dispatchResult.text
+        const m = yield* currentModel(input.sessionID)
+        const agentName = input.agent ?? (yield* agents.defaultAgent())
+        const userMsg: SessionV1.User = {
+          id: input.messageID ?? MessageID.ascending(),
+          role: "user",
+          sessionID: input.sessionID,
+          time: { created: Date.now() },
+          agent: agentName,
+          model: { providerID: m.providerID, modelID: m.modelID },
+        }
+        yield* sessions.updateMessage(userMsg)
+        const cmdText: SessionV1.TextPart = {
+          id: PartID.ascending(),
+          messageID: userMsg.id,
+          sessionID: input.sessionID,
+          type: "text",
+          text: `/${input.command} ${input.arguments}`.trim(),
+        }
+        yield* sessions.updatePart(cmdText)
+        // Non-synthetic so UserMessage renders it — the command confirmation
+        // (e.g. "⏸ 目标已暂停") must be visible. Matches the goal "done" case
+        // (loop.ts), which emits visible goal messages as non-synthetic parts.
+        const responsePart: SessionV1.TextPart = {
+          id: PartID.ascending(),
+          messageID: userMsg.id,
+          sessionID: input.sessionID,
+          type: "text",
+          text: dispatchText,
+        }
+        yield* sessions.updatePart(responsePart)
+        yield* sessions.touch(input.sessionID)
+        if (dispatchResult.type === "kick" && input.command === "goal") {
+          // Drain SessionStart hook contexts before loop
+          if (startContext) {
+            const contexts = yield* startContext.consume(input.sessionID)
+            for (const ctx of contexts) {
+              yield* sessions.updatePart({
+                id: PartID.ascending(),
+                messageID: responsePart.messageID,
+                sessionID: input.sessionID,
+                type: "text",
+                text: ctx,
+                synthetic: true,
+              } satisfies SessionV1.TextPart)
+            }
+          }
+          return yield* loop({ sessionID: input.sessionID })
+        }
         return { info: userMsg, parts: [cmdText, responsePart] }
       }
 
@@ -2167,7 +2258,7 @@ export const node = LayerNode.make(layer, [
   EventV2Bridge.node,
   RuntimeFlags.node,
   Database.node,
-  HookStartContext.node, SettingsHook.node,
+  HookStartContext.node, SettingsHook.node, Goal.node,
 ])
 
 export * as SessionPrompt from "./prompt"

--- a/packages/opencode/src/session/prompt/goal.txt
+++ b/packages/opencode/src/session/prompt/goal.txt
@@ -1,0 +1,38 @@
+# Autonomous Goal System
+
+OpenCode has a built-in **autonomous goal** feature. Use `/goal <description>` to set a persistent goal that the agent will work toward autonomously across multiple turns.
+
+While a goal is active or paused, a **live "Current Goal" block** is injected into the system prompt at the start of every turn — it carries the goal text, status, turns used/remaining, subgoals, and the last judge verdict. You do not need to call a tool to learn this state; read it from the system prompt.
+
+A `goal` **tool** is also available. Use `goal(action: "complete")` to self-declare completion when the goal is genuinely done, so the loop exits immediately instead of waiting for the external judge. `goal(action: "status")` is an optional check-in (see below).
+
+## Commands (user-facing; only you or the user can issue these)
+
+- `/goal <text>` — Set a new autonomous goal. The agent will work in a loop until the goal is achieved or the turn budget is exhausted.
+- `/goal status` — Show the current goal state (active/paused/achieved, turns used/total).
+- `/goal pause` — Pause the current goal. Use `/goal resume` to continue.
+- `/goal resume` — Resume a paused goal.
+- `/goal clear` or `/goal stop` — Clear the current goal and stop the loop.
+- `/goal done` — Explicitly mark the goal as finished (same as the `goal` tool with `action=complete`).
+- `/subgoal <text>` — Add a subgoal to the current goal.
+- `/subgoal list` — List all subgoals.
+- `/subgoal remove <n>` — Remove the nth subgoal.
+- `/subgoal clear` — Clear all subgoals.
+
+## Tool (agent-facing; call this during your turn)
+
+- `goal(action: "status")` — Current goal text, status, turns used/remaining, subgoals, and pause reason. This is an OPTIONAL check-in: the same live state is already in your system prompt each turn, so you do not need to call `status` to know whether a goal loop is running or how much budget remains. Use it only for a deliberate mid-turn re-check (e.g., after a long operation that may have changed state) or to inspect `pausedReason`.
+- `goal(action: "complete", reason: "...")` — Declare the goal achieved. **This bypasses the external judge and ends the loop immediately.** Pass a one-sentence summary of what was delivered (e.g., "3 tests written and passing; refactor verified."). The goal is then auto-cleared.
+
+### When to call `goal(complete)`
+
+- When the goal produced verifiable deliverables (files written, tests passing, a diagnosis, a concrete answer) and no subgoals remain.
+- When the goal is subjective/research-oriented and you have produced a final answer you believe is sufficient.
+- **Do not** call `complete` just because a sub-step looks done — only when the top-level goal the user set via `/goal <text>` is actually done.
+
+## Loop behavior
+
+- After each turn, an external **goal judge** evaluates whether the goal is achieved. If it returns `done`, the loop auto-clears. If `continue`, a fresh continuation prompt drives the next iteration.
+- The goal persists across turns until explicitly cleared, judge-declared done, or the turn budget is exhausted (which pauses the goal).
+- Self-declaring via `goal(complete)` is faster than waiting for the judge and is preferred when you have clear evidence of completion.
+- Default turn budget: 20 turns (configurable per goal).

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -44,6 +44,7 @@ import { RuntimeFlags } from "@/effect/runtime-flags"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 import { ModelV2 } from "@opencode-ai/core/model"
 import { SessionMessageID } from "@opencode-ai/schema/session-message-id"
+import { Goal } from "@/goal/goal"
 import { landSystemMessages } from "@/hook/trigger-result"
 
 const runtime = makeRuntime(Database.Service, Database.defaultLayer)
@@ -506,6 +507,10 @@ export const layer: Layer.Layer<
     // deferred import resolves to the cached module instantly.
     const { SettingsHook } = yield* Effect.promise(() => import("@/hook/settings"))
     const settingsHook = Option.getOrUndefined(yield* Effect.serviceOption(SettingsHook.Service))
+    // Goal cleanup is optional — Session must not require Goal at construction
+    // (that would force every Session.defaultLayer consumer to provide Goal's
+    // transitive deps). Resolved lazily via serviceOption.
+    const goalOpt = yield* Effect.serviceOption(Goal.Service)
 
     const createNext = Effect.fn("Session.createNext")(function* (input: {
       id?: SessionID
@@ -638,6 +643,10 @@ export const layer: Layer.Layer<
             .trigger({ event: "SessionEnd", reason: "delete" }, { sessionID, transcriptPath: "" })
             .pipe(Effect.catch(() => Effect.succeed({ additionalContexts: [], systemMessages: [] })))
           yield* landSystemMessages(seResult, { sessionID })
+        }
+        // Cleanup goal state (only when Goal service is available in context)
+        if (goalOpt._tag === "Some") {
+          yield* goalOpt.value.clear(sessionID).pipe(Effect.catchCause(() => Effect.void))
         }
         yield* events.remove(sessionID)
       } catch (error) {
@@ -1091,6 +1100,6 @@ export function* listGlobal(input?: {
   }
 }
 
-export const node = LayerNode.make(layer, [BackgroundJob.node, RuntimeFlags.node, Database.node, EventV2Bridge.node])
+export const node = LayerNode.make(layer, [BackgroundJob.node, RuntimeFlags.node, Database.node, EventV2Bridge.node, Goal.node])
 
 export * as Session from "./session"

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -12,6 +12,7 @@ import PROMPT_KIMI from "./prompt/kimi.txt"
 
 import PROMPT_CODEX from "./prompt/codex.txt"
 import PROMPT_TRINITY from "./prompt/trinity.txt"
+import PROMPT_GOAL from "./prompt/goal.txt"
 import type { Provider } from "@/provider/provider"
 import type { Agent } from "@/agent/agent"
 import { Permission } from "@/permission"
@@ -22,7 +23,10 @@ import { LocationServiceMap } from "@opencode-ai/core/location-layer"
 import { Reference } from "@opencode-ai/core/reference"
 import { MCP } from "@/mcp"
 import { PermissionV1 } from "@opencode-ai/core/v1/permission"
+import { Goal } from "@/goal/goal"
+import { GoalPrompts } from "@/goal/prompts"
 import { SettingsHook } from "@/hook/settings"
+import type { SessionID } from "@/session/schema"
 
 export function provider(model: Provider.Model) {
   if (model.api.id.includes("gpt-4") || model.api.id.includes("o1") || model.api.id.includes("o3"))
@@ -44,6 +48,7 @@ export interface Interface {
   readonly environment: (model: Provider.Model) => Effect.Effect<string[]>
   readonly skills: (agent: Agent.Info) => Effect.Effect<string | undefined>
   readonly mcp: (agent: Agent.Info, permission?: PermissionV1.Ruleset) => Effect.Effect<string | undefined>
+  readonly goal: (sessionID: SessionID) => Effect.Effect<string[]>
   readonly hooks: () => Effect.Effect<string[]>
 }
 
@@ -55,6 +60,13 @@ export const layer = Layer.effect(
     const skill = yield* Skill.Service
     const mcp = yield* MCP.Service
     const locations = yield* LocationServiceMap
+    // Goal.Service is resolved lazily (serviceOption) rather than declared as a
+    // hard construction dependency, mirroring src/session/prompt.ts and
+    // src/tool/goal.ts. Keeping it optional lets the system prompt degrade to a
+    // terse "no active goal" note in runtimes that omit Goal (some headless / test
+    // entry points), and avoids dragging Goal's transitive deps into every
+    // SystemPrompt consumer.
+    const goalSvc = Option.getOrUndefined(yield* Effect.serviceOption(Goal.Service))
 
     return Service.of({
       environment: Effect.fn("SystemPrompt.environment")(function* (model: Provider.Model) {
@@ -127,7 +139,21 @@ export const layer = Layer.effect(
         ].join("\n")
       }),
 
-      // Active Hooks block — dynamic: no hooks → empty
+      goal: Effect.fn("SystemPrompt.goal")(function* (sessionID: SessionID) {
+        // No Goal service wired into this entry point → degrade to a terse note.
+        if (!goalSvc) return ["No autonomous goal is active for this session."]
+        const state = yield* goalSvc.load(sessionID)
+        // Only active/paused goals carry a live-state block. `done` is transient
+        // (auto-cleared) and treated the same as "no goal" here.
+        if (!state || (state.status !== "active" && state.status !== "paused"))
+          return ["No autonomous goal is active for this session."]
+        // Active/paused: the trimmed static mechanism + the live-state block.
+        // The mechanism is intentionally NOT injected when no goal is active, to
+        // avoid prompt bloat (spec: no-active-goal-injected-as-terse-note).
+        return [PROMPT_GOAL, GoalPrompts.renderGoalSystemBlock(state)]
+      }),
+
+      // Active Hooks block — dynamic, mirrors goal's economy: no hooks → empty
       // array (no header, no placeholder). SettingsHook is resolved at request
       // time via serviceOption (per tool-service-resolution spec) so headless /
       // test entry points that omit the heavyweight service degrade cleanly.
@@ -152,11 +178,12 @@ export const layer = Layer.effect(
 export const defaultLayer = layer.pipe(
   Layer.provide(Skill.defaultLayer),
   Layer.provide(MCP.defaultLayer),
+  Layer.provide(Goal.defaultLayer),
   Layer.provide(LocationServiceMap.layer),
 )
 
 const locationServiceMapNode = LayerNode.make(LocationServiceMap.layer, [])
 
-export const node = LayerNode.make(layer, [Skill.node, MCP.node, locationServiceMapNode])
+export const node = LayerNode.make(layer, [Skill.node, MCP.node, Goal.node, locationServiceMapNode])
 
 export * as SystemPrompt from "./system"

--- a/packages/opencode/src/tool/goal.ts
+++ b/packages/opencode/src/tool/goal.ts
@@ -1,0 +1,148 @@
+import { Effect, Option, Schema } from "effect"
+import * as Tool from "./tool"
+import DESCRIPTION from "./goal.txt"
+import { Goal } from "../goal/goal"
+
+export const Parameters = Schema.Struct({
+  action: Schema.Literals(["status", "complete"]).annotate({
+    description: "`status` to query current goal state; `complete` to declare the goal achieved.",
+  }),
+  reason: Schema.optional(Schema.String).annotate({
+    description: "Required when action=complete. One-sentence summary of what was delivered.",
+  }),
+})
+
+type Metadata = {
+  goal?: {
+    text: string
+    status: "active" | "paused" | "done"
+    turnsUsed: number
+    maxTurns: number
+    subgoals: ReadonlyArray<string>
+    pausedReason?: string
+  } | null
+}
+
+// Goal.Service MUST be resolved inside `execute` (request phase), NOT in this
+// build-phase `init` gen. `init` runs once during ToolRegistry construction,
+// which lives in one Layer.mergeAll group of AppLayer while Goal.defaultLayer
+// lives in a sibling group; mergeAll siblings cannot see each other's outputs,
+// so a build-phase serviceOption(Goal.Service) is guaranteed None and would be
+// captured in this closure, permanently no-op-ing the tool (verified by the
+// runtime "autonomous goal service is not available" symptom). At execute time
+// the session request context carries the full AppLayer, so Goal.Service is
+// reachable. This corrects the misleading reference in goal-loop-correctness
+// task 6.1, which cited the old build-phase probe as the pattern to follow.
+// serviceOption contributes R = never, so Tool.define<…, never> is unchanged
+// and headless runtimes that omit Goal still degrade gracefully below.
+export const GoalTool = Tool.define<typeof Parameters, Metadata, never>(
+  "goal",
+  Effect.gen(function* () {
+    return {
+      description: DESCRIPTION,
+      parameters: Parameters,
+      execute: (params: Schema.Schema.Type<typeof Parameters>, ctx: Tool.Context<Metadata>) =>
+        Effect.gen(function* () {
+          // Goal state belongs to the session itself; it is not an external
+          // resource boundary (no filesystem, no network, no cross-session
+          // write), so it does not need a permission gate.
+          const goal = Option.getOrUndefined(yield* Effect.serviceOption(Goal.Service))
+
+          if (!goal) {
+            // Goal service not wired into this entry point (some headless
+            // / test runtimes omit it). Return a clear message rather than
+            // crashing — the tool must never break a session.
+            return {
+              title: "goal service unavailable",
+              output:
+                "The autonomous goal service is not available in this runtime. Goal state cannot be queried or modified here.",
+              metadata: { goal: null },
+            }
+          }
+
+          if (params.action === "status") {
+            const state = yield* goal.load(ctx.sessionID)
+            if (!state) {
+              return {
+                title: "no goal",
+                output: "No autonomous goal is active for this session.",
+                metadata: { goal: null },
+              }
+            }
+            const remaining = Math.max(0, Number(state.max_turns) - Number(state.turns_used))
+            const subgoals = state.subgoals ?? []
+            const line = [
+              `Goal: ${state.goal}`,
+              `Status: ${state.status}`,
+              `Turns: ${state.turns_used}/${state.max_turns} (${remaining} remaining)`,
+              subgoals.length > 0 ? `Subgoals (${subgoals.length}):` : "Subgoals: none",
+              ...subgoals.map((s, i) => `  ${i + 1}. ${s}`),
+              state.status === "paused" && state.paused_reason
+                ? `Paused because: ${state.paused_reason}`
+                : null,
+              state.last_verdict
+                ? `Last judge verdict: ${state.last_verdict}${state.last_reason ? ` — ${state.last_reason}` : ""}`
+                : null,
+            ]
+              .filter(Boolean)
+              .join("\n")
+            return {
+              title: `goal ${state.status} (${state.turns_used}/${state.max_turns})`,
+              output: line,
+              metadata: {
+                goal: {
+                  text: state.goal,
+                  status: state.status as "active" | "paused" | "done",
+                  turnsUsed: Number(state.turns_used),
+                  maxTurns: Number(state.max_turns),
+                  subgoals,
+                  pausedReason: state.paused_reason,
+                },
+              },
+            }
+          }
+
+          // action === "complete"
+          if (!params.reason || params.reason.trim().length === 0) {
+            throw new Tool.InvalidArgumentsError({
+              tool: "goal",
+              detail: "`reason` is required when action is `complete`. Describe in one sentence what was delivered.",
+            })
+          }
+          const state = yield* goal.load(ctx.sessionID)
+          if (!state || state.status !== "active") {
+            return {
+              title: "no active goal",
+              output: "Cannot complete goal: no active goal for this session. The loop may have already finished, been paused, or been cleared.",
+              metadata: { goal: null },
+            }
+          }
+          // markDone performs: clearFiber → deleteAndPublishDone (publish
+          // goal.updated(done) → deleteState → publish goal.cleared). It is
+          // budget-neutral — turns_used counts continuation dispatches only, so
+          // markDone does NOT increment it (see goal.ts markDone).
+          // deleteAndPublishDone re-loads the current row, so use its return
+          // value (NOT the pre-call `state` above) for the completion message —
+          // otherwise a turn a prior continue dispatch already accounted for
+          // could be missed in the "N turns" count shown to the user.
+          const finalState = yield* goal.markDone(ctx.sessionID, params.reason.trim())
+
+          const displayState = finalState ?? state
+          const completionMsg = `✓ 目标已达成（${displayState.turns_used}/${displayState.max_turns} 轮）：${displayState.goal}\nReason: ${params.reason.trim()}`
+          return {
+            title: `goal completed (${displayState.turns_used}/${displayState.max_turns})`,
+            output: completionMsg,
+            metadata: {
+              goal: {
+                text: displayState.goal,
+                status: "done" as const,
+                turnsUsed: Number(displayState.turns_used),
+                maxTurns: Number(displayState.max_turns),
+                subgoals: displayState.subgoals ?? [],
+              },
+            },
+          }
+        }),
+    } satisfies Tool.DefWithoutID<typeof Parameters, Metadata>
+  }),
+)

--- a/packages/opencode/src/tool/goal.txt
+++ b/packages/opencode/src/tool/goal.txt
@@ -1,0 +1,34 @@
+Interact with the autonomous goal loop that drives your session (when one is running).
+
+## Actions
+
+- `status` — Query the current goal: its text, status, turns used/remaining, subgoals, and pause reason (if any). Returns clear information when no goal is active.
+- `complete` — Declare the current goal achieved. Bypasses the external judge model and ends the loop immediately. Pass `reason` as a one-sentence summary of what was delivered (e.g., "created `src/foo.ts` and all 7 tests pass"). After `complete`, the goal is auto-cleared; the next call to `status` will report "no goal".
+
+## When to use `status`
+
+`status` is OPTIONAL. While a goal is active, a live "Current Goal" block (goal text, status, turns used/remaining, subgoals, last judge verdict) is already injected into your system prompt at the start of every turn — you do not need to call `status` to discover whether a goal loop is running or how much budget remains. Reach for `status` only as a deliberate check-in:
+- After a long operation, to re-verify state mid-turn (in case the budget or status shifted).
+- To inspect `pausedReason` when a goal appears stalled.
+
+## When to use `complete`
+
+- When the goal produced verifiable deliverables (files written, tests passing, command succeeded) and no subgoals remain.
+- When the user's task was subjective (research, diagnosis, exploration) and you have produced an answer you believe is sufficient.
+- **Do not** call `complete` just because a sub-step looks done — call it only when the top-level goal the user set via `/goal <text>` is actually done.
+
+## When NOT to use `complete`
+
+- When you have pending subgoals (check via `status` first; complete any subgoals before declaring the top-level goal done).
+- When the goal is clearly in progress and you have not yet produced the deliverable.
+
+## Examples
+
+```json
+{"action": "status"}
+{"action": "complete", "reason": "Goal delivered: 3 test files created, all assertions pass after refactor."}
+```
+
+## Notes
+
+- The external judge that decides whether the goal is `done` or should `continue` only inspects the last 4000 characters of your final assistant message each turn (see `JUDGE_RESPONSE_SNIPPET_CHARS`). Keep the substantive outcome of the turn visible in that tail — e.g. end with a one-line summary of what was delivered/verified. A long response that buries the result earlier in the message may be judged as incomplete even when the work is done.

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -12,6 +12,7 @@ import { ReadTool } from "./read"
 import { TaskTool } from "./task"
 import { Database } from "@opencode-ai/core/database/database"
 import { TodoWriteTool } from "./todo"
+import { GoalTool } from "./goal"
 import { SettingsHook } from "@/hook/settings"
 import { WebFetchTool } from "./webfetch"
 import { WriteTool } from "./write"
@@ -104,6 +105,7 @@ export const layer = Layer.effect(
     const read = yield* ReadTool
     const question = yield* QuestionTool
     const todo = yield* TodoWriteTool
+    const goaltool = yield* GoalTool
     const lsptool = yield* LspTool
     const plan = yield* PlanExitTool
     const webfetch = yield* WebFetchTool
@@ -218,6 +220,7 @@ export const layer = Layer.effect(
           task: Tool.init(task),
           fetch: Tool.init(webfetch),
           todo: Tool.init(todo),
+          goal: Tool.init(goaltool),
           search: Tool.init(websearch),
           skill: Tool.init(skilltool),
           patch: Tool.init(patchtool),
@@ -242,6 +245,7 @@ export const layer = Layer.effect(
             tool.task,
             tool.fetch,
             tool.todo,
+            tool.goal,
             tool.search,
             tool.skill,
             tool.patch,

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -93,7 +93,7 @@ export const TaskTool = Tool.define(
     // Build-phase serviceOption is SAFE here, unlike tool/goal.ts: SettingsHook
     // arrives via Layer.provideMerge (app-runtime.ts), whose output is visible to
     // the ToolRegistry mergeAll group during construction, so this resolves Some.
-    // Dag.Service, by contrast, is a mergeAll sibling and invisible at build.
+    // Goal.Service, by contrast, is a mergeAll sibling and invisible at build.
     const settingsHook = Option.getOrUndefined(yield* Effect.serviceOption(SettingsHook.Service))
 
     const run = Effect.fn("TaskTool.execute")(function* (

--- a/packages/opencode/test/fixture/tui-plugin.ts
+++ b/packages/opencode/test/fixture/tui-plugin.ts
@@ -317,6 +317,7 @@ export function createTuiPluginApi(opts: Opts = {}): HostPluginApi {
         get: opts.state?.session?.get ?? (() => undefined),
         diff: opts.state?.session?.diff ?? (() => []),
         todo: opts.state?.session?.todo ?? (() => []),
+        goal: opts.state?.session?.goal ?? (() => undefined),
         messages: opts.state?.session?.messages ?? (() => []),
         status: opts.state?.session?.status ?? (() => undefined),
         permission: opts.state?.session?.permission ?? (() => []),

--- a/packages/opencode/test/goal/e2e-loop.test.ts
+++ b/packages/opencode/test/goal/e2e-loop.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect } from "bun:test"
+import { Effect, Layer } from "effect"
+import { GoalLoop, GoalLoopJudgeLLM } from "@/goal/loop"
+import { Goal } from "@/goal/goal"
+import { GoalEvent } from "@/goal/events"
+import { EventV2Bridge } from "@/event-v2-bridge"
+import { SessionStatus } from "@/session/status"
+import { Session } from "@/session/session"
+import { SessionPrompt } from "@/session/prompt"
+import { Provider } from "@/provider/provider"
+import { Database } from "@opencode-ai/core/database/database"
+import { SessionID } from "@/session/schema"
+import { testEffect, pollWithTimeout } from "../lib/effect"
+
+// P2b: full-cycle Goal regression (D5). Drives set → idle → judge(continue) →
+// continuation → idle → judge(done) → terminal event sequence, with the judge
+// LLM scripted via the injected GoalLoopJudgeLLM (no network / Provider creds).
+// Session / SessionPrompt / Provider are mocked; Goal / SessionStatus /
+// EventV2Bridge are real so goal state, the fibers map, and the event bus are
+// exercised end-to-end.
+
+type CapturedEvent = { type: string; status?: string }
+
+const captureEvents = (events: EventV2Bridge.Service["Service"]) =>
+  Effect.gen(function* () {
+    const seen: CapturedEvent[] = []
+    const unsubscribe = yield* events.listen((event) =>
+      Effect.sync(() => {
+        const goal = (event.data as { goal?: { status?: string } }).goal
+        seen.push({ type: event.type, status: goal?.status })
+      }),
+    )
+    yield* Effect.addFinalizer(() => unsubscribe)
+    return seen
+  })
+
+// Scripted assistant response — afterIdle extracts its text as the judge input.
+const assistantText = "I have made progress on the feature."
+// GoalLoop.init forks the idle-event subscription (loop.ts Effect.forkScoped).
+// No observable latch exists for stream-subscription registration, so the only
+// sync point before publishing the first idle event is this bounded fork-window
+// wait. Kept intentionally: replacing it needs a subscribe-ready signal in
+// EventV2Bridge (production change, out of scope for test hygiene).
+const SUBSCRIPTION_SETTLE_MS = 200
+const mkAssistant = () =>
+  ({
+    info: { role: "assistant", time: { created: Date.now() } },
+    parts: [{ type: "text", text: assistantText }],
+  }) as never
+
+describe("GoalLoop end-to-end — continue → done lifecycle (P2b)", () => {
+  // Per-test mutable mock state (each it.instance runs in its own scope, but
+  // these closures are shared across the single test below — fine since the
+  // test serializes the two judge calls).
+  let judgeCalls = 0
+  const promptCalls: { noReply?: boolean; text: string }[] = []
+
+  const reset = () => {
+    judgeCalls = 0
+    promptCalls.length = 0
+  }
+
+  const sessionMock = Layer.succeed(Session.Service, {
+    messages: () => Effect.succeed([mkAssistant()]),
+  } as never)
+  const promptMock = Layer.succeed(SessionPrompt.Service, {
+    prompt: (input: { noReply?: boolean; parts?: Array<{ type: string; text: string }> }) =>
+      Effect.sync(() => {
+        promptCalls.push({
+          noReply: input.noReply,
+          text: input.parts?.map((p) => p.text).join("\n") ?? "",
+        })
+        return undefined as never
+      }),
+  } as never)
+  const providerMock = Layer.succeed(Provider.Service, {} as never)
+  const judgeMock = Layer.succeed(
+    GoalLoopJudgeLLM,
+    GoalLoopJudgeLLM.of({
+      call: () =>
+        Effect.sync(() => {
+          judgeCalls += 1
+          // First judge call → continue; second → done.
+          return judgeCalls === 1
+            ? JSON.stringify({ done: false, reason: "more steps needed" })
+            : JSON.stringify({ done: true, reason: "feature shipped" })
+        }),
+    }),
+  )
+
+  const e2eLayer = GoalLoop.layer.pipe(
+    Layer.provide(sessionMock),
+    Layer.provide(promptMock),
+    Layer.provide(providerMock),
+    Layer.provide(judgeMock),
+    Layer.provideMerge(Goal.defaultLayer),
+    Layer.provide(SessionStatus.defaultLayer),
+    Layer.provideMerge(EventV2Bridge.defaultLayer),
+  )
+  const it = testEffect(e2eLayer)
+
+  it.instance("set → continue → continuation → done → cleared, scripted judge", () =>
+    Effect.gen(function* () {
+      reset()
+      const loop = yield* GoalLoop.Service
+      const goal = yield* Goal.Service
+      const events = yield* EventV2Bridge.Service
+      const seen = yield* captureEvents(events)
+
+      yield* loop.init()
+      const sid = SessionID.descending()
+      yield* goal.set(sid, "ship the feature", 10)
+      // Let the idle subscription finish wiring (InstanceState is built on the
+      // first init) before publishing, so the first idle event is not missed.
+      yield* Effect.sleep(SUBSCRIPTION_SETTLE_MS)
+
+      // ── Turn 1: idle → judge(continue) → continuation prompt ──
+      yield* events.publish(SessionStatus.Event.Status, { sessionID: sid, status: { type: "idle" } })
+      yield* pollWithTimeout(
+        Effect.sync(() => (judgeCalls >= 1 ? true : undefined)),
+        "judge call 1 (continue) never fired",
+        "5 seconds",
+      )
+
+      const after1 = yield* goal.load(sid)
+      expect(after1?.status).toBe("active")
+      expect(Number(after1?.turns_used)).toBe(1)
+      // A continuation prompt was injected (not a noReply), carrying the goal.
+      expect(promptCalls.some((p) => !p.noReply)).toBe(true)
+
+      // ── Turn 2: idle → judge(done) → terminal event sequence ──
+      yield* events.publish(SessionStatus.Event.Status, { sessionID: sid, status: { type: "idle" } })
+      yield* pollWithTimeout(
+        Effect.sync(() => (judgeCalls >= 2 ? true : undefined)),
+        "judge call 2 (done) never fired",
+        "5 seconds",
+      )
+
+      const types = seen.map((e) => e.type)
+      // Terminal contract: goal.updated(done) then goal.cleared, exactly once.
+      const doneUpdates = seen.filter((e) => e.type === GoalEvent.Updated.type && e.status === "done")
+      expect(doneUpdates.length).toBe(1)
+      expect(types).toContain(GoalEvent.Cleared.type)
+      // Row deleted after the terminal sequence.
+      const loaded = yield* goal.load(sid)
+      expect(loaded).toBeUndefined()
+    }),
+  )
+})
+
+// D1 (hooks-goal-completeness): a continuation dispatch failure must surface as a
+// recoverable paused state, not a silent stall. Reuses the e2e harness with a
+// prompt mock that always fails — the only prompt in this flow is the
+// continuation after judge(continue), so it fails and exercises the catchCause
+// → pauseAndPublish branch added in loop.ts.
+describe("GoalLoop — continuation dispatch failure → recoverable pause (D1)", () => {
+  let judgeCalls = 0
+  const reset = () => {
+    judgeCalls = 0
+  }
+
+  const sessionMock = Layer.succeed(Session.Service, {
+    messages: () => Effect.succeed([mkAssistant()]),
+  } as never)
+  // Always-failing prompt — simulates provider fault / session write error.
+  const promptFailMock = Layer.succeed(SessionPrompt.Service, {
+    prompt: () => Effect.fail(new Error("continuation provider down")),
+  } as never)
+  const providerMock = Layer.succeed(Provider.Service, {} as never)
+  const judgeMock = Layer.succeed(
+    GoalLoopJudgeLLM,
+    GoalLoopJudgeLLM.of({
+      call: () =>
+        Effect.sync(() => {
+          judgeCalls += 1
+          return JSON.stringify({ done: false, reason: "more steps needed" })
+        }),
+    }),
+  )
+  const failLayer = GoalLoop.layer.pipe(
+    Layer.provide(sessionMock),
+    Layer.provide(promptFailMock),
+    Layer.provide(providerMock),
+    Layer.provide(judgeMock),
+    Layer.provideMerge(Goal.defaultLayer),
+    Layer.provide(SessionStatus.defaultLayer),
+    Layer.provideMerge(EventV2Bridge.defaultLayer),
+  )
+  const it = testEffect(failLayer)
+
+  // 1.2 — continuation prompt fails → goal transitions to paused with a reason
+  // and a goal.updated(paused) event; afterIdle does not propagate the error.
+  it.instance("continuation prompt 失败 → goal paused + reason + 事件发布", () =>
+    Effect.gen(function* () {
+      reset()
+      const loop = yield* GoalLoop.Service
+      const goal = yield* Goal.Service
+      const events = yield* EventV2Bridge.Service
+      const seen = yield* captureEvents(events)
+      yield* loop.init()
+      const sid = SessionID.descending()
+      yield* goal.set(sid, "ship the feature", 10)
+      // Let the idle subscription wire (InstanceState builds on first init).
+      yield* Effect.sleep(SUBSCRIPTION_SETTLE_MS)
+
+      // idle → judge(continue) → continuation prompt fails → catchCause → pause
+      yield* events.publish(SessionStatus.Event.Status, { sessionID: sid, status: { type: "idle" } })
+      yield* pollWithTimeout(
+        Effect.gen(function* () {
+          const g = yield* goal.load(sid)
+          return g?.status === "paused" ? true : undefined
+        }),
+        "goal never transitioned to paused after continuation failure",
+        "5 seconds",
+      )
+
+      const paused = yield* goal.load(sid)
+      expect(paused?.status).toBe("paused")
+      expect(String(paused?.paused_reason)).toContain("continuation dispatch failed")
+      // goal.updated(paused) published (SSE/TUI visible)
+      expect(seen.some((e) => e.type === GoalEvent.Updated.type && e.status === "paused")).toBe(true)
+      // The continuation was actually attempted: judge ran, turns_used advanced.
+      expect(judgeCalls).toBeGreaterThanOrEqual(1)
+      expect(Number(paused?.turns_used)).toBe(1)
+    }),
+  )
+
+  // 1.3 — after the failure-induced pause, /goal resume restores active and
+  // preserves the turns_used budget (resume must not silently grant a fresh budget).
+  it.instance("paused 后 resume 恢复 active，turns_used 保留", () =>
+    Effect.gen(function* () {
+      reset()
+      const loop = yield* GoalLoop.Service
+      const goal = yield* Goal.Service
+      const events = yield* EventV2Bridge.Service
+      yield* loop.init()
+      const sid = SessionID.descending()
+      yield* goal.set(sid, "ship the feature", 10)
+      yield* Effect.sleep(SUBSCRIPTION_SETTLE_MS)
+      yield* events.publish(SessionStatus.Event.Status, { sessionID: sid, status: { type: "idle" } })
+      yield* pollWithTimeout(
+        Effect.gen(function* () {
+          const g = yield* goal.load(sid)
+          return g?.status === "paused" ? true : undefined
+        }),
+        "goal never transitioned to paused before resume",
+        "5 seconds",
+      )
+      const before = yield* goal.load(sid)
+      const turnsBefore = Number(before?.turns_used)
+
+      const resumed = yield* goal.resume(sid)
+      expect(resumed?.status).toBe("active")
+      expect(Number(resumed?.turns_used)).toBe(turnsBefore) // budget preserved, not reset
+      expect(resumed?.paused_reason).toBeUndefined()
+    }),
+  )
+})

--- a/packages/opencode/test/goal/goal.test.ts
+++ b/packages/opencode/test/goal/goal.test.ts
@@ -1,0 +1,809 @@
+import { describe, expect } from "bun:test"
+import { Deferred, Effect, Fiber, Layer } from "effect"
+import { Goal } from "@/goal/goal"
+import { GoalEvent } from "@/goal/events"
+import { GoalPrompts } from "@/goal/prompts"
+import { EventV2Bridge } from "@/event-v2-bridge"
+import { SessionStatus } from "@/session/status"
+import { Database } from "@opencode-ai/core/database/database"
+import { SessionID } from "@/session/schema"
+import { pollWithTimeout, testEffect } from "../lib/effect"
+
+// Build the layer so EventV2Bridge.Service is SHARED between Goal's internals
+// (which publish via it) and this test (which subscribes via it).
+// `Layer.provideMerge` exposes the built EventV2Bridge in the output context
+// AND feeds the same instance into Goal.layer — a plain `Layer.provide` would
+// consume it internally and the test's `yield* EventV2Bridge.Service` would
+// resolve to a different instance, missing every published event.
+// Each test uses a unique SessionID so rows never collide across tests
+// (goal_state.session_id is the primary key).
+const testLayer = Goal.layer.pipe(
+  Layer.provide(SessionStatus.defaultLayer),
+  Layer.provide(Database.defaultLayer),
+  Layer.provideMerge(EventV2Bridge.defaultLayer),
+)
+
+const it = testEffect(testLayer)
+
+type CapturedEvent = {
+  type: string
+  status?: string
+  turnsUsed?: number
+  subgoals?: ReadonlyArray<unknown>
+}
+
+const captureEvents = (events: EventV2Bridge.Service["Service"]) =>
+  Effect.gen(function* () {
+    const seen: CapturedEvent[] = []
+    const unsubscribe = yield* events.listen((event) =>
+      Effect.sync(() => {
+        // goal.updated carries { sessionID, goal: { status, turnsUsed, subgoals, ... } };
+        // goal.cleared carries only { sessionID }.
+        const goal = (
+          event.data as { goal?: { status?: string; turnsUsed?: number; subgoals?: ReadonlyArray<unknown> } }
+        ).goal
+        seen.push({
+          type: event.type,
+          status: goal?.status,
+          turnsUsed: goal?.turnsUsed,
+          subgoals: goal?.subgoals,
+        })
+      }),
+    )
+    yield* Effect.addFinalizer(() => unsubscribe)
+    return seen
+  })
+
+// Returns the single goal.updated(done) event from a capture, failing the test
+// loudly if there isn't exactly one (used by markDone / terminal-flow tests).
+const doneUpdated = (events: ReadonlyArray<CapturedEvent>) => {
+  const done = events.filter((e) => e.type === GoalEvent.Updated.type && e.status === "done")
+  expect(done.length).toBe(1)
+  return done[0]
+}
+
+// Forks a synthetic "loop fiber" that blocks forever and records whether it has
+// been interrupted. The Goal service's fiber map (`fibers`) is private inside
+// its layer closure, so fiber-map behavior can only be observed through
+// interruption side effects: register the tracked fiber, trigger the action
+// under test, then read `holder.interrupted`.
+//
+// The `ready` deferred is awaited before returning so the child has STARTED and
+// registered its onInterrupt finalizer before the caller touches the map —
+// without it, an interrupt fired before the child scheduled could miss the
+// finalizer and the test would race (see AGENTS.md "Synchronizing With
+// Concurrent Work": wait on a published readiness signal, never Effect.sleep).
+const trackedFiber = () =>
+  Effect.gen(function* () {
+    const ready = yield* Deferred.make<void>()
+    const holder = { interrupted: false }
+    const fiber = yield* Effect.gen(function* () {
+      yield* Deferred.succeed(ready, undefined)
+      yield* Effect.never
+    }).pipe(
+      Effect.onInterrupt(() => Effect.sync(() => (holder.interrupted = true))),
+      Effect.forkChild,
+    )
+    yield* Deferred.await(ready)
+    return { fiber, holder }
+  })
+
+describe("Goal.updateAfterJudge — continue branch", () => {
+  // §2.1 baseline: continue increments turns_used exactly once and publishes
+  // goal.updated(active). This is the ONE branch that is correct pre-fix and
+  // must stay correct after the bug fixes.
+  it.live("continue verdict increments turns_used by exactly one and publishes goal.updated", () =>
+    Effect.gen(function* () {
+      const goal = yield* Goal.Service
+      const events = yield* EventV2Bridge.Service
+      const seen = yield* captureEvents(events)
+      const sessionID = SessionID.descending()
+
+      yield* goal.set(sessionID, "build feature X", 10)
+      seen.length = 0 // drop the set() goal.updated(active)
+
+      const result = yield* goal.updateAfterJudge(sessionID, "continue", "more steps", false)
+
+      expect(result?.shouldContinue).toBe(true)
+      const loaded = yield* goal.load(sessionID)
+      expect(Number(loaded?.turns_used)).toBe(1)
+      expect(loaded?.status).toBe("active")
+
+      const updates = seen.filter((e) => e.type === GoalEvent.Updated.type)
+      expect(updates.length).toBe(1)
+      expect(updates[0].status).toBe("active")
+      expect(updates[0].turnsUsed).toBe(1)
+    }),
+  )
+})
+
+describe("Goal.updateAfterJudge — done branch (turn budget)", () => {
+  // §2.2 — done is a STATE TRANSITION, not a continuation dispatch, so it must
+  // NOT consume budget. Pre-fix this fails (code does +1); post-§3 it passes.
+  it.live("done verdict does not increment turns_used (state transitions are budget-neutral)", () =>
+    Effect.gen(function* () {
+      const goal = yield* Goal.Service
+      const sessionID = SessionID.descending()
+      yield* goal.set(sessionID, "ship feature X", 10)
+      const before = yield* goal.load(sessionID)
+      const n = Number(before?.turns_used)
+
+      yield* goal.updateAfterJudge(sessionID, "done", "delivered", false)
+
+      const after = yield* goal.load(sessionID)
+      expect(after?.status).toBe("done")
+      expect(Number(after?.turns_used)).toBe(n)
+    }),
+  )
+})
+
+describe("Goal.updateAfterJudge — done branch (terminal event contract)", () => {
+  // §2.3 — updateAfterJudge's done branch must NOT publish goal.updated; only
+  // deleteAndPublishDone owns the terminal sequence. Pre-fix this fails (code
+  // publishes); post-§4 it passes.
+  it.live("done verdict does not publish goal.updated (single-owner: deleteAndPublishDone)", () =>
+    Effect.gen(function* () {
+      const goal = yield* Goal.Service
+      const events = yield* EventV2Bridge.Service
+      const seen = yield* captureEvents(events)
+      const sessionID = SessionID.descending()
+
+      yield* goal.set(sessionID, "ship feature X", 10)
+      seen.length = 0
+
+      yield* goal.updateAfterJudge(sessionID, "done", "delivered", false)
+
+      const updates = seen.filter((e) => e.type === GoalEvent.Updated.type)
+      expect(updates.length).toBe(0)
+    }),
+  )
+
+  // §4.3 — full judge-done flow: updateAfterJudge persists the done row WITHOUT
+  // publishing, then deleteAndPublishDone publishes the terminal sequence
+  // exactly once: goal.updated(done) → goal.cleared, no duplicate updated.
+  it.live("full judge-done flow publishes goal.updated(done) -> goal.cleared exactly once", () =>
+    Effect.gen(function* () {
+      const goal = yield* Goal.Service
+      const events = yield* EventV2Bridge.Service
+      const seen = yield* captureEvents(events)
+      const sessionID = SessionID.descending()
+
+      yield* goal.set(sessionID, "ship feature X", 10)
+      seen.length = 0
+
+      yield* goal.updateAfterJudge(sessionID, "done", "delivered", false)
+      yield* goal.deleteAndPublishDone(sessionID, "delivered")
+
+      const types = seen.map((e) => e.type)
+      expect(types).toEqual([GoalEvent.Updated.type, GoalEvent.Cleared.type])
+      doneUpdated(seen)
+      const cleared = seen.filter((e) => e.type === GoalEvent.Cleared.type)
+      expect(cleared.length).toBe(1)
+
+      // row is gone after the terminal sequence
+      const loaded = yield* goal.load(sessionID)
+      expect(loaded).toBeUndefined()
+    }),
+  )
+})
+
+describe("Goal.markDone — turns_used is budget-neutral", () => {
+  // §2.4 — user/agent-initiated completion on a goal that never ran a continue
+  // dispatch. turns_used must stay at its current value (budget counts
+  // continuation dispatches only). Pre-fix this fails (+1); post-§3 it passes.
+  // The row is deleted by deleteAndPublishDone, so turns_used is read from the
+  // published goal.updated(done) payload.
+  it.live("markDone on a fresh active goal does not increment turns_used", () =>
+    Effect.gen(function* () {
+      const goal = yield* Goal.Service
+      const events = yield* EventV2Bridge.Service
+      const seen = yield* captureEvents(events)
+      const sessionID = SessionID.descending()
+
+      yield* goal.set(sessionID, "ship feature X", 10)
+      const before = yield* goal.load(sessionID)
+      seen.length = 0
+
+      yield* goal.markDone(sessionID, "agent self-declared")
+
+      const event = doneUpdated(seen)
+      expect(event.turnsUsed).toBe(Number(before?.turns_used))
+    }),
+  )
+
+  // §2.5 — agent self-declares completion mid-loop: a continue dispatch already
+  // incremented turns_used (N → N+1); markDone must NOT add a second increment.
+  // The reported count reflects only the continuation dispatch, not the
+  // completion call (reasoner C1). Pre-fix this fails (double-count → N+2);
+  // post-§3 it passes (N+1).
+  it.live("markDone after a continue dispatch does not double-count", () =>
+    Effect.gen(function* () {
+      const goal = yield* Goal.Service
+      const events = yield* EventV2Bridge.Service
+      const seen = yield* captureEvents(events)
+      const sessionID = SessionID.descending()
+
+      yield* goal.set(sessionID, "ship feature X", 10)
+      // Simulate one continuation dispatch (the budget-consuming event).
+      yield* goal.updateAfterJudge(sessionID, "continue", "more steps", false)
+      const continued = yield* goal.load(sessionID)
+      seen.length = 0
+
+      yield* goal.markDone(sessionID, "agent self-declared")
+
+      const event = doneUpdated(seen)
+      // Only the continue increment; markDone adds nothing.
+      expect(event.turnsUsed).toBe(Number(continued?.turns_used))
+    }),
+  )
+})
+
+// ---------------------------------------------------------------------------
+// §5 — Expand state-machine coverage (lock the contract). All PASS against
+// current post-bug-fix behavior; they exist to catch regressions when §6-§10
+// land.
+// ---------------------------------------------------------------------------
+
+describe("Goal.set — saves active row + publishes goal.updated(active)", () => {
+  // §5.1 — the entry point of the lifecycle. Locks the initial row shape and
+  // the published event: status active, turns_used 0, empty subgoals.
+  it.live("set persists an active row with turns_used 0 / subgoals [] and publishes goal.updated(active)", () =>
+    Effect.gen(function* () {
+      const goal = yield* Goal.Service
+      const events = yield* EventV2Bridge.Service
+      const seen = yield* captureEvents(events)
+      const sessionID = SessionID.descending()
+
+      const state = yield* goal.set(sessionID, "build feature X", 10)
+
+      expect(state.status).toBe("active")
+      expect(Number(state.turns_used)).toBe(0)
+      expect(state.subgoals).toEqual([])
+
+      const loaded = yield* goal.load(sessionID)
+      expect(loaded?.status).toBe("active")
+      expect(Number(loaded?.turns_used)).toBe(0)
+      expect(loaded?.subgoals).toEqual([])
+
+      const updates = seen.filter((e) => e.type === GoalEvent.Updated.type)
+      expect(updates.length).toBe(1)
+      expect(updates[0].status).toBe("active")
+      expect(updates[0].turnsUsed).toBe(0)
+      expect(updates[0].subgoals).toEqual([])
+    }),
+  )
+})
+
+describe("Goal.pause — active→paused, clears loop fiber, publishes goal.updated(paused)", () => {
+  // §5.2 — pause must (a) transition to paused, (b) clear the loop fiber via
+  // clearFiber (verified through the tracked fiber's interrupt side effect),
+  // and (c) publish goal.updated(paused) carrying the reason.
+  it.live("pause transitions to paused, interrupts the loop fiber, and publishes with the reason", () =>
+    Effect.gen(function* () {
+      const goal = yield* Goal.Service
+      const events = yield* EventV2Bridge.Service
+      const seen = yield* captureEvents(events)
+      const sessionID = SessionID.descending()
+
+      yield* goal.set(sessionID, "build feature X", 10)
+      const tracked = yield* trackedFiber()
+      yield* goal.registerLoopFiber(sessionID, tracked.fiber)
+      seen.length = 0
+
+      const result = yield* goal.pause(sessionID, "user-paused: checking in")
+
+      expect(result?.status).toBe("paused")
+      expect(result?.paused_reason).toBe("user-paused: checking in")
+      // pause() calls clearFiber → Fiber.interrupt on the registered loop fiber
+      expect(tracked.holder.interrupted).toBe(true)
+
+      const loaded = yield* goal.load(sessionID)
+      expect(loaded?.status).toBe("paused")
+
+      const updates = seen.filter((e) => e.type === GoalEvent.Updated.type)
+      expect(updates.length).toBe(1)
+      expect(updates[0].status).toBe("paused")
+    }),
+  )
+})
+
+describe("Goal.resume — preserves turns_used (no fresh budget), resets parse failures", () => {
+  // §5.3 — CRITICAL regression guard: resume must NOT reset turns_used. A
+  // paused goal that exhausted its budget would otherwise get a fresh full
+  // budget on every resume, defeating max_turns as a runaway guard. Also
+  // resets consecutive_parse_failures so a resumed goal gets a clean slate
+  // for judge-parse-failure auto-pause.
+  it.live("resume transitions paused→active, preserves turns_used, and resets consecutive_parse_failures", () =>
+    Effect.gen(function* () {
+      const goal = yield* Goal.Service
+      const events = yield* EventV2Bridge.Service
+      const seen = yield* captureEvents(events)
+      const sessionID = SessionID.descending()
+
+      yield* goal.set(sessionID, "build feature X", 10)
+      // One continuation dispatch with a parse failure → turns_used=1, cpf=1
+      yield* goal.updateAfterJudge(sessionID, "continue", "more steps", true)
+      const beforePause = yield* goal.load(sessionID)
+      expect(Number(beforePause?.turns_used)).toBe(1)
+      expect(Number(beforePause?.consecutive_parse_failures)).toBe(1)
+      // User-initiated pause preserves turns_used + cpf
+      yield* goal.pause(sessionID, "user paused")
+      seen.length = 0
+
+      const result = yield* goal.resume(sessionID)
+
+      expect(result?.status).toBe("active")
+      // turns_used preserved — NOT reset to 0
+      expect(Number(result?.turns_used)).toBe(Number(beforePause?.turns_used))
+      // parse-failure counter reset on resume
+      expect(Number(result?.consecutive_parse_failures)).toBe(0)
+
+      const loaded = yield* goal.load(sessionID)
+      expect(loaded?.status).toBe("active")
+      expect(Number(loaded?.turns_used)).toBe(1)
+      expect(Number(loaded?.consecutive_parse_failures)).toBe(0)
+
+      const updates = seen.filter((e) => e.type === GoalEvent.Updated.type)
+      expect(updates.length).toBe(1)
+      expect(updates[0].status).toBe("active")
+    }),
+  )
+
+  // §5.4 — budget-exhausted pause: resume flips to active but keeps turns_used
+  // intact (== max_turns). The next judge iteration immediately re-pauses; the
+  // dispatch layer surfaces a warning (goal.ts:506-509). This locks that resume
+  // does NOT silently grant a fresh budget.
+  it.live("resume on a budget-exhausted paused goal keeps turns_used at max (no budget reset)", () =>
+    Effect.gen(function* () {
+      const goal = yield* Goal.Service
+      const sessionID = SessionID.descending()
+
+      // max_turns=2: a second continue verdict trips the budget-pause branch
+      yield* goal.set(sessionID, "build feature X", 2)
+      yield* goal.updateAfterJudge(sessionID, "continue", "step 1", false) // turns_used 1
+      yield* goal.updateAfterJudge(sessionID, "continue", "step 2", false) // turns_used 2 >= max → paused
+
+      const paused = yield* goal.load(sessionID)
+      expect(paused?.status).toBe("paused")
+      expect(Number(paused?.turns_used)).toBe(2)
+
+      const result = yield* goal.resume(sessionID)
+
+      // Active again, but turns_used unchanged — immediately re-exhaustible.
+      expect(result?.status).toBe("active")
+      expect(Number(result?.turns_used)).toBe(2)
+      expect(Number(result?.turns_used) >= Number(result?.max_turns)).toBe(true)
+    }),
+  )
+})
+
+describe("Goal.clear — deletes row, clears loop fiber, publishes goal.cleared", () => {
+  // §5.5 — clear tears down everything: row deleted, loop fiber interrupted,
+  // exactly one goal.cleared published, and NO goal.updated (clear is not a
+  // state transition, it is removal).
+  it.live("clear removes the row, interrupts the loop fiber, and publishes exactly one goal.cleared", () =>
+    Effect.gen(function* () {
+      const goal = yield* Goal.Service
+      const events = yield* EventV2Bridge.Service
+      const seen = yield* captureEvents(events)
+      const sessionID = SessionID.descending()
+
+      yield* goal.set(sessionID, "build feature X", 10)
+      const tracked = yield* trackedFiber()
+      yield* goal.registerLoopFiber(sessionID, tracked.fiber)
+      seen.length = 0
+
+      yield* goal.clear(sessionID)
+
+      expect(tracked.holder.interrupted).toBe(true)
+      const loaded = yield* goal.load(sessionID)
+      expect(loaded).toBeUndefined()
+
+      const cleared = seen.filter((e) => e.type === GoalEvent.Cleared.type)
+      expect(cleared.length).toBe(1)
+      const updates = seen.filter((e) => e.type === GoalEvent.Updated.type)
+      expect(updates.length).toBe(0)
+    }),
+  )
+})
+
+describe("Goal.registerLoopFiber — interrupts the previous fiber before storing the new one", () => {
+  // §5.6 — registering a new fiber for a session that already has one must
+  // interrupt the old one first (prevents a leaked/orphaned loop fiber when a
+  // new afterIdle run supersedes the prior). Verified by: (a) old fiber
+  // interrupted, (b) new fiber intact, (c) a subsequent clearLoopFiber
+  // interrupts the NEW fiber (proves it was actually stored).
+  it.live("registering a new fiber interrupts the previously-registered fiber for the same session", () =>
+    Effect.gen(function* () {
+      const goal = yield* Goal.Service
+      const sessionID = SessionID.descending()
+
+      const first = yield* trackedFiber()
+      yield* goal.registerLoopFiber(sessionID, first.fiber)
+      expect(first.holder.interrupted).toBe(false)
+
+      const second = yield* trackedFiber()
+      yield* goal.registerLoopFiber(sessionID, second.fiber)
+
+      // previous fiber interrupted by the re-register
+      expect(first.holder.interrupted).toBe(true)
+      // new fiber is intact and is now the one stored in the map
+      expect(second.holder.interrupted).toBe(false)
+      // clearing now interrupts the NEW fiber, proving it was stored
+      yield* goal.clearLoopFiber(sessionID)
+      expect(second.holder.interrupted).toBe(true)
+    }),
+  )
+})
+
+describe("Goal fiber-safe terminal paths — do NOT touch the fiber map", () => {
+  // §5.7 — deleteAndPublishDone and pauseAndPublish are called from INSIDE the
+  // loop fiber itself (loop.ts done / shouldPreempt branches). They must NOT
+  // manage the fiber map — doing so would self-interrupt before the terminal
+  // / pause event reaches the bus (the event would never be published). This
+  // locks the self-interrupt-hazard discipline: caller manages the fiber.
+  it.live("deleteAndPublishDone leaves the registered loop fiber intact", () =>
+    Effect.gen(function* () {
+      const goal = yield* Goal.Service
+      const sessionID = SessionID.descending()
+
+      yield* goal.set(sessionID, "build feature X", 10)
+      const tracked = yield* trackedFiber()
+      yield* goal.registerLoopFiber(sessionID, tracked.fiber)
+
+      yield* goal.deleteAndPublishDone(sessionID, "judge done")
+
+      // fiber NOT interrupted — map untouched
+      expect(tracked.holder.interrupted).toBe(false)
+      // the map still holds it: clearing now interrupts the registered fiber
+      yield* goal.clearLoopFiber(sessionID)
+      expect(tracked.holder.interrupted).toBe(true)
+    }),
+  )
+
+  it.live("pauseAndPublish leaves the registered loop fiber intact", () =>
+    Effect.gen(function* () {
+      const goal = yield* Goal.Service
+      const sessionID = SessionID.descending()
+
+      yield* goal.set(sessionID, "build feature X", 10)
+      const tracked = yield* trackedFiber()
+      yield* goal.registerLoopFiber(sessionID, tracked.fiber)
+
+      yield* goal.pauseAndPublish(sessionID, "loop self-pause")
+
+      // fiber NOT interrupted — map untouched
+      expect(tracked.holder.interrupted).toBe(false)
+      // the map still holds it: clearing now interrupts the registered fiber
+      yield* goal.clearLoopFiber(sessionID)
+      expect(tracked.holder.interrupted).toBe(true)
+    }),
+  )
+})
+
+// ---------------------------------------------------------------------------
+// §9 — Transport errors count toward pause budget (D5). Transport failures
+// (timeout, network) now return parseFailed: true from the judge, feeding the
+// same consecutive_parse_failures counter as parse failures. Three in a row
+// triggers auto-pause; alternating transport/parse failures must NOT reset the
+// counter (pre-fix transport returned parseFailed: false, which reset it to 0
+// and let a flaky provider burn the full budget without ever pausing).
+// ---------------------------------------------------------------------------
+
+describe("Goal.updateAfterJudge — transport failures trigger auto-pause (D5)", () => {
+  // §9.3a — three consecutive transport failures (parseFailed: true, simulating
+  // what judge.ts now returns on timeout/network) must reach
+  // MAX_CONSECUTIVE_PARSE_FAILURES (3) and auto-pause on the third.
+  it.live("three consecutive transport failures auto-pause the goal", () =>
+    Effect.gen(function* () {
+      const goal = yield* Goal.Service
+      const events = yield* EventV2Bridge.Service
+      const seen = yield* captureEvents(events)
+      const sessionID = SessionID.descending()
+
+      yield* goal.set(sessionID, "build feature X", 10)
+      seen.length = 0
+
+      // Two transport failures — still active, counter climbing 1 → 2
+      const r1 = yield* goal.updateAfterJudge(sessionID, "continue", "transport error 1", true)
+      const r2 = yield* goal.updateAfterJudge(sessionID, "continue", "transport error 2", true)
+      expect(r1?.shouldContinue).toBe(true)
+      expect(r2?.shouldContinue).toBe(true)
+
+      const midState = yield* goal.load(sessionID)
+      expect(midState?.status).toBe("active")
+      expect(Number(midState?.consecutive_parse_failures)).toBe(2)
+
+      // Third transport failure — counter reaches 3 → auto-pause
+      const r3 = yield* goal.updateAfterJudge(sessionID, "continue", "transport error 3", true)
+      expect(r3?.shouldContinue).toBe(false)
+
+      const finalState = yield* goal.load(sessionID)
+      expect(finalState?.status).toBe("paused")
+      expect(Number(finalState?.consecutive_parse_failures)).toBeGreaterThanOrEqual(
+        GoalPrompts.MAX_CONSECUTIVE_PARSE_FAILURES,
+      )
+
+      const paused = seen.filter((e) => e.type === GoalEvent.Updated.type && e.status === "paused")
+      expect(paused.length).toBe(1)
+    }),
+  )
+
+  // §9.3b — alternating transport + parse failures. Before §9, transport errors
+  // returned parseFailed: false which reset consecutive_parse_failures to 0 on
+  // every transport blip, so alternating transport/parse/transport never
+  // reached the threshold. After §9, both failure modes set parseFailed: true,
+  // so the counter climbs monotonically across the mix and pauses on the 3rd.
+  it.live("alternating transport + parse failures still triggers auto-pause", () =>
+    Effect.gen(function* () {
+      const goal = yield* Goal.Service
+      const sessionID = SessionID.descending()
+
+      yield* goal.set(sessionID, "build feature X", 10)
+
+      // transport-fail (parseFailed: true) → counter 1
+      yield* goal.updateAfterJudge(sessionID, "continue", "transport error", true)
+      let state = yield* goal.load(sessionID)
+      expect(Number(state?.consecutive_parse_failures)).toBe(1)
+      expect(state?.status).toBe("active")
+
+      // parse-fail (parseFailed: true) → counter 2
+      yield* goal.updateAfterJudge(sessionID, "continue", "无法解析", true)
+      state = yield* goal.load(sessionID)
+      expect(Number(state?.consecutive_parse_failures)).toBe(2)
+      expect(state?.status).toBe("active")
+
+      // transport-fail (parseFailed: true) → counter 3 → PAUSE
+      const r3 = yield* goal.updateAfterJudge(sessionID, "continue", "transport error", true)
+      expect(r3?.shouldContinue).toBe(false)
+
+      state = yield* goal.load(sessionID)
+      expect(state?.status).toBe("paused")
+    }),
+  )
+})
+
+// ---------------------------------------------------------------------------
+// §10 — Zombie-goal freshness guard (D6). When afterIdle detects an active goal
+// with turns_used 0, no assistant message, and created_at older than
+// FRESHNESS_THRESHOLD, it calls pauseAndPublish with a freshness reason. This
+// tests that the pause transition (the mechanism the guard uses) publishes the
+// paused event with the freshness reason — the guard's predicate logic itself
+// is locked in loop.test.ts (isStaleZombie).
+// ---------------------------------------------------------------------------
+
+describe("Goal.pauseAndPublish — freshness-guard pause (D6)", () => {
+  // §10.3 — the exact pause transition afterIdle's freshness guard performs:
+  // pauseAndPublish with the freshness reason string. Verifies the goal flips
+  // to paused, the reason is persisted, and goal.updated(paused) fires on the
+  // bus so the TUI/SSE surfaces the orphaned goal instead of leaving it silent.
+  it.live("freshness pause transitions active→paused and publishes with the reason", () =>
+    Effect.gen(function* () {
+      const goal = yield* Goal.Service
+      const events = yield* EventV2Bridge.Service
+      const seen = yield* captureEvents(events)
+      const sessionID = SessionID.descending()
+
+      yield* goal.set(sessionID, "build feature X", 10)
+      seen.length = 0
+
+      const reason = `initial kick produced no assistant response within ${GoalPrompts.FRESHNESS_THRESHOLD / 1000}s — likely provider error or model refusal. Use /goal resume to retry.`
+      const result = yield* goal.pauseAndPublish(sessionID, reason)
+
+      expect(result?.status).toBe("paused")
+      expect(result?.paused_reason).toBe(reason)
+
+      const loaded = yield* goal.load(sessionID)
+      expect(loaded?.status).toBe("paused")
+      expect(loaded?.paused_reason).toBe(reason)
+
+      const paused = seen.filter((e) => e.type === GoalEvent.Updated.type && e.status === "paused")
+      expect(paused.length).toBe(1)
+    }),
+  )
+
+  // §10.4 — a fresh goal (within threshold) does NOT hit the freshness guard.
+  // pauseAndPublish with a freshness reason is never invoked; the goal stays
+  // active. This is verified at the predicate level in loop.test.ts
+  // (isStaleZombie returns false for fresh goals); here we confirm a fresh
+  // goal row remains active and unpauseable by anything other than an explicit
+  // pause call — the guard's absence is the expected behavior.
+  it.live("fresh goal stays active (freshness guard does not fire)", () =>
+    Effect.gen(function* () {
+      const goal = yield* Goal.Service
+      const sessionID = SessionID.descending()
+
+      // A freshly-set goal: created_at is now, turns_used 0 — the exact state
+      // the guard checks, but within the threshold so the predicate is false.
+      yield* goal.set(sessionID, "build feature X", 10)
+
+      const state = yield* goal.load(sessionID)
+      expect(state?.status).toBe("active")
+      expect(Number(state?.turns_used)).toBe(0)
+      // created_at is recent (within the last second), well inside the threshold
+      expect(Date.now() - Number(state?.created_at)).toBeLessThan(GoalPrompts.FRESHNESS_THRESHOLD)
+    }),
+  )
+})
+
+// ---------------------------------------------------------------------------
+// §F1 — Terminal / pause sequences are uninterruptible (defense-in-depth).
+// deleteAndPublishDone and pauseAndPublish are wrapped in Effect.uninterruptible
+// so an interrupt landing mid-region can never split the load → publish →
+// delete → publish contract. These tests fork each effect, prove the fiber has
+// ENTERED the uninterruptible region via an observable entry signal, then
+// interrupt and assert the remaining events still fired.
+// ---------------------------------------------------------------------------
+
+describe("Goal.deleteAndPublishDone — terminal sequence is uninterruptible (F1)", () => {
+  // The rigorous interrupt-during-region proof. goal.updated(done) can only
+  // fire once the region has started (loadState + publishGoal both ran), so
+  // waiting for it guarantees the interrupt below lands INSIDE the region. If
+  // the Effect.uninterruptible wrapper were removed, the interrupt could kill
+  // the fiber between publish(done) and publish(cleared), and the cleared
+  // assertion would fail.
+  it.live("publishes goal.updated(done) and goal.cleared when the calling fiber is interrupted mid-region", () =>
+    Effect.gen(function* () {
+      const goal = yield* Goal.Service
+      const events = yield* EventV2Bridge.Service
+      const seen = yield* captureEvents(events)
+      const sessionID = SessionID.descending()
+
+      yield* goal.set(sessionID, "ship feature X", 10)
+      // Persist a done row WITHOUT publishing — mirrors what loop.ts does
+      // (updateAfterJudge) before invoking deleteAndPublishDone.
+      yield* goal.updateAfterJudge(sessionID, "done", "delivered", false)
+      seen.length = 0
+
+      const fiber = yield* goal.deleteAndPublishDone(sessionID, "delivered").pipe(Effect.forkScoped)
+
+      // Entry proof: goal.updated(done) published → region entered.
+      yield* pollWithTimeout(
+        Effect.sync(() =>
+          seen.some((e) => e.type === GoalEvent.Updated.type && e.status === "done") ? true : undefined,
+        ),
+        "deleteAndPublishDone never published goal.updated(done)",
+      )
+
+      // Interrupt mid-region. The region is uninterruptible, so deleteState +
+      // publish(cleared) complete before the deferred interrupt terminates
+      // the fiber.
+      yield* Fiber.interrupt(fiber)
+
+      const done = seen.filter((e) => e.type === GoalEvent.Updated.type && e.status === "done")
+      expect(done.length).toBe(1)
+      const cleared = seen.filter((e) => e.type === GoalEvent.Cleared.type)
+      expect(cleared.length).toBe(1)
+
+      // deleteState ran — row is gone.
+      const loaded = yield* goal.load(sessionID)
+      expect(loaded).toBeUndefined()
+    }),
+  )
+})
+
+describe("Goal.pauseAndPublish — pause transition is uninterruptible (F1)", () => {
+  // Complementary to the deleteAndPublishDone test. pauseAndPublish publishes
+  // only one event (goal.updated(paused)), so the entry signal is the DB row
+  // flipping to paused (saveState completed = region entered). After that we
+  // interrupt and assert publishGoal(paused) still fired. Combined with the
+  // deleteAndPublishDone test (same Effect.uninterruptible pattern), this
+  // locks the F1 uninterruptible wrapping on both fiber-safe paths.
+  it.live("publishes goal.updated(paused) when the calling fiber is interrupted after the region starts", () =>
+    Effect.gen(function* () {
+      const goal = yield* Goal.Service
+      const events = yield* EventV2Bridge.Service
+      const seen = yield* captureEvents(events)
+      const sessionID = SessionID.descending()
+
+      yield* goal.set(sessionID, "build feature X", 10)
+      seen.length = 0
+
+      const fiber = yield* goal.pauseAndPublish(sessionID, "interrupted mid-pause").pipe(Effect.forkScoped)
+
+      // Entry proof: saveState completed → row flipped to paused.
+      yield* pollWithTimeout(
+        Effect.gen(function* () {
+          const st = yield* goal.load(sessionID)
+          return st?.status === "paused" ? true : undefined
+        }),
+        "pauseAndPublish never persisted the paused row",
+      )
+
+      // Interrupt after the region started. The region is uninterruptible, so
+      // publishGoal(paused) still runs before the fiber terminates.
+      yield* Fiber.interrupt(fiber)
+
+      const loaded = yield* goal.load(sessionID)
+      expect(loaded?.status).toBe("paused")
+      expect(loaded?.paused_reason).toBe("interrupted mid-pause")
+      const paused = seen.filter((e) => e.type === GoalEvent.Updated.type && e.status === "paused")
+      expect(paused.length).toBe(1)
+    }),
+  )
+})
+
+// ── Goal.dispatch resume — busy guard (D5) ─────────────────────────
+//
+// `/goal resume` is a control command and bypasses the generic dispatch busy
+// check. Without an explicit guard it would return `kick` on a busy session,
+// prompting prompt.ts to start a second agent loop concurrently. The resume
+// branch now checks sessionStatus first: busy → message (ask to /stop), goal
+// stays paused; idle → kick as before (including the budget-exhaustion announce).
+//
+// SessionStatus is mocked (rather than the real defaultLayer) so the test can
+// pin the busy/idle verdict Goal.dispatch observes without dragging in
+// InstanceRef/InstanceState machinery. Goal.layer is provided the mock, so
+// dispatch queries the same controllable instance.
+
+const mockStatusLayer = (status: SessionStatus.Info) =>
+  Layer.succeed(SessionStatus.Service, {
+    get: () => Effect.succeed(status),
+    set: () => Effect.void,
+    list: () => Effect.succeed(new Map()),
+  })
+
+const resumeLayer = (status: SessionStatus.Info) =>
+  Goal.layer.pipe(
+    Layer.provide(mockStatusLayer(status)),
+    Layer.provide(Database.defaultLayer),
+    Layer.provideMerge(EventV2Bridge.defaultLayer),
+  )
+
+describe("Goal.dispatch resume — busy guard (D5)", () => {
+  testEffect(resumeLayer({ type: "busy" })).live(
+    "busy session: /goal resume returns a message and keeps the goal paused",
+    () =>
+      Effect.gen(function* () {
+        const goal = yield* Goal.Service
+        const sessionID = SessionID.descending()
+        yield* goal.set(sessionID, "ship feature X", 10)
+        yield* goal.pause(sessionID, "user-paused")
+
+        const result = yield* goal.dispatch(sessionID, "resume")
+
+        expect(result.type).toBe("message")
+        const loaded = yield* goal.load(sessionID)
+        expect(loaded?.status).toBe("paused")
+      }),
+  )
+
+  testEffect(resumeLayer({ type: "idle" })).live(
+    "idle session: /goal resume returns a kick and reactivates the goal",
+    () =>
+      Effect.gen(function* () {
+        const goal = yield* Goal.Service
+        const sessionID = SessionID.descending()
+        yield* goal.set(sessionID, "ship feature X", 10)
+        yield* goal.pause(sessionID, "user-paused")
+
+        const result = yield* goal.dispatch(sessionID, "resume")
+
+        expect(result.type).toBe("kick")
+        const loaded = yield* goal.load(sessionID)
+        expect(loaded?.status).toBe("active")
+      }),
+  )
+
+  // Budget-exhausted resume still returns kick on idle (the existing announce
+  // UX), but the busy guard must take precedence over the kick path.
+  testEffect(resumeLayer({ type: "busy" })).live(
+    "busy session: resume does not kick even when budget is exhausted",
+    () =>
+      Effect.gen(function* () {
+        const goal = yield* Goal.Service
+        const sessionID = SessionID.descending()
+        // max_turns 1 → one continue exhausts the budget and auto-pauses.
+        yield* goal.set(sessionID, "ship feature X", 1)
+        yield* goal.updateAfterJudge(sessionID, "continue", "more", false)
+        const paused = yield* goal.load(sessionID)
+        expect(paused?.status).toBe("paused")
+
+        const result = yield* goal.dispatch(sessionID, "resume")
+
+        expect(result.type).toBe("message")
+        const loaded = yield* goal.load(sessionID)
+        expect(loaded?.status).toBe("paused")
+      }),
+  )
+})

--- a/packages/opencode/test/goal/judge.test.ts
+++ b/packages/opencode/test/goal/judge.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test } from "bun:test"
+import { Effect } from "effect"
+import { GoalJudge } from "@/goal/judge"
+
+describe("parseJudgeResponse", () => {
+  // §1.2 — clean JSON parses directly (step 2)
+  test("clean JSON object returns matching verdict", () => {
+    const result = GoalJudge.parseJudgeResponse('{"done": true, "reason": "all tests pass"}')
+    expect(result).toEqual({ verdict: "done", reason: "all tests pass", parseFailed: false })
+  })
+
+  test("clean JSON with done=false returns continue", () => {
+    const result = GoalJudge.parseJudgeResponse('{"done": false, "reason": "still working"}')
+    expect(result).toEqual({ verdict: "continue", reason: "still working", parseFailed: false })
+  })
+
+  // §1.3 — markdown-fenced JSON strips fences (step 1)
+  test("markdown-fenced JSON strips fences and parses", () => {
+    const raw = "```json\n{\"done\": false, \"reason\": \"more steps remain\"}\n```"
+    const result = GoalJudge.parseJudgeResponse(raw)
+    expect(result).toEqual({ verdict: "continue", reason: "more steps remain", parseFailed: false })
+  })
+
+  test("markdown-fenced without language tag also strips", () => {
+    const raw = "```\n{\"done\": true, \"reason\": \"done\"}\n```"
+    const result = GoalJudge.parseJudgeResponse(raw)
+    expect(result).toEqual({ verdict: "done", reason: "done", parseFailed: false })
+  })
+
+  // §1.4 — JSON embedded in prose: regex step extracts first {...} block (step 3)
+  test("JSON embedded in prose is extracted by regex fallback", () => {
+    const raw = 'Sure! {"done": true, "reason": "shipped"} Thanks'
+    const result = GoalJudge.parseJudgeResponse(raw)
+    expect(result).toEqual({ verdict: "done", reason: "shipped", parseFailed: false })
+  })
+
+  // §1.5 — unparseable input falls through all steps (step 4)
+  test("unparseable prose returns continue with parseFailed true", () => {
+    const result = GoalJudge.parseJudgeResponse("I think it's done")
+    expect(result).toEqual({
+      verdict: "continue",
+      reason: "无法解析 judge 输出",
+      parseFailed: true,
+    })
+  })
+
+  test("empty string returns parseFailed", () => {
+    const result = GoalJudge.parseJudgeResponse("")
+    expect(result.parseFailed).toBe(true)
+    expect(result.verdict).toBe("continue")
+  })
+
+  test("valid JSON but wrong shape (missing reason) returns parseFailed", () => {
+    const result = GoalJudge.parseJudgeResponse('{"done": true}')
+    expect(result.parseFailed).toBe(true)
+  })
+
+  // §1.6 — nested-brace reason. NOTE: this contradicts tasks.md §1.6, which
+  // claims this input hits "step 4 fallback, parseFailed: true." It does not:
+  // step 2 runs `JSON.parse` on the whole string, and JSON.parse correctly
+  // handles braces inside string literals, so `{"reason": "set up {config}"}`
+  // parses cleanly. The regex limitation (`\{[^{}]*\}` cannot span nested
+  // braces) only manifests at STEP 3, and step 3 is only reached when step 2
+  // has already FAILED — i.e. when the verdict JSON is embedded in prose.
+  // See the next test for the case that actually demonstrates the limitation.
+  // Asserting the real current behavior keeps RED-1 green.
+  test("nested-brace reason parses via step 2 (JSON.parse handles braces in strings)", () => {
+    const raw = '{"done": true, "reason": "set up {config}"}'
+    const result = GoalJudge.parseJudgeResponse(raw)
+    expect(result).toEqual({ verdict: "done", reason: "set up {config}", parseFailed: false })
+  })
+
+  // The genuine step-3 regex limitation: verdict JSON embedded in prose where
+  // the reason itself contains a nested brace. Step 2 fails (not pure JSON),
+  // so step 3 runs. `\{[^{}]*\}` cannot span the outer object (it forbids inner
+  // braces), so it instead matches the innermost `{config}`, which is not valid
+  // verdict JSON → falls through to step 4 (parseFailed: true). A future
+  // balanced-brace extractor would fix this; locked here so the limitation is
+  // visible and a fix is detectable.
+  test("nested-brace reason embedded in prose hits the step-3 regex limitation", () => {
+    const raw = 'Sure! {"done": true, "reason": "set up {config}"} done'
+    const result = GoalJudge.parseJudgeResponse(raw)
+    expect(result.parseFailed).toBe(true)
+    expect(result.verdict).toBe("continue")
+  })
+})
+
+describe("GoalJudge.run — transport failures count toward pause budget (D5)", () => {
+  // §9.2 — when the injected callLLM fails (timeout, network error, rejection),
+  // the orElseSucceed fallback MUST return parseFailed: true (not false) so the
+  // failure increments consecutive_parse_failures via updateAfterJudge's
+  // `parseFailed ? count + 1 : 0` logic. Pre-fix this returned parseFailed:
+  // false, which reset the counter and let a flaky provider burn the full
+  // max_turns budget without ever pausing.
+  test("transport failure (Effect.fail) returns parseFailed: true", () =>
+    Effect.gen(function* () {
+      const result = yield* GoalJudge.run(
+        "build feature X",
+        "some agent response",
+        [],
+        () => Effect.fail(new Error("timeout")),
+      )
+      expect(result.verdict).toBe("continue")
+      expect(result.parseFailed).toBe(true)
+    }).pipe(Effect.runPromise),
+  )
+
+  test("transport failure reason names the failure mode", () =>
+    Effect.gen(function* () {
+      const result = yield* GoalJudge.run(
+        "build feature X",
+        "some agent response",
+        [],
+        () => Effect.fail(new Error("network down")),
+      )
+      // The reason must name the transport failure so the pause message
+      // (when it eventually fires after MAX_CONSECUTIVE_PARSE_FAILURES)
+      // can distinguish transport unreliability from parse failures.
+      expect(result.reason).toMatch(/transport/i)
+      expect(result.reason).toMatch(/timeout|network/i)
+    }).pipe(Effect.runPromise),
+  )
+
+  test("non-Error rejection also returns parseFailed: true", () =>
+    Effect.gen(function* () {
+      const result = yield* GoalJudge.run(
+        "build feature X",
+        "some agent response",
+        [],
+        () => Effect.fail(new Error("ECONNRESET")),
+      )
+      expect(result.parseFailed).toBe(true)
+      expect(result.verdict).toBe("continue")
+    }).pipe(Effect.runPromise),
+  )
+})

--- a/packages/opencode/test/goal/loop.test.ts
+++ b/packages/opencode/test/goal/loop.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, test } from "bun:test"
+import { Deferred, Effect, Fiber, Layer } from "effect"
+import { GoalLoop } from "@/goal/loop"
+import { Goal } from "@/goal/goal"
+import { GoalPrompts } from "@/goal/prompts"
+import { EventV2Bridge } from "@/event-v2-bridge"
+import { SessionStatus } from "@/session/status"
+import { Database } from "@opencode-ai/core/database/database"
+import { SessionID } from "@/session/schema"
+import { testEffect } from "../lib/effect"
+
+type Msg = Parameters<typeof GoalLoop.shouldPreempt>[0][number]
+
+const mk = (role: "user" | "assistant", created: number): Msg => ({
+  info: { role, time: { created } },
+})
+
+describe("shouldPreempt", () => {
+  // §1.7 — last user message newer than last assistant → preempt (true)
+  test("user message newer than last assistant returns true", () => {
+    const msgs = [mk("assistant", 100), mk("user", 200)]
+    expect(GoalLoop.shouldPreempt(msgs)).toBe(true)
+  })
+
+  // §1.8 — last assistant newer → no preempt (false)
+  test("assistant message newer than last user returns false", () => {
+    const msgs = [mk("user", 100), mk("assistant", 200)]
+    expect(GoalLoop.shouldPreempt(msgs)).toBe(false)
+  })
+
+  // §1.9 — missing user OR assistant → defensive false
+  test("missing user message returns false", () => {
+    const msgs = [mk("assistant", 100), mk("assistant", 200)]
+    expect(GoalLoop.shouldPreempt(msgs)).toBe(false)
+  })
+
+  test("missing assistant message returns false", () => {
+    const msgs = [mk("user", 100), mk("user", 200)]
+    expect(GoalLoop.shouldPreempt(msgs)).toBe(false)
+  })
+
+  test("empty message list returns false", () => {
+    expect(GoalLoop.shouldPreempt([])).toBe(false)
+  })
+
+  // strict `>` comparison: equal timestamps are NOT a preempt
+  test("equal timestamps return false (strict greater-than)", () => {
+    const msgs = [mk("assistant", 200), mk("user", 200)]
+    expect(GoalLoop.shouldPreempt(msgs)).toBe(false)
+  })
+
+  // tracks the MAXIMUM timestamp per role across interleaved messages
+  test("uses the most recent timestamp per role regardless of order", () => {
+    const msgs = [
+      mk("assistant", 500),
+      mk("user", 100),
+      mk("assistant", 200),
+      mk("user", 600),
+    ]
+    // lastUserAt = 600, lastAsstAt = 500 → preempt
+    expect(GoalLoop.shouldPreempt(msgs)).toBe(true)
+  })
+
+  // messages missing `time.created` are skipped (defensive)
+  test("messages missing created timestamp are skipped", () => {
+    const msgs = [
+      { info: { role: "assistant", time: { created: 100 } } },
+      { info: { role: "user", time: {} } },
+    ] as ReadonlyArray<Msg>
+    // no valid user timestamp → false
+    expect(GoalLoop.shouldPreempt(msgs)).toBe(false)
+  })
+})
+
+describe("isStaleZombie — freshness guard predicate (D6)", () => {
+  // Helper: builds a goal-state-shaped object for the predicate. created_at is
+  // expressed relative to a fixed `now` to keep tests deterministic.
+  const state = (overrides: Partial<{ status: string; turns_used: number; created_at: number }> = {}) => ({
+    status: "active",
+    turns_used: 0,
+    created_at: 0,
+    ...overrides,
+  })
+  const NOW = 1_000_000
+
+  // §10.3 — the fire condition: active, turns_used 0, older than the threshold,
+  // and no assistant message. This is exactly the orphan state afterIdle must
+  // convert into a visible pause.
+  test("stale active goal with zero turns and no assistant → true", () => {
+    const s = state({ created_at: NOW - GoalPrompts.FRESHNESS_THRESHOLD - 1 })
+    expect(GoalLoop.isStaleZombie(s, false, NOW)).toBe(true)
+  })
+
+  // §10.4 — fresh goal: created within the threshold. Must NOT pause even with
+  // no assistant message — the initial kick may just be slow, not failed.
+  test("fresh active goal (within threshold) → false", () => {
+    const s = state({ created_at: NOW - 1000 })
+    expect(GoalLoop.isStaleZombie(s, false, NOW)).toBe(false)
+  })
+
+  // Exactly at the threshold is NOT stale (strict >).
+  test("goal exactly at threshold boundary → false (strict greater-than)", () => {
+    const s = state({ created_at: NOW - GoalPrompts.FRESHNESS_THRESHOLD })
+    expect(GoalLoop.isStaleZombie(s, false, NOW)).toBe(false)
+  })
+
+  // Has an assistant message → not orphaned, the initial kick succeeded.
+  test("stale goal but assistant message exists → false", () => {
+    const s = state({ created_at: NOW - GoalPrompts.FRESHNESS_THRESHOLD - 1 })
+    expect(GoalLoop.isStaleZombie(s, true, NOW)).toBe(false)
+  })
+
+  // Already ran continuations → turns_used > 0, not a zombie.
+  test("stale goal but turns_used > 0 → false", () => {
+    const s = state({ turns_used: 3, created_at: NOW - GoalPrompts.FRESHNESS_THRESHOLD - 1 })
+    expect(GoalLoop.isStaleZombie(s, false, NOW)).toBe(false)
+  })
+
+  // Not active (paused/done) → predicate short-circuits; pauseAndPublish would
+  // be a no-op anyway, but the guard must not fire.
+  test("paused goal → false", () => {
+    const s = state({ status: "paused", created_at: NOW - GoalPrompts.FRESHNESS_THRESHOLD - 1 })
+    expect(GoalLoop.isStaleZombie(s, false, NOW)).toBe(false)
+  })
+})
+
+// ── clearLoopFiberIf — fiber-map lifecycle contract (D4) ───────────
+//
+// GoalLoop now (a) does NOT fork/register a fiber for sessions without an
+// active goal, and (b) self-cleans each afterIdle fiber from the Goal fibers
+// Map via clearLoopFiberIf when it completes. The Map is private to Goal's
+// layer closure, so behavior is observed through interruption side effects
+// (the trackedFiber pattern from goal.test.ts).
+//
+// The three cases below pin the identity contract of clearLoopFiberIf — the
+// property that keeps a naturally-completing OLD fiber from evicting a
+// freshly-registered NEW fiber (which would silently stall the goal loop).
+
+const fiberTestLayer = Goal.layer.pipe(
+  Layer.provide(SessionStatus.defaultLayer),
+  Layer.provide(Database.defaultLayer),
+  Layer.provideMerge(EventV2Bridge.defaultLayer),
+)
+const fiberIt = testEffect(fiberTestLayer)
+
+// Forks a synthetic loop fiber that blocks forever and records whether it was
+// interrupted, awaiting a readiness signal first so the caller knows the
+// onInterrupt finalizer is installed (see AGENTS.md "Synchronizing With
+// Concurrent Work").
+const trackedFiber = () =>
+  Effect.gen(function* () {
+    const ready = yield* Deferred.make<void>()
+    const holder = { interrupted: false }
+    const fiber = yield* Effect.gen(function* () {
+      yield* Deferred.succeed(ready, undefined)
+      yield* Effect.never
+    }).pipe(
+      Effect.onInterrupt(() => Effect.sync(() => (holder.interrupted = true))),
+      Effect.forkChild,
+    )
+    yield* Deferred.await(ready)
+    return { fiber, holder }
+  })
+
+describe("Goal.clearLoopFiberIf — identity-scoped self-clean (D4)", () => {
+  // §D4.1 — clearLoopFiberIf removes the entry on identity match and, unlike
+  // clearLoopFiber, MUST NOT interrupt the fiber (it has already finished).
+  fiberIt.live("removes the entry on identity match without interrupting", () =>
+    Effect.gen(function* () {
+      const goal = yield* Goal.Service
+      const sessionID = SessionID.descending()
+      const { fiber: f1, holder: h1 } = yield* trackedFiber()
+      yield* goal.registerLoopFiber(sessionID, f1)
+      yield* goal.clearLoopFiberIf(sessionID, f1)
+
+      expect(h1.interrupted).toBe(false)
+      // Entry was removed: a second registration finds nothing to interrupt, so
+      // f1 stays uninterrupted. (If the entry had survived, registerLoopFiber
+      // would interrupt f1 and flip h1.interrupted to true.)
+      const { fiber: f2 } = yield* trackedFiber()
+      yield* goal.registerLoopFiber(sessionID, f2)
+      expect(h1.interrupted).toBe(false)
+    }),
+  )
+
+  // §D4.2 — a non-matching fiber identity is a no-op; the registered fiber
+  // stays in the Map and remains interruptible by a subsequent clearLoopFiber.
+  fiberIt.live("non-matching fiber identity leaves the entry intact", () =>
+    Effect.gen(function* () {
+      const goal = yield* Goal.Service
+      const sessionID = SessionID.descending()
+      const { fiber: f1, holder: h1 } = yield* trackedFiber()
+      yield* goal.registerLoopFiber(sessionID, f1)
+
+      const { fiber: f2 } = yield* trackedFiber()
+      yield* goal.clearLoopFiberIf(sessionID, f2)
+
+      // f1 is still registered → clearLoopFiber interrupts it.
+      yield* goal.clearLoopFiber(sessionID)
+      expect(h1.interrupted).toBe(true)
+    }),
+  )
+
+  // §D4.3 (scenario 3) — the case the identity check exists to protect: an old
+  // afterIdle fiber completes after a newer idle event has already registered a
+  // fresh fiber. The old fiber's clearLoopFiberIf MUST NOT evict the new one.
+  fiberIt.live("old fiber self-clean does not evict a newer registration", () =>
+    Effect.gen(function* () {
+      const goal = yield* Goal.Service
+      const sessionID = SessionID.descending()
+      const { fiber: f1, holder: h1 } = yield* trackedFiber()
+      yield* goal.registerLoopFiber(sessionID, f1)
+
+      // A newer idle event registers f2, interrupting f1 (registerLoopFiber
+      // semantics). The Map now holds f2.
+      const { fiber: f2, holder: h2 } = yield* trackedFiber()
+      yield* goal.registerLoopFiber(sessionID, f2)
+      expect(h1.interrupted).toBe(true)
+
+      // The old f1's self-clean fires with f1's identity — must NOT remove f2.
+      yield* goal.clearLoopFiberIf(sessionID, f1)
+
+      // f2 survived → clearLoopFiber interrupts it, proving it was still
+      // registered. Without the identity check this would have evicted f2 and
+      // h2.interrupted would stay false (silent goal-loop stall).
+      yield* goal.clearLoopFiber(sessionID)
+      expect(h2.interrupted).toBe(true)
+    }),
+  )
+})

--- a/packages/opencode/test/goal/prompts.test.ts
+++ b/packages/opencode/test/goal/prompts.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, test } from "bun:test"
+import { Schema } from "effect"
+import { GoalState } from "@/goal/state"
+import { GoalPrompts } from "@/goal/prompts"
+
+// Decode a plain object into a branded GoalState.Info so tests stay free of
+// `as any` brand casts. Decoding also exercises the optional/withDecodingDefault
+// fields (subgoals defaults to [], optional verdict/reason stay undefined).
+function mkState(overrides: Partial<{
+  goal: string
+  status: "active" | "paused" | "done"
+  turns_used: number
+  max_turns: number
+  created_at: number
+  last_turn_at: number
+  last_verdict: "done" | "continue"
+  last_reason: string
+  paused_reason: string
+  subgoals: ReadonlyArray<string>
+}>): GoalState.Info {
+  return Schema.decodeUnknownSync(GoalState.Info)({
+    goal: "ship the feature",
+    status: "active",
+    turns_used: 3,
+    max_turns: 20,
+    created_at: 1000,
+    last_turn_at: 2000,
+    last_verdict: "continue",
+    last_reason: "making progress",
+    consecutive_parse_failures: 0,
+    subgoals: [],
+    ...overrides,
+  })
+}
+
+describe("GoalPrompts.renderGoalSystemBlock (D4.1 dynamic system prompt)", () => {
+  test("active goal with subgoals renders structured live-state block", () => {
+    const block = GoalPrompts.renderGoalSystemBlock(
+      mkState({
+        goal: "Add login page",
+        status: "active",
+        turns_used: 3,
+        max_turns: 20,
+        subgoals: ["write tests", "wire route"],
+        last_verdict: "continue",
+        last_reason: "tests passing, route pending",
+      }),
+    )
+
+    expect(block).toContain("## Current Goal (autonomous loop)")
+    expect(block).toContain("Goal: Add login page")
+    expect(block).toContain("Status: active")
+    expect(block).toContain("Turns: 3/20 (17 remaining)")
+    expect(block).toContain("Subgoals:")
+    expect(block).toContain("1. write tests")
+    expect(block).toContain("2. wire route")
+    expect(block).toContain("Last judge verdict: continue — tests passing, route pending")
+  })
+
+  test("paused goal surfaces the paused reason", () => {
+    const block = GoalPrompts.renderGoalSystemBlock(
+      mkState({
+        status: "paused",
+        paused_reason: "budget exhausted",
+        turns_used: 20,
+        max_turns: 20,
+      }),
+    )
+
+    expect(block).toContain("Status: paused")
+    expect(block).toContain("Paused because: budget exhausted")
+    expect(block).toContain("Turns: 20/20 (0 remaining)")
+  })
+
+  test("goal with no subgoals reports none", () => {
+    const block = GoalPrompts.renderGoalSystemBlock(mkState({ subgoals: [] }))
+    expect(block).toContain("Subgoals: none")
+    expect(block).not.toMatch(/Subgoals:\n/)
+  })
+
+  test("goal without a prior verdict omits the judge line", () => {
+    const block = GoalPrompts.renderGoalSystemBlock(
+      mkState({ last_verdict: undefined, last_reason: undefined }),
+    )
+    expect(block).not.toContain("Last judge verdict")
+  })
+
+  test("verdict present without reason still renders the verdict", () => {
+    const block = GoalPrompts.renderGoalSystemBlock(
+      mkState({ last_verdict: "continue", last_reason: undefined }),
+    )
+    expect(block).toContain("Last judge verdict: continue")
+    expect(block).not.toContain("Last judge verdict: continue —")
+  })
+})
+
+describe("GoalPrompts.renderContinuation (D4.2 merged injection)", () => {
+  test("renders goal, turns/budget, and the autonomous-mode frame", () => {
+    const text = GoalPrompts.renderContinuation({
+      goal: "Add login page",
+      subgoals: [],
+      turnsUsed: 3,
+      maxTurns: 20,
+    })
+
+    expect(text).toContain("[Continuing toward your standing goal]")
+    expect(text).toContain("Goal: Add login page")
+    expect(text).toContain("Turns: 3/20 (17 remaining)")
+    expect(text).toContain("autonomous mode")
+    expect(text).toContain("Do not ask the user for clarification or confirmation.")
+    expect(text).toContain("Take the next concrete step.")
+  })
+
+  test("numbers subgoals when present", () => {
+    const text = GoalPrompts.renderContinuation({
+      goal: "Add login page",
+      subgoals: ["write tests", "wire route"],
+      turnsUsed: 1,
+      maxTurns: 10,
+    })
+
+    expect(text).toContain("Subgoals:")
+    expect(text).toContain("1. write tests")
+    expect(text).toContain("2. wire route")
+  })
+
+  test("omits the subgoals block when there are none", () => {
+    const text = GoalPrompts.renderContinuation({
+      goal: "Add login page",
+      subgoals: [],
+      turnsUsed: 1,
+      maxTurns: 10,
+    })
+    expect(text).not.toContain("Subgoals:")
+  })
+
+  test("labels the last judge reason when provided", () => {
+    const text = GoalPrompts.renderContinuation({
+      goal: "Add login page",
+      subgoals: [],
+      turnsUsed: 2,
+      maxTurns: 10,
+      lastJudgeReason: "needs error handling",
+    })
+    expect(text).toContain("Judge feedback: needs error handling")
+  })
+
+  test("omits the judge feedback line when no reason is given", () => {
+    const text = GoalPrompts.renderContinuation({
+      goal: "Add login page",
+      subgoals: [],
+      turnsUsed: 2,
+      maxTurns: 10,
+    })
+    expect(text).not.toContain("Judge feedback:")
+  })
+
+  test("clamps remaining turns at zero when budget exhausted", () => {
+    const text = GoalPrompts.renderContinuation({
+      goal: "Add login page",
+      subgoals: [],
+      turnsUsed: 20,
+      maxTurns: 20,
+    })
+    expect(text).toContain("Turns: 20/20 (0 remaining)")
+  })
+})

--- a/packages/opencode/test/server/httpapi-exercise/index.ts
+++ b/packages/opencode/test/server/httpapi-exercise/index.ts
@@ -1183,6 +1183,36 @@ const scenarios: Scenario[] = [
       check(stable(body) === stable(ctx.state.todos), "todos should match seeded state")
     }),
   http.protected
+    .get("/session/{sessionID}/goal", "session.goal")
+    .seeded((ctx) =>
+      Effect.gen(function* () {
+        const session = yield* ctx.session({ title: "Goal session" })
+        yield* ctx.goal(session.id, "cover session goal")
+        return { session }
+      }),
+    )
+    .at((ctx) => ({
+      path: route("/session/{sessionID}/goal", { sessionID: ctx.state.session.id }),
+      headers: ctx.headers(),
+    }))
+    .json(200, (body) => {
+      object(body)
+      check(body.goal === "cover session goal", "goal text should match seeded state")
+      check(body.status === "active", "status should be active for a freshly seeded goal")
+      check(body.turnsUsed === 0, "turnsUsed should be 0 for a freshly seeded goal")
+      check(body.maxTurns === 20, "maxTurns should be the default (20)")
+      check(Array.isArray(body.subgoals) && body.subgoals.length === 0, "subgoals should be an empty array")
+      check(!("pausedReason" in body), "pausedReason should be absent when goal is active")
+    }),
+  http.protected
+    .get("/session/{sessionID}/goal", "session.goal.absent")
+    .seeded((ctx) => ctx.session({ title: "Goalless session" }))
+    .at((ctx) => ({
+      path: route("/session/{sessionID}/goal", { sessionID: ctx.state.id }),
+      headers: ctx.headers(),
+    }))
+    .json(404, object, "status"),
+  http.protected
     .post("/session/{sessionID}/hook", "session.hook.add")
     .seeded((ctx) => ctx.session({ title: "Hook session" }))
     .at((ctx) => ({

--- a/packages/opencode/test/server/httpapi-exercise/runner.ts
+++ b/packages/opencode/test/server/httpapi-exercise/runner.ts
@@ -184,6 +184,8 @@ function withContext<A, E>(
           messages: (sessionID) =>
             run(modules.Session.Service.use((svc) => svc.messages({ sessionID }).pipe(Effect.orDie))),
           todos: (sessionID, todos) => run(modules.Todo.Service.use((svc) => svc.update({ sessionID, todos }))),
+          goal: (sessionID, goalText, maxTurns) =>
+            run(modules.Goal.Service.use((svc) => svc.set(sessionID, goalText, maxTurns))).pipe(Effect.asVoid),
           worktree: (input) => run(modules.Worktree.Service.use((svc) => svc.create(input).pipe(Effect.orDie))),
           worktreeRemove: (directory) =>
             run(modules.Worktree.Service.use((svc) => svc.remove({ directory })).pipe(Effect.ignore)),

--- a/packages/opencode/test/server/httpapi-exercise/runtime.ts
+++ b/packages/opencode/test/server/httpapi-exercise/runtime.ts
@@ -6,6 +6,7 @@ export type Runtime = {
   InstanceRef: (typeof import("../../../src/effect/instance-ref"))["InstanceRef"]
   InstanceStore: (typeof import("../../../src/project/instance-store"))["InstanceStore"]
   Session: (typeof import("../../../src/session/session"))["Session"]
+  Goal: (typeof import("../../../src/goal/goal"))["Goal"]
   Todo: (typeof import("../../../src/session/todo"))["Todo"]
   Worktree: (typeof import("../../../src/worktree"))["Worktree"]
   Project: (typeof import("../../../src/project/project"))["Project"]
@@ -27,6 +28,7 @@ export function runtime() {
     const instanceRef = await import("../../../src/effect/instance-ref")
     const instanceStore = await import("../../../src/project/instance-store")
     const session = await import("../../../src/session/session")
+    const goal = await import("../../../src/goal/goal")
     const todo = await import("../../../src/session/todo")
     const worktree = await import("../../../src/worktree")
     const project = await import("../../../src/project/project")
@@ -42,6 +44,7 @@ export function runtime() {
       InstanceRef: instanceRef.InstanceRef,
       InstanceStore: instanceStore.InstanceStore,
       Session: session.Session,
+      Goal: goal.Goal,
       Todo: todo.Todo,
       Worktree: worktree.Worktree,
       Project: project.Project,

--- a/packages/opencode/test/server/httpapi-exercise/types.ts
+++ b/packages/opencode/test/server/httpapi-exercise/types.ts
@@ -58,6 +58,7 @@ export type ScenarioContext = {
   message: (sessionID: SessionID, input?: { text?: string }) => Effect.Effect<MessageSeed>
   messages: (sessionID: SessionID) => Effect.Effect<SessionV1.WithParts[]>
   todos: (sessionID: SessionID, todos: TodoInfo[]) => Effect.Effect<void>
+  goal: (sessionID: SessionID, goalText: string, maxTurns?: number) => Effect.Effect<void>
   worktree: (input?: { name?: string }) => Effect.Effect<Worktree.Info>
   worktreeRemove: (directory: string) => Effect.Effect<void>
   llmText: (value: string) => Effect.Effect<void>

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -47,6 +47,7 @@ import { Shell } from "@opencode-ai/core/shell"
 import { Snapshot } from "../../src/snapshot"
 import { ToolRegistry } from "@/tool/registry"
 import { Dag } from "@/dag/dag"
+import { Goal } from "@/goal/goal"
 import { Truncate } from "@/tool/truncate"
 import { SettingsHook, type HookPayload } from "@/hook/settings"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
@@ -229,7 +230,10 @@ const blockingProcessor = Layer.succeed(
   }),
 )
 
-function makePrompt(input?: { mcpInstructions?: MCP.ServerInstructions[]; processor?: "blocking" }) {
+function makePrompt(input?: { mcpInstructions?: MCP.ServerInstructions[]; processor?: "blocking"; goal?: boolean }) {
+  // goal: false exercises the Goal-absent degradation path (serviceOption None)
+  const goalLayer: Layer.Layer<Goal.Service> =
+    input?.goal === false ? (Layer.empty as unknown as Layer.Layer<Goal.Service>) : Goal.defaultLayer
   const deps = Layer.mergeAll(
     hookRecorderLayer,
     Session.defaultLayer,
@@ -290,10 +294,12 @@ function makePrompt(input?: { mcpInstructions?: MCP.ServerInstructions[]; proces
     Layer.provideMerge(registry),
     Layer.provideMerge(trunc),
     Layer.provide(Instruction.defaultLayer),
+    Layer.provideMerge(goalLayer),
     Layer.provide(
       SystemPrompt.layer.pipe(
         Layer.provide(Skill.defaultLayer),
         Layer.provide(LocationServiceMap.layer),
+        Layer.provide(goalLayer),
         Layer.provide(deps),
       ),
     ),
@@ -303,11 +309,11 @@ function makePrompt(input?: { mcpInstructions?: MCP.ServerInstructions[]; proces
   )
 }
 
-function makeHttp(input?: { mcpInstructions?: MCP.ServerInstructions[]; processor?: "blocking" }) {
+function makeHttp(input?: { mcpInstructions?: MCP.ServerInstructions[]; processor?: "blocking"; goal?: boolean }) {
   return Layer.mergeAll(TestLLMServer.layer, makePrompt(input))
 }
 
-function makeHttpNoLLMServer(input?: { mcpInstructions?: MCP.ServerInstructions[]; processor?: "blocking" }) {
+function makeHttpNoLLMServer(input?: { mcpInstructions?: MCP.ServerInstructions[]; processor?: "blocking"; goal?: boolean }) {
   return makePrompt(input)
 }
 
@@ -2274,6 +2280,104 @@ it.instance("stores the slash invocation as visible text and hides the expanded 
       "Expanded command instructions:\ninspect layout",
     )
     expect(JSON.stringify(yield* llm.inputs)).toContain("Expanded command instructions")
+  }),
+)
+
+it.instance("dispatches /goal set through the Goal service and runs one loop turn", () =>
+  Effect.gen(function* () {
+    const { llm } = yield* useServerConfig(providerCfg)
+    const { prompt, sessions, chat } = yield* boot()
+    const goalSvc = yield* Goal.Service
+    yield* llm.text("working")
+
+    const result = yield* prompt.command({
+      sessionID: chat.id,
+      command: "goal",
+      arguments: "write the docs",
+    })
+    // kick dispatch returns the loop result (assistant WithParts)
+    expect(result.info.role).toBe("assistant")
+    const texts = (yield* sessions.messages({ sessionID: chat.id }))
+      .flatMap((message) => message.parts)
+      .filter((part): part is SessionV1.TextPart => part.type === "text")
+      .map((part) => part.text)
+
+    expect(texts).toContain("/goal write the docs")
+    expect(texts.some((text) => text.includes("目标已设定"))).toBe(true)
+    const state = yield* goalSvc.load(chat.id)
+    expect(state?.goal).toBe("write the docs")
+    expect(state?.status).toBe("active")
+    expect((yield* llm.inputs).length).toBe(1)
+  }),
+)
+
+it.instance("returns /goal status without running a loop turn", () =>
+  Effect.gen(function* () {
+    const { llm } = yield* useServerConfig(providerCfg)
+    const { prompt, chat } = yield* boot()
+    const goalSvc = yield* Goal.Service
+    yield* goalSvc.set(chat.id, "status probe goal")
+
+    const result = yield* prompt.command({
+      sessionID: chat.id,
+      command: "goal",
+      arguments: "status",
+    })
+    const texts = result.parts
+      .filter((part): part is SessionV1.TextPart => part.type === "text")
+      .map((part) => part.text)
+
+    expect(texts).toContain("/goal status")
+    expect(texts.some((text) => text.includes("status probe goal"))).toBe(true)
+    expect((yield* llm.inputs).length).toBe(0)
+  }),
+)
+
+it.instance("dispatches /subgoal add through the Goal service without a loop turn", () =>
+  Effect.gen(function* () {
+    const { llm } = yield* useServerConfig(providerCfg)
+    const { prompt, chat } = yield* boot()
+    const goalSvc = yield* Goal.Service
+    yield* goalSvc.set(chat.id, "goal with subgoals")
+
+    const result = yield* prompt.command({
+      sessionID: chat.id,
+      command: "subgoal",
+      arguments: "step one",
+    })
+    const texts = result.parts
+      .filter((part): part is SessionV1.TextPart => part.type === "text")
+      .map((part) => part.text)
+
+    expect(texts).toContain("/subgoal step one")
+    const state = yield* goalSvc.load(chat.id)
+    expect(state?.subgoals).toContain("step one")
+    expect((yield* llm.inputs).length).toBe(0)
+  }),
+)
+
+const noGoal = testEffect(makeHttp({ goal: false }))
+noGoal.instance("falls through to the command registry when the Goal service is absent", () =>
+  Effect.gen(function* () {
+    const { llm } = yield* useServerConfig(providerCfg)
+    const { prompt, sessions, chat } = yield* boot()
+    yield* llm.text("noop")
+
+    yield* prompt.command({
+      sessionID: chat.id,
+      command: "goal",
+      arguments: "orphan request",
+    })
+
+    const texts = (yield* sessions.messages({ sessionID: chat.id }))
+      .flatMap((message) => message.parts)
+      .filter((part): part is SessionV1.TextPart => part.type === "text")
+      .map((part) => part.text)
+    expect(texts.some((text) => text.includes("目标已设定"))).toBe(false)
+    // Positive fall-through markers: the command registry path persists the
+    // slash text and drives exactly one LLM turn (empty template expansion).
+    expect(texts).toContain("/goal orphan request")
+    expect((yield* llm.inputs).length).toBe(1)
   }),
 )
 

--- a/packages/opencode/test/tool/goal-tool.test.ts
+++ b/packages/opencode/test/tool/goal-tool.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect } from "bun:test"
+import { Effect, Layer } from "effect"
+import { Agent } from "../../src/agent/agent"
+import { Goal } from "../../src/goal/goal"
+import { GoalState } from "../../src/goal/state"
+import { GoalTool } from "../../src/tool/goal"
+import { MessageID, SessionID } from "../../src/session/schema"
+import { Truncate } from "@/tool/truncate"
+import type { Tool } from "@/tool/tool"
+import { testEffect } from "../lib/effect"
+
+// Goal.Service is INTENTIONALLY absent from this build context — it mirrors the
+// production ToolRegistry build phase (AppLayer group2), where Goal.Service (a
+// group1 Layer.mergeAll sibling) is not visible at construction. Goal is
+// provided only at execute time below, matching the production request phase.
+//
+// Before the tool-init-service-resolution fix, the goal tool captured a
+// build-phase `None` from Effect.serviceOption(Goal.Service) into a closure, so
+// the reachability assertions below would FAIL regardless of the execute-time
+// provide (the tool always returned "service unavailable"). These tests lock
+// the fixed contract: the probe resolves in execute, where Goal.Service lives.
+const it = testEffect(Layer.mergeAll(Truncate.defaultLayer, Agent.defaultLayer))
+
+function ctx(): Tool.Context {
+  return {
+    sessionID: SessionID.make("ses_goal_tool"),
+    messageID: MessageID.make("msg_goal_tool"),
+    callID: "call_goal_tool",
+    agent: "build",
+    abort: AbortSignal.any([]),
+    messages: [],
+    metadata: () => Effect.void,
+    ask: () => Effect.void,
+  }
+}
+
+const activeGoal = {
+  goal: "read the docs",
+  status: "active",
+  turns_used: 2,
+  max_turns: 20,
+  created_at: Date.now(),
+  last_turn_at: Date.now(),
+  consecutive_parse_failures: 0,
+  subgoals: [],
+} as GoalState.Info
+
+const doneGoal = { ...activeGoal, status: "done", turns_used: 3 } as GoalState.Info
+
+describe("tool.goal — service resolution phase", () => {
+  it.instance("status reaches Goal.Service when provided at execute time", () =>
+    Effect.gen(function* () {
+      const info = yield* GoalTool
+      const tool = yield* info.init()
+      const goalLayer = Layer.mock(Goal.Service, {
+        load: () => Effect.succeed(undefined),
+      })
+
+      const result = yield* tool.execute({ action: "status" }, ctx()).pipe(Effect.provide(goalLayer))
+
+      expect(result.output).not.toContain("not available in this runtime")
+      expect(result.output).toContain("No autonomous goal")
+    }),
+  )
+
+  it.instance("status renders state when an active goal is loaded", () =>
+    Effect.gen(function* () {
+      const info = yield* GoalTool
+      const tool = yield* info.init()
+      const goalLayer = Layer.mock(Goal.Service, {
+        load: () => Effect.succeed(activeGoal),
+      })
+
+      const result = yield* tool.execute({ action: "status" }, ctx()).pipe(Effect.provide(goalLayer))
+
+      expect(result.output).toContain("Goal: read the docs")
+      expect(result.output).toContain("Status: active")
+      expect(result.output).toContain("Turns: 2/20")
+    }),
+  )
+
+  it.instance("complete calls markDone and clears goal state (regression guard)", () =>
+    Effect.gen(function* () {
+      let markDoneCalls = 0
+      const info = yield* GoalTool
+      const tool = yield* info.init()
+      const goalLayer = Layer.mock(Goal.Service, {
+        load: () => Effect.succeed(activeGoal),
+        markDone: () =>
+          Effect.sync(() => {
+            markDoneCalls += 1
+            return doneGoal
+          }),
+      })
+
+      const result = yield* tool.execute({ action: "complete", reason: "docs read" }, ctx()).pipe(
+        Effect.provide(goalLayer),
+      )
+
+      expect(markDoneCalls).toBe(1)
+      expect(result.output).toContain("目标已达成")
+      expect(result.output).toContain("docs read")
+    }),
+  )
+
+  it.instance("complete refuses to complete when no active goal is loaded", () =>
+    Effect.gen(function* () {
+      const info = yield* GoalTool
+      const tool = yield* info.init()
+      const goalLayer = Layer.mock(Goal.Service, {
+        load: () => Effect.succeed(undefined),
+      })
+
+      const result = yield* tool.execute({ action: "complete", reason: "nothing to do" }, ctx()).pipe(
+        Effect.provide(goalLayer),
+      )
+
+      expect(markDoneNeverCalled(result.output))
+      expect(result.output).toContain("Cannot complete goal: no active goal")
+    }),
+  )
+
+  it.instance("status degrades gracefully when Goal.Service is absent (headless)", () =>
+    Effect.gen(function* () {
+      const info = yield* GoalTool
+      const tool = yield* info.init()
+
+      // No Goal.Service provided at execute time — e.g. a headless runtime.
+      const result = yield* tool.execute({ action: "status" }, ctx())
+
+      expect(result.output).toContain("not available in this runtime")
+    }),
+  )
+})
+
+function markDoneNeverCalled(output: string) {
+  return !output.includes("目标已达成")
+}

--- a/packages/plugin/src/tui.ts
+++ b/packages/plugin/src/tui.ts
@@ -3,6 +3,7 @@ import type {
   OpencodeClient,
   Event,
   FilePart,
+  Goal,
   LspStatus,
   McpStatus,
   Todo,
@@ -389,6 +390,7 @@ export type TuiState = {
     get: (sessionID: string) => Session | undefined
     diff: (sessionID: string) => ReadonlyArray<TuiSidebarFileItem>
     todo: (sessionID: string) => ReadonlyArray<TuiSidebarTodoItem>
+    goal: (sessionID: string) => TuiSidebarGoalItem | undefined
     messages: (sessionID: string) => ReadonlyArray<Message>
     status: (sessionID: string) => SessionStatus | undefined
     permission: (sessionID: string) => ReadonlyArray<PermissionRequest>
@@ -447,6 +449,8 @@ export type TuiSidebarMcpItem = {
 export type TuiSidebarLspItem = Pick<LspStatus, "id" | "root" | "status">
 
 export type TuiSidebarTodoItem = Pick<Todo, "content" | "status">
+
+export type TuiSidebarGoalItem = Pick<Goal, "goal" | "status" | "turnsUsed" | "maxTurns">
 
 export type TuiSidebarFileItem = {
   file: string

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -205,6 +205,8 @@ import type {
   SessionForkResponses,
   SessionGetErrors,
   SessionGetResponses,
+  SessionGoalErrors,
+  SessionGoalResponses,
   SessionHookAddErrors,
   SessionHookAddResponses,
   SessionHookListErrors,
@@ -3823,6 +3825,38 @@ export class Session2 extends HeyApiClient {
     )
     return (options?.client ?? this.client).get<SessionTodoResponses, SessionTodoErrors, ThrowOnError>({
       url: "/session/{sessionID}/todo",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Get session goal
+   *
+   * Retrieve the autonomous goal state for a session, if one is set.
+   */
+  public goal<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<SessionGoalResponses, SessionGoalErrors, ThrowOnError>({
+      url: "/session/{sessionID}/goal",
       ...options,
       ...params,
     })

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -10036,6 +10036,40 @@ export type SessionTodoResponses = {
 
 export type SessionTodoResponse = SessionTodoResponses[keyof SessionTodoResponses]
 
+export type SessionGoalData = {
+  body?: never
+  path: {
+    sessionID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/session/{sessionID}/goal"
+}
+
+export type SessionGoalErrors = {
+  /**
+   * BadRequest | InvalidRequestError
+   */
+  400: EffectHttpApiErrorBadRequest | InvalidRequestError
+  /**
+   * NotFoundError
+   */
+  404: NotFoundError
+}
+
+export type SessionGoalError = SessionGoalErrors[keyof SessionGoalErrors]
+
+export type SessionGoalResponses = {
+  /**
+   * Goal state
+   */
+  200: Goal
+}
+
+export type SessionGoalResponse = SessionGoalResponses[keyof SessionGoalResponses]
+
 export type SessionHookListData = {
   body?: never
   path: {

--- a/packages/tui/src/context/sync.tsx
+++ b/packages/tui/src/context/sync.tsx
@@ -19,6 +19,7 @@ import type {
   VcsInfo,
   SnapshotFileDiff,
   ConsoleState,
+  Goal,
   DagWorkflowSummary,
 } from "@opencode-ai/sdk/v2"
 
@@ -92,6 +93,9 @@ export const {
       todo: {
         [sessionID: string]: Todo[]
       }
+      goal: {
+        [sessionID: string]: Goal | undefined
+      }
       message: {
         [sessionID: string]: Message[]
       }
@@ -133,6 +137,7 @@ export const {
       session_status: {},
       session_diff: {},
       todo: {},
+      goal: {},
       message: {},
       part: {},
       lsp: [],
@@ -255,6 +260,14 @@ export const {
 
         case "todo.updated":
           setStore("todo", event.properties.sessionID, event.properties.todos)
+          break
+
+        case "goal.updated":
+          setStore("goal", event.properties.sessionID, event.properties.goal)
+          break
+
+        case "goal.cleared":
+          setStore("goal", event.properties.sessionID, undefined)
           break
 
         // ── DAG workflow summary ────────────────────────────────────
@@ -647,11 +660,12 @@ export const {
           const tracker = { messages: new Set<string>(), parts: new Set<string>() }
           hydratingSessions.set(sessionID, tracker)
           const task = (async () => {
-            const [session, messages, todo, diff] = await Promise.all([
+            const [session, messages, todo, diff, goal] = await Promise.all([
               sdk.client.session.get({ sessionID }, { throwOnError: true }),
               sdk.client.session.messages({ sessionID, limit: 100 }),
               sdk.client.session.todo({ sessionID }),
               sdk.client.session.diff({ sessionID }),
+              sdk.client.session.goal({ sessionID }).catch(() => ({ data: undefined })),
             ])
             setStore(
               produce((draft) => {
@@ -659,6 +673,7 @@ export const {
                 if (match.found) draft.session[match.index] = session.data!
                 if (!match.found) draft.session.splice(match.index, 0, session.data!)
                 draft.todo[sessionID] = todo.data ?? []
+                draft.goal[sessionID] = goal.data ?? undefined
                 const currentMessages = draft.message[sessionID] ?? []
                 const infos = (messages.data ?? []).flatMap((message) => {
                   if (!tracker.messages.has(message.info.id)) return [message.info]

--- a/packages/tui/src/feature-plugins/builtins.ts
+++ b/packages/tui/src/feature-plugins/builtins.ts
@@ -4,6 +4,7 @@ import HomeTips from "./home/tips"
 import SidebarContext from "./sidebar/context"
 import SidebarFiles from "./sidebar/files"
 import SidebarFooter from "./sidebar/footer"
+import SidebarGoal from "./sidebar/goal"
 import SidebarLsp from "./sidebar/lsp"
 import SidebarMcp from "./sidebar/mcp"
 import SidebarTodo from "./sidebar/todo"
@@ -29,6 +30,7 @@ export function createBuiltinPlugins(options: { experimentalEventSystem: boolean
     SidebarMcp,
     SidebarLsp,
     SidebarTodo,
+    SidebarGoal,
     SidebarFiles,
     SidebarDag,
     SidebarDagPanel,

--- a/packages/tui/src/feature-plugins/sidebar/goal.tsx
+++ b/packages/tui/src/feature-plugins/sidebar/goal.tsx
@@ -1,0 +1,50 @@
+import type { TuiPlugin, TuiPluginApi } from "@opencode-ai/plugin/tui"
+import type { BuiltinTuiPlugin } from "../builtins"
+import { createMemo, Show } from "solid-js"
+
+const id = "internal:sidebar-goal"
+
+const STATUS_LABEL: Record<string, string> = {
+  active: "进行中",
+  done: "已达成",
+  paused: "已暂停",
+}
+
+function View(props: { api: TuiPluginApi; session_id: string }) {
+  const theme = () => props.api.theme.current
+  const goal = createMemo(() => props.api.state.session.goal(props.session_id))
+
+  return (
+    <Show when={goal()}>
+      {(g) => (
+        <box>
+          <text fg={theme().text}>
+            <b>目标</b> [{STATUS_LABEL[g().status] ?? g().status}]
+          </text>
+          <text fg={theme().textMuted}>
+            {g().goal.length > 60 ? g().goal.slice(0, 57) + "..." : g().goal}
+          </text>
+          <text fg={theme().textMuted}>{`${g().turnsUsed}/${g().maxTurns} 轮`}</text>
+        </box>
+      )}
+    </Show>
+  )
+}
+
+const tui: TuiPlugin = async (api) => {
+  api.slots.register({
+    order: 150,
+    slots: {
+      sidebar_content(_ctx, props) {
+        return <View api={api} session_id={props.session_id} />
+      },
+    },
+  })
+}
+
+const plugin: BuiltinTuiPlugin = {
+  id,
+  tui,
+}
+
+export default plugin

--- a/packages/tui/src/plugin/adapters.tsx
+++ b/packages/tui/src/plugin/adapters.tsx
@@ -131,6 +131,14 @@ function stateApi(sync: ReturnType<typeof useSync>): TuiPluginApi["state"] {
       todo(sessionID) {
         return sync.data.todo[sessionID] ?? []
       },
+      goal(sessionID) {
+        const g = sync.data.goal[sessionID]
+        // SDK serializes turnsUsed/maxTurns as JSON Schema number (number | "NaN" | "Infinity");
+        // at runtime these are always finite numbers from the DB. Coerce at the boundary.
+        return g
+          ? { goal: g.goal, status: g.status, turnsUsed: Number(g.turnsUsed), maxTurns: Number(g.maxTurns) }
+          : undefined
+      },
       dag(sessionID) {
         return sync.data.dag[sessionID] ?? []
       },

--- a/packages/tui/test/cli/cmd/tui/sync-goal.test.tsx
+++ b/packages/tui/test/cli/cmd/tui/sync-goal.test.tsx
@@ -1,0 +1,100 @@
+/** @jsxImportSource @opentui/solid */
+import { describe, expect, test } from "bun:test"
+import { tmpdir } from "../../../fixture/fixture"
+import { directory, mount, wait } from "./sync-fixture"
+import type { GlobalEvent } from "@opencode-ai/sdk/v2"
+
+const sid = "ses_goal_1"
+
+function goalUpdated(overrides: Partial<{ goal: string; status: "active" | "paused" | "done"; turnsUsed: number; maxTurns: number }> = {}): GlobalEvent {
+  return {
+    directory,
+    project: "proj_test",
+    payload: {
+      id: `evt_goal_updated_${Date.now()}_${Math.random()}`,
+      type: "goal.updated",
+      properties: {
+        sessionID: sid,
+        goal: {
+          goal: overrides.goal ?? "ship the feature",
+          status: overrides.status ?? "active",
+          turnsUsed: overrides.turnsUsed ?? 0,
+          maxTurns: overrides.maxTurns ?? 20,
+          subgoals: [],
+        },
+      },
+    },
+  }
+}
+
+function goalCleared(): GlobalEvent {
+  return {
+    directory,
+    project: "proj_test",
+    payload: {
+      id: `evt_goal_cleared_${Date.now()}_${Math.random()}`,
+      type: "goal.cleared",
+      properties: { sessionID: sid },
+    },
+  }
+}
+
+describe("tui sync goal slice", () => {
+  test("goal.updated writes the goal state into store.goal[sessionID]", async () => {
+    await using tmp = await tmpdir()
+    await Bun.write(`${tmp.path}/kv.json`, "{}")
+    const { app, emit, sync } = await mount(undefined, tmp.path)
+
+    try {
+      expect(sync.data.goal[sid]).toBeUndefined()
+
+      emit(goalUpdated())
+      await wait(() => sync.data.goal[sid] !== undefined)
+
+      expect(sync.data.goal[sid]).toMatchObject({
+        goal: "ship the feature",
+        status: "active",
+        turnsUsed: 0,
+        maxTurns: 20,
+      })
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+
+  test("subsequent goal.updated events replace the slice", async () => {
+    await using tmp = await tmpdir()
+    await Bun.write(`${tmp.path}/kv.json`, "{}")
+    const { app, emit, sync } = await mount(undefined, tmp.path)
+
+    try {
+      emit(goalUpdated())
+      await wait(() => sync.data.goal[sid] !== undefined)
+
+      emit(goalUpdated({ status: "paused", turnsUsed: 3 }))
+      await wait(() => sync.data.goal[sid]?.status === "paused")
+
+      expect(sync.data.goal[sid]).toMatchObject({ status: "paused", turnsUsed: 3, goal: "ship the feature" })
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+
+  test("goal.cleared removes the slice", async () => {
+    await using tmp = await tmpdir()
+    await Bun.write(`${tmp.path}/kv.json`, "{}")
+    const { app, emit, sync } = await mount(undefined, tmp.path)
+
+    try {
+      emit(goalUpdated())
+      await wait(() => sync.data.goal[sid] !== undefined)
+
+      emit(goalCleared())
+      await wait(() => sync.data.goal[sid] === undefined)
+
+      expect(sync.data.goal[sid]).toBeUndefined()
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+})


### PR DESCRIPTION
## 动机

/goal（自主目标循环）在 DAG 化时被退役，实践中证明仍有独立价值——恢复之。基线：退役前 `826bf59d4`，忠实恢复并按当前架构适配。

## 内容

**状态管理**：goal_state 表 + load/set/pause/resume/clear/markDone/subgoals；goal.updated/goal.cleared 事件（schema manifest 从未移除）

**循环与判定**：GoalLoop idle 驱动续跑 + judge 判定 + kick dispatch + 轮次预算/暂停语义；fiber 生命周期与崩溃安全

**工具注册**：goal 工具（status/complete）入 ToolRegistry；/goal、/subgoal 命令分发（prompt.ts 早退路径，含 Goal 缺省降级回退）

**系统提示注入**：静态机制 + 实时目标状态块，Goal.defaultLayer + Goal.node 双组合系统接线（修复 round-2 发现的状态块不可达 MEDIUM）

**面**：HTTP `session.goal`（无 goal 返回 404，200 即承载 Goal，契约诚实）+ SDK Goal 类型 + TUI 侧栏/同步 reducer/水合 + exercise goal/goal 缺省场景

**测试**：goal 套件恢复 + 新增 4 个 dispatch 测试（set+kick/status/subgoal/Goal 缺省回退）+ TUI reducer 3 测试；e2e 固定 sleep 整合为论证常量

## 评审轨迹

双轴代码评审（Standards+Spec）+ 三轮 DAG 深审闭环：修复 SystemPrompt 接线、dispatch 零测试、goal 端点 200-null 类型矛盾等；R1-R10 残余全部论证处置（详见 .opencode/.dag-specs/review-parts-round3/final-audit-report.md）。

## 验证

471 opencode 测试、227 httpapi 场景、tui 8 测试、typecheck 全包、migration check 通过

## 堆叠说明

基于 #169（共享生成文件的拆分顺序）。#169 合并后请将本 PR base 改为 dev。