### PR TITLE
fix(test): out-of-process watchdog for the httpapi exerciser

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -143,6 +143,11 @@ jobs:
         # default 6h. The full gate baseline is ~6m in CI, so 15m is generous;
         # test:httpapi:ci adds --progress/--trace to effect mode so the log
         # names the exact scenario and phase if it ever hangs again.
+        # 2026-08-05: a native-level freeze survived every in-process guard
+        # (timers die with the event loop) and burned the full 15m silently.
+        # --progress now also arms an out-of-process watchdog that SIGKILLs
+        # the runner after 120s without progress, naming the last scenario/
+        # phase — the step timeout stays as the final backstop.
         timeout-minutes: 15
         run: bun run test:httpapi:ci
 

--- a/packages/opencode/test/server/httpapi-exercise/index.ts
+++ b/packages/opencode/test/server/httpapi-exercise/index.ts
@@ -35,7 +35,8 @@ import { coverageResult, parseOptions, routeKey, routeKeys, selectedScenarios } 
 import { runScenario } from "./runner"
 import { disposeApps } from "./backend"
 import { runtime } from "./runtime"
-import { type Scenario } from "./types"
+import { type Options, type Scenario } from "./types"
+import { startProgressWatchdog } from "./watchdog"
 
 function cursor(input: Record<string, unknown>) {
   return Buffer.from(JSON.stringify(input)).toString("base64url")
@@ -2091,7 +2092,8 @@ const llmScenarios = new Set([
 
 const main = Effect.gen(function* () {
   yield* Effect.addFinalizer(() => Effect.promise(() => disposeApps()).pipe(Effect.andThen(cleanupExercisePaths)))
-  const options = parseOptions(Bun.argv.slice(2))
+  const parsed = parseOptions(Bun.argv.slice(2))
+  const options: Options = parsed.progress ? { ...parsed, heartbeat: startProgressWatchdog() } : parsed
   const modules = yield* Effect.promise(() => runtime())
   const effectRoutes = routeKeys(OpenApi.fromApi(modules.PublicApi))
   const selected = selectedScenarios(options, scenarios)
@@ -2117,6 +2119,7 @@ const main = Effect.gen(function* () {
           (scenario) =>
             Effect.gen(function* () {
               if (options.progress) console.log(`${color.dim}RUN ${routeKey(scenario)} ${scenario.name}${color.reset}`)
+              options.heartbeat?.(`RUN ${routeKey(scenario)} ${scenario.name}`)
               return yield* runScenario(options)(scenario)
             }),
           { concurrency: 1 },

--- a/packages/opencode/test/server/httpapi-exercise/runner.ts
+++ b/packages/opencode/test/server/httpapi-exercise/runner.ts
@@ -208,6 +208,7 @@ function withContext<A, E>(
 
 function trace(options: Options, scenario: ActiveScenario, phase: string) {
   return Effect.sync(() => {
+    options.heartbeat?.(`${scenario.name}: ${phase}`)
     if (!options.trace) return
     console.log(`[trace] ${scenario.name}: ${phase}`)
   })

--- a/packages/opencode/test/server/httpapi-exercise/types.ts
+++ b/packages/opencode/test/server/httpapi-exercise/types.ts
@@ -27,6 +27,8 @@ export type Options = {
   scenarioTimeout: Duration.Duration
   progress: boolean
   trace: boolean
+  /** Progress heartbeat for the out-of-process watchdog (CI only). */
+  heartbeat?: (label: string) => void
 }
 
 export type RequestSpec = {

--- a/packages/opencode/test/server/httpapi-exercise/watchdog.ts
+++ b/packages/opencode/test/server/httpapi-exercise/watchdog.ts
@@ -1,0 +1,74 @@
+import { spawn } from "bun"
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+
+// Out-of-process progress watchdog for the exerciser.
+//
+// Scenario timeouts and the bounded() cleanup guards are all timer-based —
+// they only fire while the JS event loop runs. A native hang (instance
+// dispose / tree-sitter / sqlite teardown) can freeze the loop so completely
+// that every in-process guard dies with it: the runner then emits nothing
+// until the CI step timeout (2026-08-05: 13 minutes of silence after
+// "worktree.create: shared use done"). A separate process is the only guard
+// that survives a frozen event loop.
+//
+// The runner heartbeats a file on every scenario/phase transition; the child
+// polls it, and if it goes stale the child prints the last recorded activity
+// and SIGKILLs the runner — turning a silent 15-minute freeze into a 2-minute
+// attributed failure.
+
+const WATCHDOG_SCRIPT = `
+const fs = require("node:fs")
+const pid = Number(process.env.WATCHDOG_PID)
+const file = process.env.WATCHDOG_FILE
+const timeoutMs = Number(process.env.WATCHDOG_TIMEOUT_MS)
+const pollMs = Number(process.env.WATCHDOG_POLL_MS)
+setInterval(() => {
+  let alive = true
+  try {
+    process.kill(pid, 0)
+  } catch {
+    alive = false
+  }
+  if (!alive) process.exit(0)
+  let mtime = 0
+  try {
+    mtime = fs.statSync(file).mtimeMs
+  } catch {}
+  if (!mtime || Date.now() - mtime <= timeoutMs) return
+  let last = "<none>"
+  try {
+    last = fs.readFileSync(file, "utf8")
+  } catch {}
+  console.error("[watchdog] no progress for " + Math.round((Date.now() - mtime) / 1000) + "s; last activity: " + last + " — killing pid " + pid)
+  try {
+    process.kill(pid, "SIGKILL")
+  } catch {}
+  process.exit(1)
+}, pollMs)
+`
+
+export function startProgressWatchdog(timeoutMs = 120_000, pollMs = 5_000): (label: string) => void {
+  const heartbeat = path.join(os.tmpdir(), `httpapi-exercise-heartbeat-${process.pid}`)
+  fs.writeFileSync(heartbeat, "startup")
+  const child = spawn(["bun", "-e", WATCHDOG_SCRIPT], {
+    env: {
+      ...process.env,
+      WATCHDOG_PID: String(process.pid),
+      WATCHDOG_FILE: heartbeat,
+      WATCHDOG_TIMEOUT_MS: String(timeoutMs),
+      WATCHDOG_POLL_MS: String(pollMs),
+    },
+    stdout: "inherit",
+    stderr: "inherit",
+  })
+  child.unref()
+  return (label: string) => {
+    try {
+      fs.writeFileSync(heartbeat, label)
+    } catch {
+      // A missed heartbeat only shortens the watchdog's patience margin.
+    }
+  }
+}


### PR DESCRIPTION
## 起因（2026-08-05 CI 事故）

merge #176 推 main 触发的全量 CI（run 30968399761）中，`Run HttpAPI Exerciser Gates` 在 `worktree.create: shared use done` 之后**静默卡死 13 分钟**直到步骤 15 分钟硬超时。重跑即过（同代码 40 分钟前在 dev 也全绿）——罕见 flake，非 #176 引入的回归。

## 根因分析

exerciser 现有的两层防线都是**基于定时器**的：
1. 30s 场景超时（`Effect.timeoutOrElse`）——Effect 中断无法打断阻塞在永不 settle 的原生 Promise / 卡死原生调用上的 fiber
2. 2026-07-27 事故后加的 `bounded()` 清理守卫——用 `setTimeout + Promise.race` 兜底

两层都要求 **JS 事件循环还在转**。本次卡死的形态（13 分钟零输出）说明事件循环整体冻结（实例 dispose / tree-sitter / sqlite 原生清理死锁类）——此时所有进程内守卫与事件循环同归于尽，什么都不会触发。

**能救冻结事件循环的守卫只有独立进程。**

## 修复

- runner 在每个 scenario/phase 转移时向心跳文件写最后活动（`--progress` 模式，即 CI）
- 子进程每 5s 轮询心跳；静默 120s 即打印最后的 scenario/phase 归属并 SIGKILL 主进程
- 静默 15 分钟的卡死 → 2 分钟内带归属信息的失败；步骤 15 分钟超时保留为最后兜底
- 父进程退出后看门狗子进程自行退出（探测父进程存活）

## 验证

- typecheck ✓
- worktree 场景子集（5 个）带看门狗全过，正常路径无误杀
- 合成事件循环冻结测试：3s 超时 + 1s 轮询下约 4s 被杀，输出 `[watchdog] no progress for 4s; last activity: phase-two: about to freeze — killing pid`，exit 137