### PR TITLE
test(goal): replace subscription settle sleeps

### DIFF
--- a/.scratch/batch-b/issues/04-f3-subscription-readiness.md
+++ b/.scratch/batch-b/issues/04-f3-subscription-readiness.md
@@ -5,10 +5,18 @@
 **Evidence:** `.scratch/batch-b/evidence.md#f3--固定订阅-settle-sleep`
 **Branch:** `test/goal-readiness`
 **Blocked by:** None（03 已完成；代码写集独立）
-**Status:** ready-for-agent
+**Status:** closed
 
-- [ ] 先证明每个 sleep 等待的具体事件/状态，不用另一个超时数值替换 200ms
-- [ ] 8 个固定 settle sleeps 全部删除或由同一确定性同步机制取代
-- [ ] 默认不改生产行为；确需生产 readiness 信号时先在票内写明边界
-- [ ] 目标测试连续运行至少 5 次稳定绿色
-- [ ] 在 `packages/opencode` 运行目标测试与 `bun typecheck`
+- [x] 先证明每个 sleep 等待的具体事件/状态，不用另一个超时数值替换 200ms
+- [x] 8 个固定 settle sleeps 全部删除或由同一确定性同步机制取代
+- [x] 默认不改生产行为；确需生产 readiness 信号时先在票内写明边界
+- [x] 目标测试连续运行至少 5 次稳定绿色
+- [x] 在 `packages/opencode` 运行目标测试与 `bun typecheck`
+
+## 完成证据
+
+- Commit: `f77106bc03b5c4ec6816dd82d9bba8485974f790`（`test(goal): replace subscription settle sleeps`）
+- PR: [#195](https://github.com/LeXwDeX/OpenCode-GraphAgent/pull/195) → `dev`
+- TDD: 首场景保留 200ms sleep 时基线绿色；删除同步点后首次 idle 被漏掉，`judge call 1` 未触发；加入一次 `Effect.yieldNow` 后恢复绿色，再机械推广到其余 7 处。
+- 验证：目标文件连续 5 次全绿（每次 8/8）；`packages/opencode` 的 `bun typecheck` 通过；提交钩子 lint 0 error、全仓 typecheck 29/29。
+- 范围：旧常量与 8 个固定 sleep 全部消失；生产代码零 diff。

--- a/.scratch/batch-b/issues/05-f4-type-safe-dag-store-fixtures.md
+++ b/.scratch/batch-b/issues/05-f4-type-safe-dag-store-fixtures.md
@@ -4,8 +4,8 @@
 
 **Evidence:** `.scratch/batch-b/evidence.md#f4--dagstore-双重断言`
 **Branch:** `test/dag-store-fixtures`
-**Blocked by:** 04（批次串行；代码写集独立）
-**Status:** blocked
+**Blocked by:** None（04 已完成；代码写集独立）
+**Status:** ready-for-agent
 
 - [ ] 两处双重断言都消失，不能只修原评审记录的第一处
 - [ ] fixture 缺少/签名漂移的方法能在 typecheck 时暴露

--- a/packages/opencode/test/goal/e2e-loop.test.ts
+++ b/packages/opencode/test/goal/e2e-loop.test.ts
@@ -36,11 +36,9 @@ const captureEvents = (events: EventV2Bridge.Service["Service"]) =>
 // Scripted assistant response — afterIdle extracts its text as the judge input.
 const assistantText = "I have made progress on the feature."
 // GoalLoop.init forks the idle-event subscription (loop.ts Effect.forkScoped).
-// No observable latch exists for stream-subscription registration, so the only
-// sync point before publishing the first idle event is this bounded fork-window
-// wait. Kept intentionally: replacing it needs a subscribe-ready signal in
-// EventV2Bridge (production change, out of scope for test hygiene).
-const SUBSCRIPTION_SETTLE_MS = 200
+// Each scenario yields one scheduler turn before its first idle publish so that
+// fiber can acquire the PubSub subscription. No business event exists yet, so
+// outcome completion remains separately observed through public state/events.
 const mkAssistant = () =>
   ({
     info: { role: "assistant", time: { created: Date.now() } },
@@ -141,9 +139,9 @@ describe("GoalLoop end-to-end — continue → done lifecycle (P2b)", () => {
       yield* loop.init()
       const sid = SessionID.descending()
       yield* goal.set(sid, "ship the feature", 10)
-      // Let the idle subscription finish wiring (InstanceState is built on the
-      // first init) before publishing, so the first idle event is not missed.
-      yield* Effect.sleep(SUBSCRIPTION_SETTLE_MS)
+      // Give the forkScoped idle subscriber one scheduler turn to acquire its
+      // PubSub subscription. Business completion is observed below.
+      yield* Effect.yieldNow
 
       // ── Turn 1: idle → judge(continue) → continuation prompt ──
       yield* events.publish(SessionStatus.Event.Status, { sessionID: sid, status: { type: "idle" } })
@@ -231,8 +229,7 @@ describe("GoalLoop — continuation dispatch failure → recoverable pause (D1)"
       yield* loop.init()
       const sid = SessionID.descending()
       yield* goal.set(sid, "ship the feature", 10)
-      // Let the idle subscription wire (InstanceState builds on first init).
-      yield* Effect.sleep(SUBSCRIPTION_SETTLE_MS)
+      yield* Effect.yieldNow
 
       // idle → judge(continue) → continuation prompt fails → catchCause → pause
       yield* events.publish(SessionStatus.Event.Status, { sessionID: sid, status: { type: "idle" } })
@@ -267,7 +264,7 @@ describe("GoalLoop — continuation dispatch failure → recoverable pause (D1)"
       yield* loop.init()
       const sid = SessionID.descending()
       yield* goal.set(sid, "ship the feature", 10)
-      yield* Effect.sleep(SUBSCRIPTION_SETTLE_MS)
+      yield* Effect.yieldNow
       yield* events.publish(SessionStatus.Event.Status, { sessionID: sid, status: { type: "idle" } })
       yield* pollWithTimeout(
         Effect.gen(function* () {
@@ -332,7 +329,7 @@ describe("GoalLoop — no assistant in window → visible pause (branch 1)", () 
       yield* loop.init()
       const sid = SessionID.descending()
       yield* goal.set(sid, "ship the feature", 10)
-      yield* Effect.sleep(SUBSCRIPTION_SETTLE_MS)
+      yield* Effect.yieldNow
 
       yield* events.publish(SessionStatus.Event.Status, { sessionID: sid, status: { type: "idle" } })
       yield* pollWithTimeout(
@@ -400,7 +397,7 @@ describe("GoalLoop — empty assistant text → synthetic continue, no stall (br
       yield* loop.init()
       const sid = SessionID.descending()
       yield* goal.set(sid, "ship the feature", 10)
-      yield* Effect.sleep(SUBSCRIPTION_SETTLE_MS)
+      yield* Effect.yieldNow
 
       yield* events.publish(SessionStatus.Event.Status, { sessionID: sid, status: { type: "idle" } })
       // The synthetic continue dispatches a continuation prompt (non-noReply).
@@ -477,7 +474,7 @@ describe("GoalLoop — status changed during judge → visible pause (branch 3)"
       // busy. The raw idle-event publish below drives afterIdle WITHOUT
       // touching the status map, so the busy entry persists.
       yield* status.set(sid, { type: "busy" })
-      yield* Effect.sleep(SUBSCRIPTION_SETTLE_MS)
+      yield* Effect.yieldNow
 
       yield* events.publish(SessionStatus.Event.Status, { sessionID: sid, status: { type: "idle" } })
       yield* pollWithTimeout(
@@ -558,7 +555,7 @@ describe("GoalLoop — continuation interrupted → no pause, goal stays active 
       yield* loop.init()
       const sid = SessionID.descending()
       yield* goal.set(sid, "ship the feature", 10)
-      yield* Effect.sleep(SUBSCRIPTION_SETTLE_MS)
+      yield* Effect.yieldNow
 
       // Turn 1: idle → judge(continue) → continuation fails with interrupt →
       // branch 4: log + return, NO pause.
@@ -608,7 +605,7 @@ describe("GoalLoop — continuation interrupted → no pause, goal stays active 
       yield* loop.init()
       const sid = SessionID.descending()
       yield* goal.set(sid, "ship the feature", 10)
-      yield* Effect.sleep(SUBSCRIPTION_SETTLE_MS)
+      yield* Effect.yieldNow
 
       // idle → judge(continue) → continuation fails with an anonymous interrupt
       // → branch 4: log + return, NO pause (the F1 fix; old code paused here).


### PR DESCRIPTION
## Summary

- replace all eight fixed 200 ms subscription-settle sleeps with one deterministic Effect scheduler yield
- keep synchronization at the public GoalLoop/EventV2Bridge seam with no production-code changes
- document that the yield only lets the forkScoped subscriber acquire its PubSub subscription; business completion remains observed separately

## TDD evidence

- baseline first lifecycle scenario: passed with the existing 200 ms sleep
- red mutation: removing readiness synchronization missed the first idle event; judge call 1 never fired
- green: one Effect.yieldNow restored the scenario, then the same change was applied to the remaining seven sites

## Validation

- target file passed five consecutive full runs (8/8 each)
- bun typecheck from packages/opencode
- commit hooks: lint 0 errors and monorepo typecheck 29/29