### PR TITLE
fix(dag): acceptance-time template binding validation removes spawn-dead window

### DIFF
--- a/packages/core/src/plugin/command/workflow.md
+++ b/packages/core/src/plugin/command/workflow.md
@@ -444,6 +444,24 @@ error, crash-recovery loss) never justifies restarting the workflow from zero.
 Completed node outputs are durable and reusable; a full restart wastes paid
 provider work and destroys evidence the earlier nodes already earned.
 
+### Graph-action acceptance is not execution
+
+`start`, `extend`, and `control(replan)` responses confirm that a graph was
+**accepted**, not that its nodes **execute**. Acceptance-time validation does
+not resolve template placeholders or map upstream outputs — spawn-time
+contract failures (`verdict_fail`: unresolved placeholders, broken
+input_mapping, condition-expression errors) kill freshly added nodes seconds
+after a successful "Added" response, leaving a silent window where the wave
+is believed to be running. Two disciplines close the gap:
+
+- After any successful graph-carrying call, make ONE `status` read before
+  reporting nodes as running: every newly added node must have left
+  `pending` (a `child_session_id` or `running` status). An acceptance
+  receipt alone is never evidence of execution.
+- After any rejected graph-carrying call (SchemaError, validation error),
+  fix the spec AND re-issue the call in the same turn — a fixed file is not
+  a fixed operation, and the re-issue needs the same `status` verification.
+
 ## Model Assignment Strategy
 
 Workflow definitions MUST NOT specify `node.model` or

--- a/packages/opencode/src/dag/dag.ts
+++ b/packages/opencode/src/dag/dag.ts
@@ -32,6 +32,7 @@ import {
 import { unresolvedReviewOutcomes, validateReviewLifecycle } from "./review-lifecycle"
 import { conditionReference } from "./runtime/eval"
 import { unsupportedSchemaKeywords } from "./runtime/capture"
+import { placeholderKeys } from "./templates/resolve"
 
 // Re-export domain types
 export const ID = DagEvent.DagID
@@ -239,6 +240,32 @@ function conditionReferenceErrors(nodes: readonly NodeConfig[]): string[] {
   })
 }
 
+/**
+ * An inline prompt_template may only reference variables that have a binding
+ * source: static prompt_template.input keys, input_mapping target names, or —
+ * when input_mapping is omitted — the direct depends_on ids that feed the
+ * spawn-time input. Anything else is guaranteed to die at spawn (verdict_fail:
+ * Unresolved template placeholders), so rejecting at acceptance removes the
+ * "Added, then spawn-dead" silent window. `id` templates are read lazily from
+ * disk and cannot be binding-checked here; spawn-time enforcement still
+ * covers them.
+ */
+function templateBindingErrors(nodes: readonly NodeConfig[]): string[] {
+  return nodes.flatMap((node) => {
+    const template = node.prompt_template.inline
+    if (template === undefined) return []
+    const bound = new Set([
+      ...Object.keys(node.prompt_template.input ?? {}),
+      ...Object.keys(node.input_mapping ?? Object.fromEntries(node.depends_on.map((dep) => [dep, dep]))),
+    ])
+    return placeholderKeys(template)
+      .filter((key) => !bound.has(key))
+      .map((key) =>
+        `node "${node.id}" prompt_template references unbound variable "{{${key}}}" (bind it via prompt_template.input, input_mapping, or depends_on)`,
+      )
+  })
+}
+
 // The runtime validator enforces a JSON Schema subset; anything outside it is
 // inert. Warn (not reject) at create/replan so authors learn their constraint
 // won't fire before a payload silently sails past it.
@@ -369,6 +396,10 @@ export const layer = Layer.effect(
       const conditionErrors = conditionReferenceErrors(config.nodes)
       if (conditionErrors.length > 0) {
         return yield* Effect.fail(new Error(`Invalid workflow config: ${conditionErrors.join("; ")}`))
+      }
+      const bindingErrors = templateBindingErrors(config.nodes)
+      if (bindingErrors.length > 0) {
+        return yield* Effect.fail(new Error(`Invalid workflow config: ${bindingErrors.join("; ")}`))
       }
       yield* warnUnsupportedSchemaKeywords(config.nodes)
       // Enforce the total node ceiling at creation, not only on replan — the
@@ -584,15 +615,18 @@ export const layer = Layer.effect(
       // ignored by the plan and keep their immutable definitions; cancelled
       // nodes never evaluate a condition again.
       const nodeStatusById = new Map(nodes.map((n) => [n.id, n.status]))
-      const conditionErrors = conditionReferenceErrors(
-        normalizedFragment.nodes.filter((n) => {
-          if (n.cancel) return false
-          const status = nodeStatusById.get(n.id)
-          return status === undefined || !isNodeTerminalStatus(status as NodeStatus)
-        }),
-      )
+      const rerunNodes = normalizedFragment.nodes.filter((n) => {
+        if (n.cancel) return false
+        const status = nodeStatusById.get(n.id)
+        return status === undefined || !isNodeTerminalStatus(status as NodeStatus)
+      })
+      const conditionErrors = conditionReferenceErrors(rerunNodes)
       if (conditionErrors.length > 0) {
         return yield* Effect.fail(new Error(`Replan rejected: ${conditionErrors.join("; ")}`))
+      }
+      const bindingErrors = templateBindingErrors(rerunNodes)
+      if (bindingErrors.length > 0) {
+        return yield* Effect.fail(new Error(`Replan rejected: ${bindingErrors.join("; ")}`))
       }
       yield* warnUnsupportedSchemaKeywords(normalizedFragment.nodes)
 

--- a/packages/opencode/src/dag/templates/resolve.ts
+++ b/packages/opencode/src/dag/templates/resolve.ts
@@ -26,6 +26,14 @@ export interface TemplateRef {
 
 const INTERPOLATION_RE = /{{\s*([^{}]+?)\s*}}/g
 
+/** Placeholder keys appearing in a template source, deduplicated, first-seen
+ * order. Matches exactly what `interpolate` tries to resolve — the single
+ * source of truth for template syntax, shared with acceptance-time binding
+ * validation. */
+export function placeholderKeys(template: string): string[] {
+  return [...new Set([...template.matchAll(INTERPOLATION_RE)].map((match) => match[1]))]
+}
+
 /** A template id must be a single path segment (no separators, no parent refs)
  * so it cannot escape the dag-prompts directory via path traversal. */
 function isSafeTemplateId(id: string): boolean {

--- a/packages/opencode/test/dag/dag-create-validation.test.ts
+++ b/packages/opencode/test/dag/dag-create-validation.test.ts
@@ -125,3 +125,122 @@ describe("Dag.create structural validation", () => {
     )
   })
 })
+
+describe("Dag prompt_template binding validation", () => {
+  it("rejects an inline template referencing a variable with no binding source", async () => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        // Pre-fix, the graph was "Added" and every node died at spawn time
+        // (verdict_fail: Unresolved template placeholders) — a silent window
+        // where the wave looked running. Acceptance rejects it up front.
+        const error = yield* createExpectingError({
+          nodes: [{ ...node("repair"), prompt_template: { inline: "Work in {{path}}" } }],
+        })
+        expect(error.message).toContain('node "repair" prompt_template references unbound variable "{{path}}"')
+      }).pipe(Effect.scoped, Effect.provide(dagLayer)) as Effect.Effect<never>,
+    )
+  })
+
+  it("accepts when prompt_template.input binds the variable", async () => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* setupFKs()
+        const dag = yield* Dag.Service
+        const dagID = yield* dag.create({
+          projectID: Project.ID.global,
+          sessionID: "ses_create",
+          title: "binding-input",
+          config: {
+            name: "binding-input",
+            nodes: [{ ...node("repair"), prompt_template: { inline: "Work in {{path}}", input: { path: "/repo" } } }],
+          },
+        }).pipe(Effect.orDie)
+        expect(dagID.startsWith("dag")).toBe(true)
+      }).pipe(Effect.scoped, Effect.provide(dagLayer)) as Effect.Effect<never>,
+    )
+  })
+
+  it("accepts when depends_on identity binding covers the variable", async () => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* setupFKs()
+        const dag = yield* Dag.Service
+        const dagID = yield* dag.create({
+          projectID: Project.ID.global,
+          sessionID: "ses_create",
+          title: "binding-identity",
+          config: {
+            name: "binding-identity",
+            nodes: [node("explore"), { ...node("repair", ["explore"]), prompt_template: { inline: "Use {{explore}}" } }],
+          },
+        }).pipe(Effect.orDie)
+        expect(dagID.startsWith("dag")).toBe(true)
+      }).pipe(Effect.scoped, Effect.provide(dagLayer)) as Effect.Effect<never>,
+    )
+  })
+
+  it("accepts when input_mapping binds the variable", async () => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* setupFKs()
+        const dag = yield* Dag.Service
+        const dagID = yield* dag.create({
+          projectID: Project.ID.global,
+          sessionID: "ses_create",
+          title: "binding-mapping",
+          config: {
+            name: "binding-mapping",
+            nodes: [
+              node("explore"),
+              {
+                ...node("repair", ["explore"]),
+                input_mapping: { findings: "explore.output" },
+                prompt_template: { inline: "Use {{findings}}" },
+              },
+            ],
+          },
+        }).pipe(Effect.orDie)
+        expect(dagID.startsWith("dag")).toBe(true)
+      }).pipe(Effect.scoped, Effect.provide(dagLayer)) as Effect.Effect<never>,
+    )
+  })
+
+  it("does not binding-check id templates at acceptance (spawn-time enforcement covers them)", async () => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* setupFKs()
+        const dag = yield* Dag.Service
+        const dagID = yield* dag.create({
+          projectID: Project.ID.global,
+          sessionID: "ses_create",
+          title: "binding-id-template",
+          config: {
+            name: "binding-id-template",
+            nodes: [{ ...node("repair"), prompt_template: { id: "not-on-disk" } }],
+          },
+        }).pipe(Effect.orDie)
+        expect(dagID.startsWith("dag")).toBe(true)
+      }).pipe(Effect.scoped, Effect.provide(dagLayer)) as Effect.Effect<never>,
+    )
+  })
+
+  it("rejects an extend whose new node has an unbound inline placeholder", async () => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* setupFKs()
+        const dag = yield* Dag.Service
+        const dagID = yield* dag.create({
+          projectID: Project.ID.global,
+          sessionID: "ses_create",
+          title: "binding-extend",
+          config: { name: "binding-extend", nodes: [node("explore")] },
+        }).pipe(Effect.orDie)
+        const error = yield* dag.extend(dagID, [
+          { ...node("repair", ["explore"]), prompt_template: { inline: "Use {{path}}" } },
+        ]).pipe(Effect.catch((e: Error) => Effect.succeed(e)))
+        expect(error).toBeInstanceOf(Error)
+        expect((error as Error).message).toContain('Replan rejected: node "repair" prompt_template references unbound variable "{{path}}"')
+      }).pipe(Effect.scoped, Effect.provide(dagLayer)) as Effect.Effect<never>,
+    )
+  })
+})

--- a/packages/opencode/test/dag/dag-create-validation.test.ts
+++ b/packages/opencode/test/dag/dag-create-validation.test.ts
@@ -137,7 +137,7 @@ describe("Dag prompt_template binding validation", () => {
           nodes: [{ ...node("repair"), prompt_template: { inline: "Work in {{path}}" } }],
         })
         expect(error.message).toContain('node "repair" prompt_template references unbound variable "{{path}}"')
-      }).pipe(Effect.scoped, Effect.provide(dagLayer)) as Effect.Effect<never>,
+      }).pipe(Effect.scoped, Effect.provide(dagLayer)),
     )
   })
 
@@ -156,7 +156,7 @@ describe("Dag prompt_template binding validation", () => {
           },
         }).pipe(Effect.orDie)
         expect(dagID.startsWith("dag")).toBe(true)
-      }).pipe(Effect.scoped, Effect.provide(dagLayer)) as Effect.Effect<never>,
+      }).pipe(Effect.scoped, Effect.provide(dagLayer)),
     )
   })
 
@@ -175,7 +175,7 @@ describe("Dag prompt_template binding validation", () => {
           },
         }).pipe(Effect.orDie)
         expect(dagID.startsWith("dag")).toBe(true)
-      }).pipe(Effect.scoped, Effect.provide(dagLayer)) as Effect.Effect<never>,
+      }).pipe(Effect.scoped, Effect.provide(dagLayer)),
     )
   })
 
@@ -201,7 +201,7 @@ describe("Dag prompt_template binding validation", () => {
           },
         }).pipe(Effect.orDie)
         expect(dagID.startsWith("dag")).toBe(true)
-      }).pipe(Effect.scoped, Effect.provide(dagLayer)) as Effect.Effect<never>,
+      }).pipe(Effect.scoped, Effect.provide(dagLayer)),
     )
   })
 
@@ -220,7 +220,7 @@ describe("Dag prompt_template binding validation", () => {
           },
         }).pipe(Effect.orDie)
         expect(dagID.startsWith("dag")).toBe(true)
-      }).pipe(Effect.scoped, Effect.provide(dagLayer)) as Effect.Effect<never>,
+      }).pipe(Effect.scoped, Effect.provide(dagLayer)),
     )
   })
 
@@ -239,7 +239,7 @@ describe("Dag prompt_template binding validation", () => {
           { ...node("repair", ["explore"]), prompt_template: { inline: "Use {{path}}" } },
         ]).pipe(Effect.catch((e: Error) => Effect.succeed(e.message)))
         expect(errorMessage).toContain('Replan rejected: node "repair" prompt_template references unbound variable "{{path}}"')
-      }).pipe(Effect.scoped, Effect.provide(dagLayer)) as Effect.Effect<never>,
+      }).pipe(Effect.scoped, Effect.provide(dagLayer)),
     )
   })
 })

--- a/packages/opencode/test/dag/dag-create-validation.test.ts
+++ b/packages/opencode/test/dag/dag-create-validation.test.ts
@@ -235,11 +235,10 @@ describe("Dag prompt_template binding validation", () => {
           title: "binding-extend",
           config: { name: "binding-extend", nodes: [node("explore")] },
         }).pipe(Effect.orDie)
-        const error = yield* dag.extend(dagID, [
+        const errorMessage = yield* dag.extend(dagID, [
           { ...node("repair", ["explore"]), prompt_template: { inline: "Use {{path}}" } },
-        ]).pipe(Effect.catch((e: Error) => Effect.succeed(e)))
-        expect(error).toBeInstanceOf(Error)
-        expect((error as Error).message).toContain('Replan rejected: node "repair" prompt_template references unbound variable "{{path}}"')
+        ]).pipe(Effect.catch((e: Error) => Effect.succeed(e.message)))
+        expect(errorMessage).toContain('Replan rejected: node "repair" prompt_template references unbound variable "{{path}}"')
       }).pipe(Effect.scoped, Effect.provide(dagLayer)) as Effect.Effect<never>,
     )
   })

--- a/packages/opencode/test/dag/dag-wake-integration.test.ts
+++ b/packages/opencode/test/dag/dag-wake-integration.test.ts
@@ -778,7 +778,7 @@ describe("DagLoop atomic wake integration", () => {
           // (verdict_fail: Unresolved template placeholders). Acceptance-time
           // binding validation now rejects it before any node can spawn — the
           // "Added, then spawn-dead" silent window is gone.
-          const error = yield* dag.create({
+          const createError = yield* dag.create({
             projectID: "project-1",
             sessionID: "ses_parent",
             title: "Unresolved aggregate input",
@@ -793,9 +793,8 @@ describe("DagLoop atomic wake integration", () => {
                 },
               ],
             },
-          }).pipe(Effect.catch((cause: Error) => Effect.succeed(cause)))
-          expect(error).toBeInstanceOf(Error)
-          expect((error as Error).message).toContain('unbound variable "{{node-a}}"')
+          }).pipe(Effect.catch((cause: Error) => Effect.succeed(cause.message)))
+          expect(createError).toContain('unbound variable "{{node-a}}"')
           expect(yield* Queue.poll(childPrompts)).toEqual(Option.none())
         }),
       ),

--- a/packages/opencode/test/dag/dag-wake-integration.test.ts
+++ b/packages/opencode/test/dag/dag-wake-integration.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "bun:test"
+import * as fs from "node:fs/promises"
+import * as path from "node:path"
 import { Deferred, Effect, Fiber, Layer, Option, Queue } from "effect"
 import type { SessionV1 } from "@opencode-ai/core/v1/session"
 import { Database } from "@opencode-ai/core/database/database"
@@ -768,11 +770,15 @@ describe("DagLoop atomic wake integration", () => {
     ),
   )
 
-  it("fails an aggregate node before execution when template placeholders remain unresolved", async () => {
+  it("rejects an unbound inline placeholder at acceptance instead of spawning a doomed node", async () => {
     await Effect.runPromise(
-      runWakeTest(({ dag, store, childPrompts, parentPrompts }) =>
+      runWakeTest(({ dag, childPrompts }) =>
         Effect.gen(function* () {
-          const dagID = yield* dag.create({
+          // Pre-fix this graph was created and the summary node died at spawn
+          // (verdict_fail: Unresolved template placeholders). Acceptance-time
+          // binding validation now rejects it before any node can spawn — the
+          // "Added, then spawn-dead" silent window is gone.
+          const error = yield* dag.create({
             projectID: "project-1",
             sessionID: "ses_parent",
             title: "Unresolved aggregate input",
@@ -787,29 +793,69 @@ describe("DagLoop atomic wake integration", () => {
                 },
               ],
             },
-          })
-
-          const root = yield* takeWithin(childPrompts, "root node did not start")
-          yield* Deferred.succeed(root.release, "A")
-
-          yield* pollWithTimeout(
-            store.getNode(dagID, "summary").pipe(
-              Effect.map((item) => item?.status === "failed" ? item : undefined),
-            ),
-            "summary node did not fail",
-          )
-          const summary = yield* store.getNode(dagID, "summary")
-          expect(summary?.errorReason).toContain("Unresolved template placeholders")
-          expect(summary?.errorClass).toBe("verdict_fail")
-          const parent = yield* takeWithin(parentPrompts, "workflow failure did not wake the parent")
-          const wakeText = promptText(parent.input)
-          expect(wakeText).toContain('[DAG Workflow failed] Workflow "Unresolved aggregate input" has reached terminal status.')
-          expect(wakeText).toContain('Failed nodes:\n- "summary" (verdict_fail):')
-          yield* Deferred.succeed(parent.release, "success")
+          }).pipe(Effect.catch((cause: Error) => Effect.succeed(cause)))
+          expect(error).toBeInstanceOf(Error)
+          expect((error as Error).message).toContain('unbound variable "{{node-a}}"')
           expect(yield* Queue.poll(childPrompts)).toEqual(Option.none())
         }),
       ),
     )
+  })
+
+  it("fails an id-template node at spawn and wakes the parent when placeholders remain unresolved", async () => {
+    // Acceptance-time binding validation only covers inline templates; id
+    // templates are read lazily from disk, so the spawn-time guard (and its
+    // failure wake) stays live for them. Exercise that path with a real
+    // template file carrying an unbound placeholder.
+    const templateDir = path.join(process.cwd(), ".opencode", "dag-prompts")
+    const templateFile = path.join(templateDir, "wake-unbound-fixture.md")
+    await fs.mkdir(templateDir, { recursive: true })
+    await fs.writeFile(templateFile, "汇总结果：{{never-bound}}")
+    try {
+      await Effect.runPromise(
+        runWakeTest(({ dag, store, childPrompts, parentPrompts }) =>
+          Effect.gen(function* () {
+            const dagID = yield* dag.create({
+              projectID: "project-1",
+              sessionID: "ses_parent",
+              title: "Unresolved aggregate input",
+              config: {
+                name: "unresolved-aggregate-input",
+                nodes: [
+                  node("node-a"),
+                  {
+                    ...node("summary", ["node-a"]),
+                    input_mapping: {},
+                    prompt_template: { id: "wake-unbound-fixture" },
+                  },
+                ],
+              },
+            })
+
+            const root = yield* takeWithin(childPrompts, "root node did not start")
+            yield* Deferred.succeed(root.release, "A")
+
+            yield* pollWithTimeout(
+              store.getNode(dagID, "summary").pipe(
+                Effect.map((item) => item?.status === "failed" ? item : undefined),
+              ),
+              "summary node did not fail",
+            )
+            const summary = yield* store.getNode(dagID, "summary")
+            expect(summary?.errorReason).toContain("Unresolved template placeholders")
+            expect(summary?.errorClass).toBe("verdict_fail")
+            const parent = yield* takeWithin(parentPrompts, "workflow failure did not wake the parent")
+            const wakeText = promptText(parent.input)
+            expect(wakeText).toContain('[DAG Workflow failed] Workflow "Unresolved aggregate input" has reached terminal status.')
+            expect(wakeText).toContain('Failed nodes:\n- "summary" (verdict_fail):')
+            yield* Deferred.succeed(parent.release, "success")
+            expect(yield* Queue.poll(childPrompts)).toEqual(Option.none())
+          }),
+        ),
+      )
+    } finally {
+      await fs.rm(templateFile, { force: true })
+    }
   })
 
   it("does not block a second workflow's downstream scheduling on a parent wake", async () => {


### PR DESCRIPTION
## 问题

start/extend/replan 接受期只做结构校验，不解析模板占位符。引用了无绑定来源变量（不在 `prompt_template.input` / `input_mapping` / `depends_on` identity 中）的 inline 模板会被正常接受（API 返回 Added），随后全部节点在 spawn 时以 `verdict_fail: Unresolved template placeholders` 死亡——留下"以为在跑、实际已死"的静默窗口（两次真实事故均为 inline 模板）。

## 修复

- `dag.ts`：`templateBindingErrors` 校验器与 `conditionReferenceErrors` 并列，接入 create 与 replan/extend 接受路径（extend 经 _replan 汇入；replan 沿用"实际会(重)跑节点"过滤器）。无绑定变量 → 当场拒绝整个调用，错误信息指名 node 与 `{{变量}}`
- `templates/resolve.ts`：导出 `placeholderKeys`——占位符提取的单一事实来源，接受期与 spawn 期语义同源
- 已知不对称：`id` 模板从磁盘惰性读取，接受期无目录上下文，仍由 spawn 期兜底（注释与测试中显式记录）

## 测试

- `dag-create-validation.test.ts` +6：拒绝无绑定变量（复刻事故形态）/ input 覆盖 / depends_on identity / input_mapping / id 模板跳过接受期检查 / extend 拒绝
- `dag-wake-integration.test.ts`：原 spawn 期失败测试改写为两段——接受期新契约断言 + 经真实模板夹具保留 spawn 期兜底与失败唤醒覆盖
- dag 全量 334 pass / 0 fail；typecheck clean；core command 测试 16/16

## 附带

`workflow.md` 新增编排纪律节 "Graph-action acceptance is not execution"：接受回执不构成执行证据（start/extend 后必须 status 核验）、被拒调用必须同回合重发——引擎修完后该纪律退化为兜底。