### PR TITLE
fix(dag): reopen completed workflow for extend past condition-skipped dependents

### DIFF
--- a/packages/core/src/dag/core/types.ts
+++ b/packages/core/src/dag/core/types.ts
@@ -96,11 +96,11 @@ export class InvalidTransitionError extends DagCoreError {
 }
 
 export class TerminalViolationError extends DagCoreError {
-  constructor(entityId: string, terminalStatus: string, attemptedStatus: string) {
+  constructor(entityId: string, terminalStatus: string, attemptedStatus: string, reason?: string) {
     super(
       ErrorCode.TERMINAL_VIOLATION,
-      `Cannot transition from terminal state: ${entityId} (${terminalStatus} -> ${attemptedStatus})`,
-      { entityId, terminalStatus, attemptedStatus },
+      `Cannot transition from terminal state: ${entityId} (${terminalStatus} -> ${attemptedStatus})${reason ? `: ${reason}` : ""}`,
+      { entityId, terminalStatus, attemptedStatus, reason },
     )
     this.name = "TerminalViolationError"
   }

--- a/packages/opencode/src/dag/dag.ts
+++ b/packages/opencode/src/dag/dag.ts
@@ -700,22 +700,49 @@ export const layer = Layer.effect(
         .map((n) => cfgById.get(n.id))
         .filter((n): n is NodeConfig => n !== undefined)
       const configuredNodes = config?.nodes ?? []
-      const hasReportingLeafCheckpoint = nodes.some(
+      // Leaf qualification runs on the RUNTIME topology, not the static config:
+      // a dependent that was skipped (condition_false / orphan_cascade) never
+      // executed, so the graph effectively ended at the checkpoint and the
+      // naturally-completed workflow may still be reopened by additive extend.
+      // Dependents that completed or failed continued the graph past the
+      // checkpoint and block the exception.
+      const executedDependents = (nodeID: string) =>
+        nodes.filter(
+          (candidate) =>
+            candidate.dependsOn.includes(nodeID)
+            && (candidate.status === NodeStatus.COMPLETED || candidate.status === NodeStatus.FAILED),
+        )
+      const checkpointCandidates = nodes.filter(
         (node) =>
           node.status === NodeStatus.COMPLETED
           && node.wakeEligible
-          && configuredNodes.some((candidate) => candidate.id === node.id)
-          && !configuredNodes.some((candidate) => candidate.depends_on.includes(node.id)),
+          && configuredNodes.some((candidate) => candidate.id === node.id),
       )
+      const hasReportingLeafCheckpoint = checkpointCandidates.some((node) => executedDependents(node.id).length === 0)
+      const addsNewNode = newNodes.some((node) => !nodes.some((existing) => existing.id === node.id))
+      const earlyCompleted = nodes.some((node) => node.errorReason === "agent_complete")
       const reopenCompleted =
         wf.status === WorkflowStatus.COMPLETED
-        && newNodes.some((node) => !nodes.some((existing) => existing.id === node.id))
+        && addsNewNode
         && hasReportingLeafCheckpoint
-        && !nodes.some((node) => node.errorReason === "agent_complete")
+        && !earlyCompleted
+      function reopenDenial(workflowStatus: string): string | undefined {
+        if (workflowStatus === WorkflowStatus.ARCHIVED) return "archived workflows are immutable — start a new workflow instead"
+        if (workflowStatus !== WorkflowStatus.COMPLETED) return "only a naturally completed workflow can be reopened — failed and cancelled workflows are immutable; start a new workflow reusing their completed outputs as static input"
+        if (!addsNewNode) return "the fragment adds no new node ids — an additive reopen requires at least one new node"
+        if (earlyCompleted) return "the workflow was completed early via control(complete); early completion stays terminal"
+        if (checkpointCandidates.length === 0) return "no wake-eligible reporting checkpoint completed the graph — only a naturally completed reporting-leaf checkpoint may be reopened"
+        const blockers = [...new Set(checkpointCandidates.flatMap((node) => executedDependents(node.id).map((dependent) => dependent.id)))]
+        return `reporting checkpoint(s) ${checkpointCandidates.map((node) => `"${node.id}"`).join(", ")} are followed by executed dependent(s) ${blockers.map((id) => `"${id}"`).join(", ")} — the graph continued past the checkpoint`
+      }
       // A terminal atomic wake may ask the parent to add the next bounded wave.
       // Keep the exception private to naturally completed additive extension;
       // an early control(complete) leaves an agent_complete marker and remains
       // terminal, as do public replan and non-additive terminal mutations.
+      if (isWorkflowTerminalStatus(wf.status as WorkflowStatus) && !reopenCompleted) {
+        const status = wf.status
+        return yield* Effect.fail(new TerminalViolationError(dagID, status, "extend", reopenDenial(status)))
+      }
       // Internal call to _replan — shares the caller's lock holding period,
       // does NOT re-acquire the per-workflow lock or go through Service.of.
       return yield* _replan(lock, dagID, { nodes: [...preserved, ...newNodes] }, reopenCompleted)

--- a/packages/opencode/src/dag/dag.ts
+++ b/packages/opencode/src/dag/dag.ts
@@ -705,16 +705,18 @@ export const layer = Layer.effect(
       // executed, so the graph effectively ended at the checkpoint and the
       // naturally-completed workflow may still be reopened by additive extend.
       // Dependents that completed or failed continued the graph past the
-      // checkpoint and block the exception.
+      // checkpoint and block the exception. Row statuses are compared as
+      // plain strings (loop.ts convention) — enum casts on read-model rows
+      // trip the lint ratchet.
       const executedDependents = (nodeID: string) =>
         nodes.filter(
           (candidate) =>
             candidate.dependsOn.includes(nodeID)
-            && (candidate.status === NodeStatus.COMPLETED || candidate.status === NodeStatus.FAILED),
+            && (candidate.status === "completed" || candidate.status === "failed"),
         )
       const checkpointCandidates = nodes.filter(
         (node) =>
-          node.status === NodeStatus.COMPLETED
+          node.status === "completed"
           && node.wakeEligible
           && configuredNodes.some((candidate) => candidate.id === node.id),
       )
@@ -722,13 +724,13 @@ export const layer = Layer.effect(
       const addsNewNode = newNodes.some((node) => !nodes.some((existing) => existing.id === node.id))
       const earlyCompleted = nodes.some((node) => node.errorReason === "agent_complete")
       const reopenCompleted =
-        wf.status === WorkflowStatus.COMPLETED
+        wf.status === "completed"
         && addsNewNode
         && hasReportingLeafCheckpoint
         && !earlyCompleted
       function reopenDenial(workflowStatus: string): string | undefined {
-        if (workflowStatus === WorkflowStatus.ARCHIVED) return "archived workflows are immutable — start a new workflow instead"
-        if (workflowStatus !== WorkflowStatus.COMPLETED) return "only a naturally completed workflow can be reopened — failed and cancelled workflows are immutable; start a new workflow reusing their completed outputs as static input"
+        if (workflowStatus === "archived") return "archived workflows are immutable — start a new workflow instead"
+        if (workflowStatus !== "completed") return "only a naturally completed workflow can be reopened — failed and cancelled workflows are immutable; start a new workflow reusing their completed outputs as static input"
         if (!addsNewNode) return "the fragment adds no new node ids — an additive reopen requires at least one new node"
         if (earlyCompleted) return "the workflow was completed early via control(complete); early completion stays terminal"
         if (checkpointCandidates.length === 0) return "no wake-eligible reporting checkpoint completed the graph — only a naturally completed reporting-leaf checkpoint may be reopened"
@@ -739,9 +741,10 @@ export const layer = Layer.effect(
       // Keep the exception private to naturally completed additive extension;
       // an early control(complete) leaves an agent_complete marker and remains
       // terminal, as do public replan and non-additive terminal mutations.
-      if (isWorkflowTerminalStatus(wf.status as WorkflowStatus) && !reopenCompleted) {
-        const status = wf.status
-        return yield* Effect.fail(new TerminalViolationError(dagID, status, "extend", reopenDenial(status)))
+      const wfTerminal =
+        wf.status === "completed" || wf.status === "failed" || wf.status === "cancelled" || wf.status === "archived"
+      if (wfTerminal && !reopenCompleted) {
+        return yield* Effect.fail(new TerminalViolationError(dagID, wf.status, "extend", reopenDenial(wf.status)))
       }
       // Internal call to _replan — shares the caller's lock holding period,
       // does NOT re-acquire the per-workflow lock or go through Service.of.

--- a/packages/opencode/src/tool/workflow.ts
+++ b/packages/opencode/src/tool/workflow.ts
@@ -278,7 +278,10 @@ export const WorkflowTool = Tool.define<
                 Effect.mapError((error) => new Error(`Invalid workflow spec ${specFile.path}: ${String(error)}`)),
                 Effect.orDie,
               )
-              const r = yield* dag.extend(params.workflow_id, spec.nodes as NodeConfig[]).pipe(Effect.orDie)
+              const r = yield* withTerminalRecovery(
+                dag.extend(params.workflow_id, spec.nodes as NodeConfig[]),
+                "Terminal workflows are immutable except for the additive-extend reopen, which requires the workflow to have completed naturally at a wake-eligible reporting checkpoint (fragment adds new node ids; no early control(complete); no executed node beyond the checkpoint — condition-skipped dependents are fine). When the reopen does not apply, recover by starting a NEW workflow spec that reuses this workflow's completed outputs as static input.",
+              ).pipe(Effect.orDie)
               return {
                 title: `Workflow extended: ${r.add.length} nodes added`,
                 output: `<workflow id="${params.workflow_id}" action="extend">\nAdded: ${r.add.join(", ")}\n</workflow>`,
@@ -312,19 +315,13 @@ export const WorkflowTool = Tool.define<
                     Effect.mapError((error) => new Error(`Invalid workflow spec ${specFile.path}: ${String(error)}`)),
                     Effect.orDie,
                   )
-                  const r = yield* dag.replan(wfId, { nodes: spec.fragment.nodes as NodeConfig[] }).pipe(
-                    // The graph raced to terminal while the fragment was being
-                    // composed (the pause-first protocol was skipped). Surface
-                    // the recovery options instead of a bare iron-law rejection.
-                    Effect.catchIf(
-                      (err): err is TerminalViolationError => err instanceof TerminalViolationError,
-                      (err) =>
-                        Effect.die(new Error(
-                          `${err.message}. The workflow reached a terminal status before the replan arrived — terminal workflows are immutable. Recover by writing a new start spec with the updated node definitions and passing its spec_path, or extend if a reporting leaf checkpoint naturally completed the graph. Next time issue control(pause) BEFORE composing the spec file.`,
-                        )),
-                    ),
-                    Effect.orDie,
-                  )
+                  // The graph raced to terminal while the fragment was being
+                  // composed (the pause-first protocol was skipped). Surface
+                  // the recovery options instead of a bare iron-law rejection.
+                  const r = yield* withTerminalRecovery(
+                    dag.replan(wfId, { nodes: spec.fragment.nodes as NodeConfig[] }),
+                    "The workflow reached a terminal status before the replan arrived — terminal workflows are immutable. Recover by writing a new start spec with the updated node definitions and passing its spec_path, or extend if a reporting leaf checkpoint naturally completed the graph. Next time issue control(pause) BEFORE composing the spec file.",
+                  ).pipe(Effect.orDie)
                   const ignored = r.ignore.length > 0 ? `\nIgnored (terminal, immutable — add replacements under new ids to retry): ${r.ignore.join(", ")}` : ""
                   return {
                     title: `Workflow replanned: +${r.add.length} -${r.cancel.length} ↻${r.restart.length}`,
@@ -406,6 +403,17 @@ function resolveSpecPath(specPath: string, directory: string, ctx: Tool.Context)
 
 function workflowSpecParseError(filepath: string, error: unknown) {
   return new Error(`Invalid workflow YAML ${filepath}: ${error instanceof Error ? error.message : String(error)}`)
+}
+
+/** Terminal-workflow rejections surface as defects carrying recovery
+ * guidance, not bare iron-law errors. Shared by the replan and extend paths. */
+function withTerminalRecovery<A>(effect: Effect.Effect<A, Error>, guidance: string) {
+  return effect.pipe(
+    Effect.catchIf(
+      (err): err is TerminalViolationError => err instanceof TerminalViolationError,
+      (err) => Effect.die(new Error(`${err.message}. ${guidance}`)),
+    ),
+  )
 }
 
 function findNodesWithoutModel(input: {

--- a/packages/opencode/test/dag/dag-wake-integration.test.ts
+++ b/packages/opencode/test/dag/dag-wake-integration.test.ts
@@ -84,6 +84,15 @@ function promptText(input: SessionPrompt.PromptInput) {
     .join("\n")
 }
 
+function waitForCompletion(store: DagStore.Interface, dagID: string, message: string) {
+  return pollWithTimeout<true, Error, never>(
+    store.getWorkflow(dagID).pipe(
+      Effect.map((workflow) => workflow?.status === "completed" ? true : undefined),
+    ),
+    message,
+  )
+}
+
 function wakeLayer(input: {
   readonly childPrompts: Queue.Queue<PromptGate>
   readonly parentPrompts: Queue.Queue<ParentPromptGate>
@@ -526,6 +535,74 @@ describe("DagLoop atomic wake integration", () => {
           ),
           "extended workflow did not complete",
         )
+      }),
+    ),
+  )
+
+  integration.live("reopens a completed workflow whose checkpoint dependents were condition-skipped", () =>
+    runWakeTest(({ dag, store, childPrompts, parentPrompts }) =>
+      Effect.gen(function* () {
+        const dagID = yield* dag.create({
+          projectID: "project-1",
+          sessionID: "ses_parent",
+          title: "Skipped-dependent checkpoint continuation",
+          config: {
+            name: "skipped-dependent-checkpoint-continuation",
+            nodes: [
+              node("checkpoint"),
+              {
+                ...node("downstream", ["checkpoint"]),
+                condition: 'checkpoint.output == "GO"',
+              },
+            ],
+          },
+        })
+
+        const checkpoint = yield* takeWithin(childPrompts, "checkpoint did not start")
+        yield* Deferred.succeed(checkpoint.release, "REVISE")
+        yield* waitForCompletion(store, dagID, "checkpoint workflow did not complete")
+        expect((yield* store.getNode(dagID, "downstream"))?.status).toBe("skipped")
+        expect((yield* store.getNode(dagID, "downstream"))?.errorReason).toBe("condition_false")
+
+        const parent = yield* takeWithin(parentPrompts, "terminal checkpoint did not wake the parent")
+        const result = yield* dag.extend(dagID, [node("repair", ["checkpoint"])])
+        expect(result.add).toEqual(["repair"])
+
+        const repair = yield* takeWithin(childPrompts, "additive repair node did not start")
+        expect(repair.title).toBe("repair")
+        expect((yield* store.getWorkflow(dagID))?.status).toBe("running")
+        expect((yield* store.getNode(dagID, "checkpoint"))?.status).toBe("completed")
+        yield* Deferred.succeed(parent.release, "success")
+        yield* Deferred.succeed(repair.release, "fixed")
+        yield* waitForCompletion(store, dagID, "extended workflow did not complete")
+      }),
+    ),
+  )
+
+  integration.live("keeps a completed workflow terminal when the graph ran past the checkpoint", () =>
+    runWakeTest(({ dag, store, childPrompts }) =>
+      Effect.gen(function* () {
+        const dagID = yield* dag.create({
+          projectID: "project-1",
+          sessionID: "ses_parent",
+          title: "Post-checkpoint completion",
+          config: {
+            name: "post-checkpoint-completion",
+            nodes: [node("checkpoint"), { ...node("downstream", ["checkpoint"]), report_to_parent: false }],
+          },
+        })
+
+        const checkpoint = yield* takeWithin(childPrompts, "checkpoint did not start")
+        yield* Deferred.succeed(checkpoint.release, "CHECK")
+        const downstream = yield* takeWithin(childPrompts, "downstream did not start")
+        yield* Deferred.succeed(downstream.release, "done")
+        yield* waitForCompletion(store, dagID, "workflow did not complete")
+
+        const error = yield* dag.extend(dagID, [node("repair", ["checkpoint"])]).pipe(
+          Effect.catch((cause: Error) => Effect.succeed(cause)),
+        )
+        if (!(error instanceof TerminalViolationError)) throw new Error("extend unexpectedly succeeded past a terminal checkpoint")
+        expect(error.message).toContain("continued past the checkpoint")
       }),
     ),
   )


### PR DESCRIPTION
## 背景（线上取证）

工作流 `dag_0343f5b05ffeOJ6UoFkgYubHl1`（session `ses_034c17efbffeMRvuJHJFz7rkln`）：agent 按文档契约（Verdict Disposal Contract：reporting leaf checkpoint 自然完成图后 extend 追加波次有效）对 completed 工作流调用 `workflow(action=extend)`，被拒 `Cannot transition from terminal state ... (completed -> replan)`。agent 并未误解 DAG——是引擎缺陷误拒，迫使它新建重复 workflow。

## 根因

`_extend.hasReportingLeafCheckpoint` 用**静态 config 拓扑**判 leaf（`!configuredNodes.some(c => c.depends_on.includes(node.id))`），忽略运行时终态。现场拓扑：checkpoint `audit-module-wave`（completed + wakeEligible + report_to_parent）的配置下游 `wire-modules` 运行时 SKIPPED(condition_false)、整链 orphan_cascade——**事实上图止于 reporting leaf**，但静态判定误认为非 leaf → `reopenCompleted=false`。projector 的 reopen 机制（`replanReopen: completed→running`）本身齐全，仅被此误判挡住。

## 修复

- leaf 判定改用**运行时拓扑**：SKIPPED（从未执行）依赖不阻塞 checkpoint 资格；COMPLETED/FAILED（实际执行过）依赖仍阻塞
- extend 拒绝归因 `extend` 而非误导性的 `replan`；`TerminalViolationError` 增加可选 reason，对所有终态（completed/failed/cancelled/archived）给出具体拒绝原因
- workflow 工具 extend 分支补恢复指引（与 replan 分支 `catchIf` 对齐）

## 测试

- 新增集成测试（dag-wake-integration）：condition-skipped 依赖可 reopen（正向，复现生产拓扑）+ 执行过的依赖阻塞 reopen（负向）
- 既有终态语义测试全部保留通过：早停 control(complete) / 非 reporting leaf / 图越过 checkpoint

## 验证

- packages/core、packages/opencode `bun typecheck` ✓（基于 main 基线）
- opencode test/dag 327 pass；core dag 测试 89 pass