### PR TITLE
feat(config): add remote config LKG

### DIFF
--- a/.scratch/batch-b/config-lkg-spec.md
+++ b/.scratch/batch-b/config-lkg-spec.md
@@ -243,27 +243,27 @@ URL 用 WHATWG `URL` 规范化：清除不会随 HTTP 请求发送的 fragment�
 <!-- BEGIN artifact: tasks.md -->
 ## 1. 红灯：锁定外部行为
 
-- [ ] 1.1 在 `packages/opencode/test/config/wellknown-offline.test.ts` 增加两跳在线成功写入、换实例后第一跳/第二跳 transport 与非认证 body 失败使用 LKG 的场景，并先运行目标文件确认新断言因 LKG 尚未实现而失败；对应[在线成功后写入并可离线复用](specs/remote-config-lkg/spec.md#scenario-在线成功后写入并可离线复用)与[允许降级回退](specs/remote-config-lkg/spec.md#scenario-transport-或非认证不可用状态回退)。
-- [ ] 1.2 在同一集成测试预置可用 LKG，再覆盖 401、403、HTML login、合法 JSON 的 well-known schema 错误、第二跳非对象和最终 `ConfigV1.Info` decode 错误；逐项断言硬失败、未使用/未覆盖 LKG，对应[401/403](specs/remote-config-lkg/spec.md#scenario-401-或-403-不回退)、[HTML](specs/remote-config-lkg/spec.md#scenario-html-登录页不回退)与[schema decode](specs/remote-config-lkg/spec.md#scenario-schema-decode-错误不回退)。
-- [ ] 1.3 在同一集成测试加入缺失、空、损坏和超旧缓存；断言第一跳保持 warn + skip、本地配置可用，第二跳保持内嵌 config 合并，超旧记录仍使用且只给安全年龄诊断；不得改写现有降级分支的结果。
-- [ ] 1.4 新建 `packages/opencode/test/config/remote-lkg.test.ts`，用隔离 cache 根和真实文件系统锁定 URL 规范化摘要、原始 Environment 占位符、同目录 rename、完整 envelope、POSIX `0600`、并发完整性，并用最窄 rename 故障注入锁定失败更新后旧 LKG 仍可读。
-- [ ] 1.5 在两份目标测试放置独特的 header/token/Environment/正文标记，断言文件名、key 和所有 remote-config/cache 日志不含标记，envelope 不含请求认证元数据；确认新增安全断言先红。
+- [x] 1.1 在 `packages/opencode/test/config/wellknown-offline.test.ts` 增加两跳在线成功写入、换实例后第一跳/第二跳 transport 与非认证 body 失败使用 LKG 的场景，并先运行目标文件确认新断言因 LKG 尚未实现而失败；对应[在线成功后写入并可离线复用](specs/remote-config-lkg/spec.md#scenario-在线成功后写入并可离线复用)与[允许降级回退](specs/remote-config-lkg/spec.md#scenario-transport-或非认证不可用状态回退)。
+- [x] 1.2 在同一集成测试预置可用 LKG，再覆盖 401、403、HTML login、合法 JSON 的 well-known schema 错误、第二跳非对象和最终 `ConfigV1.Info` decode 错误；逐项断言硬失败、未使用/未覆盖 LKG，对应[401/403](specs/remote-config-lkg/spec.md#scenario-401-或-403-不回退)、[HTML](specs/remote-config-lkg/spec.md#scenario-html-登录页不回退)与[schema decode](specs/remote-config-lkg/spec.md#scenario-schema-decode-错误不回退)。
+- [x] 1.3 在同一集成测试加入缺失、空、损坏和超旧缓存；断言第一跳保持 warn + skip、本地配置可用，第二跳保持内嵌 config 合并，超旧记录仍使用且只给安全年龄诊断；不得改写现有降级分支的结果。
+- [x] 1.4 新建 `packages/opencode/test/config/remote-lkg.test.ts`，用隔离 cache 根和真实文件系统锁定 URL 规范化摘要、原始 Environment 占位符、同目录 rename、完整 envelope、POSIX `0600`、并发完整性，并用最窄 rename 故障注入锁定失败更新后旧 LKG 仍可读。
+- [x] 1.5 在两份目标测试放置独特的 header/token/Environment/正文标记，断言文件名、key 和所有 remote-config/cache 日志不含标记，envelope 不含请求认证元数据；确认新增安全断言先红。
 
 ## 2. 绿灯：实现私有原子 LKG 模块
 
-- [ ] 2.1 新建 `packages/opencode/src/config/remote-lkg.ts` 并按 `src/config` 自导出规范提供窄接口：WHATWG URL 去 fragment、SHA-256 文件名、version 1 envelope decode，以及从 `Global.Path.cache/remote-config-lkg/` 读取原始 body；损坏、空和不支持版本返回可分类的不可用结果，不抛出正文。
-- [ ] 2.2 在该模块实现 best-effort 写入：目标同目录唯一临时文件以 `0600` 写完整 envelope，关闭后原子 rename，最终模式 `0600`；失败时安全告警、best-effort 清理临时文件且不触碰旧目标。
-- [ ] 2.3 保持 `writtenAt` 为合法 RFC 3339 诊断字段；读取不检查 TTL/mtime，不增加配置项、清理器、后台刷新或 TTL 扩展接口。
+- [x] 2.1 新建 `packages/opencode/src/config/remote-lkg.ts` 并按 `src/config` 自导出规范提供窄接口：WHATWG URL 去 fragment、SHA-256 文件名、version 1 envelope decode，以及从 `Global.Path.cache/remote-config-lkg/` 读取原始 body；损坏、空和不支持版本返回可分类的不可用结果，不抛出正文。
+- [x] 2.2 在该模块实现 best-effort 写入：目标同目录唯一临时文件以 `0600` 写完整 envelope，关闭后原子 rename，最终模式 `0600`；失败时安全告警、best-effort 清理临时文件且不触碰旧目标。
+- [x] 2.3 保持 `writtenAt` 为合法 RFC 3339 诊断字段；读取不检查 TTL/mtime，不增加配置项、清理器、后台刷新或 TTL 扩展接口。
 
 ## 3. 绿灯：接入当前 remote config 流程
 
-- [ ] 3.1 仅在 `packages/opencode/src/config/config.ts` 调整 `fetchRemoteJson` 附近：把 JSON 语法解析与 schema decode 分开，并将结果分类为在线成功、允许降级失败和硬失败；401/403 与 HTML/login/auth 继续使用硬认证错误，合法 JSON 的 schema/object/final-config 错误继续硬失败。
-- [ ] 3.2 well-known 与第二跳在线响应只暂存 Environment 替换前 body；完整来源通过 `loadConfig` 最终 schema 验证后才调用 LKG 写入。仅允许降级失败读取并重验 LKG；无可用 LKG 时分别复用现有“第一跳 skip 来源”和“第二跳空 fetched config”分支。
-- [ ] 3.3 把触及的 remote-config/cache 诊断限定为摘要、端点角色、失败分类和非敏感年龄；不得序列化原始 URL、底层可能回显请求的错误对象、headers、token、Environment 值或 body。
+- [x] 3.1 仅在 `packages/opencode/src/config/config.ts` 调整 `fetchRemoteJson` 附近：把 JSON 语法解析与 schema decode 分开，并将结果分类为在线成功、允许降级失败和硬失败；401/403 与 HTML/login/auth 继续使用硬认证错误，合法 JSON 的 schema/object/final-config 错误继续硬失败。
+- [x] 3.2 well-known 与第二跳在线响应只暂存 Environment 替换前 body；完整来源通过 `loadConfig` 最终 schema 验证后才调用 LKG 写入。仅允许降级失败读取并重验 LKG；无可用 LKG 时分别复用现有“第一跳 skip 来源”和“第二跳空 fetched config”分支。
+- [x] 3.3 把触及的 remote-config/cache 诊断限定为摘要、端点角色、失败分类和非敏感年龄；不得序列化原始 URL、底层可能回显请求的错误对象、headers、token、Environment 值或 body。
 
 ## 4. 验收与范围门禁
 
-- [ ] 4.1 从 `packages/opencode` 运行 `bun test test/config/remote-lkg.test.ts test/config/wellknown-offline.test.ts`，确认在线→离线、旧 LKG、auth/decode、损坏/空缓存、永不过期、key/log 安全及原子/权限场景全绿。
-- [ ] 4.2 从 `packages/opencode` 运行 `bun typecheck`；不得用 `bun run build` 代替类型门禁。
-- [ ] 4.3 检查实现 diff 只涉及 `packages/opencode/src/config/config.ts`、`packages/opencode/src/config/remote-lkg.ts` 和上述两份 config 测试；如确需测试 fixture 的最小改动须在提交说明中列出，`packages/core`、HTTP routes、SDK 生成物、依赖与既有 warn + skip 语义保持零改动。
+- [x] 4.1 从 `packages/opencode` 运行 `bun test test/config/remote-lkg.test.ts test/config/wellknown-offline.test.ts`，确认在线→离线、旧 LKG、auth/decode、损坏/空缓存、永不过期、key/log 安全及原子/权限场景全绿。
+- [x] 4.2 从 `packages/opencode` 运行 `bun typecheck`；不得用 `bun run build` 代替类型门禁。
+- [x] 4.3 检查实现 diff 只涉及 `packages/opencode/src/config/config.ts`、`packages/opencode/src/config/remote-lkg.ts` 和上述两份 config 测试；如确需测试 fixture 的最小改动须在提交说明中列出，`packages/core`、HTTP routes、SDK 生成物、依赖与既有 warn + skip 语义保持零改动。
 <!-- END artifact: tasks.md -->

--- a/.scratch/batch-b/issues/07-o1-lkg-implement.md
+++ b/.scratch/batch-b/issues/07-o1-lkg-implement.md
@@ -5,13 +5,22 @@
 **Evidence:** `.scratch/batch-b/evidence.md#o1--remote-config-last-known-good`
 **Branch:** `feat/config-lkg`
 **Blocked by:** 无（06 已关闭；OpenSpec `remote-config-lkg` 为 apply-ready）
-**Status:** ready-for-agent
+**Status:** closed
 
 - [x] 06 的 OpenSpec requirements/scenarios 已写入下方“规格入口”；实施以 tracked 镜像为稳定入口，以 local-only change 为 OpenSpec 原件
-- [ ] 在线成功后产生可复用 LKG，随后 transport/body 失败按规格回退
-- [ ] auth/HTML login/decode 失败仍保持硬失败
-- [ ] 损坏缓存不崩溃、不覆盖错误类别，且日志不含凭据
-- [ ] 在 `packages/opencode` 运行目标测试与 `bun typecheck`
+- [x] 在线成功后产生可复用 LKG，随后 transport/body 失败按规格回退
+- [x] auth/HTML login/decode 失败仍保持硬失败
+- [x] 损坏缓存不崩溃、不覆盖错误类别，且日志不含凭据
+- [x] 在 `packages/opencode` 运行目标测试与 `bun typecheck`
+
+## 实施证据
+
+- **基线/分支：** `af0be65b0831c352cad28e6a32ac1c3c883fc5d8` → `feat/config-lkg`
+- **公开 seam：** `Config.Service.get()` 的 well-known/remote-config 加载结果；持久化细节通过 `RemoteLkg.digest/read/write` 窄接口验证
+- **RED：** 在线→transport 新实例期望 `lkg/transport-model`、实际 `undefined`；持久化测试因 `@/config/remote-lkg` 不存在失败；401/403 预实现错误地返回成功
+- **GREEN：** `bun test test/config/remote-lkg.test.ts test/config/wellknown-offline.test.ts` 连续 3 次 `24 pass / 0 fail`；`bun typecheck` 绿色
+- **OpenSpec：** `remote-config-lkg` 为 `14/14`、`all_done`；`openspec validate --changes` 为 `1 passed, 0 failed`，strict change validate 为 valid；tracked 镜像 4/4 artifacts 与当前 local-only 原件逐字节一致
+- **范围：** 4 个指定代码/测试文件；无 fixture、依赖、lockfile、core、HTTP/SDK 改动
 
 ## 规格入口
 

--- a/.scratch/batch-b/issues/08-s7-recovery-invented-diagnosis.md
+++ b/.scratch/batch-b/issues/08-s7-recovery-invented-diagnosis.md
@@ -5,8 +5,8 @@
 **Method:** `/diagnosing-bugs`
 **Evidence:** `.scratch/batch-b/evidence.md#s7--recovery-invented-推断`
 **Branch:** `test/recovery-diagnosis`
-**Blocked by:** 07（批次串行）
-**Status:** blocked
+**Blocked by:** 无（07 已关闭）
+**Status:** ready-for-agent
 
 - [ ] 第一项产出是一条确定性、快速、可由 agent 重复运行且能红灯的命令；在此之前不写理论/修复
 - [ ] 症状必须包含“durable transcript 语义完成”与“reconcile 实际写 failed”，不能只单测 helper 返回 active

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -31,6 +31,7 @@ import { ConfigManaged } from "./managed"
 import { ConfigParse } from "./parse"
 import { ConfigPaths } from "./paths"
 import { ConfigPlugin } from "./plugin"
+import { RemoteLkg } from "./remote-lkg"
 import { ConfigVariable } from "./variable"
 import { Npm } from "@opencode-ai/core/npm"
 import { withTransientReadRetry } from "@/util/effect-http-client"
@@ -183,47 +184,89 @@ export const layer = Layer.effect(
 
     const readConfigFile = (filepath: string) => fs.readFileStringSafe(filepath).pipe(Effect.orDie)
 
-    const fetchRemoteJson = Effect.fnUntraced(function* <S extends Schema.Top>(
+    const readRemoteLkg = Effect.fnUntraced(function* <S extends Schema.Decoder<unknown, never>>(
+      url: string,
+      schema: S,
+      role: RemoteLkg.Role,
+    ) {
+      const cached = yield* RemoteLkg.read({ url, role })
+      if (cached.status !== "available") return undefined
+      const parsed = Schema.decodeUnknownOption(Schema.UnknownFromJsonString)(cached.body)
+      if (Option.isNone(parsed)) {
+        yield* Effect.logWarning("remote config LKG unavailable", {
+          digest: cached.digest,
+          role,
+          reason: "invalid-json",
+        })
+        return undefined
+      }
+      const data = Schema.decodeUnknownOption(schema)(parsed.value)
+      if (Option.isNone(data)) {
+        yield* Effect.logWarning("remote config LKG unavailable", {
+          digest: cached.digest,
+          role,
+          reason: "schema-decode",
+        })
+        return undefined
+      }
+      yield* Effect.logInfo("using remote config LKG", {
+        digest: cached.digest,
+        role,
+        ageSeconds: cached.ageSeconds,
+      })
+      return { data: data.value, source: "lkg" as const }
+    })
+
+    const fallbackRemoteJson = Effect.fnUntraced(function* <S extends Schema.Decoder<unknown, never>>(
+      url: string,
+      schema: S,
+      role: RemoteLkg.Role,
+      reason: "transport" | "http-status" | "body-read" | "json-syntax",
+      status?: number,
+    ) {
+      yield* Effect.logWarning(
+        reason === "body-read" || reason === "json-syntax"
+          ? "failed to read remote config, skipping source"
+          : "failed to fetch remote config, skipping source",
+        { digest: RemoteLkg.digest(url), role, reason, status },
+      )
+      return yield* readRemoteLkg(url, schema, role)
+    })
+
+    const fetchRemoteJson = Effect.fnUntraced(function* <S extends Schema.Decoder<unknown, never>>(
       url: string,
       headers: Record<string, string> | undefined,
       schema: S,
       loginOrigin: string,
+      role: RemoteLkg.Role,
     ) {
-      // Transport-level failures (DNS/connection/timeout, non-2xx status, body
-      // read failures) always degrade to a warning — an unreachable well-known
-      // source cannot crash config loading. Auth errors (RemoteAuthError) and
-      // decode failures stay hard errors: they indicate a broken credential or
-      // a malformed remote config, not an offline environment.
-      const response = yield* HttpClient.filterStatusOk(withTransientReadRetry(http))
+      const response = yield* withTransientReadRetry(http)
         .execute(
           HttpClientRequest.get(url).pipe(HttpClientRequest.acceptJson, HttpClientRequest.setHeaders(headers ?? {})),
         )
-        .pipe(
-          Effect.catch((error) =>
-            Effect.logWarning("failed to fetch remote config, skipping source", {
-              url,
-              reason: String(error),
-            }).pipe(Effect.as(undefined)),
-          ),
-        )
-      if (response === undefined) return undefined
-      const body = yield* response.text.pipe(
-        Effect.catch((error) =>
-          Effect.logWarning("failed to read remote config, skipping source", {
-            url,
-            reason: String(error),
-          }).pipe(Effect.as(undefined)),
-        ),
-      )
-      if (body === undefined) return undefined
+        .pipe(Effect.catch(() => Effect.succeed(undefined)))
+      if (response === undefined) return yield* fallbackRemoteJson(url, schema, role, "transport")
+      if (response.status === 401 || response.status === 403) {
+        return yield* Effect.die(new RemoteAuthError({ url: loginOrigin, remote: url }))
+      }
+      if (response.status < 200 || response.status >= 300) {
+        return yield* fallbackRemoteJson(url, schema, role, "http-status", response.status)
+      }
+      const body = yield* response.text.pipe(Effect.catch(() => Effect.succeed(undefined)))
+      if (body === undefined) return yield* fallbackRemoteJson(url, schema, role, "body-read")
       // An auth proxy can answer with an HTML login page at HTTP 200 (passes filterStatusOk); treat it as a re-auth error, not a decode failure.
       const contentType = (response.headers["content-type"] ?? "").toLowerCase()
       if (contentType.includes("html") || /^\s*<!doctype|^\s*<html/i.test(body)) {
         return yield* Effect.die(new RemoteAuthError({ url: loginOrigin, remote: url }))
       }
-      return yield* Schema.decodeEffect(Schema.fromJsonString(schema))(body).pipe(
-        Effect.catch((error) => Effect.die(new Error(`failed to decode remote config from ${url}: ${String(error)}`))),
+      const parsed = Schema.decodeUnknownOption(Schema.UnknownFromJsonString)(body)
+      if (Option.isNone(parsed)) return yield* fallbackRemoteJson(url, schema, role, "json-syntax")
+      const data = yield* Schema.decodeUnknownEffect(schema)(parsed.value).pipe(
+        Effect.catch(() =>
+          Effect.die(new Error(`failed to decode remote config (${RemoteLkg.digest(url)}): schema-decode`)),
+        ),
       )
+      return { data, source: "online" as const, body }
     })
 
     const loadConfig = Effect.fnUntraced(function* (
@@ -373,32 +416,58 @@ export const layer = Layer.effect(
             const url = key.replace(/\/+$/, "")
             authEnv[value.key] = value.token
             const wellknownURL = `${url}/.well-known/opencode`
-            yield* Effect.logDebug("fetching remote config", { url: wellknownURL })
-            const wellknown = yield* fetchRemoteJson(wellknownURL, undefined, ConfigV1.WellKnown, url)
+            yield* Effect.logDebug("fetching remote config", {
+              digest: RemoteLkg.digest(wellknownURL),
+              role: "well-known",
+            })
+            const wellknown = yield* fetchRemoteJson(wellknownURL, undefined, ConfigV1.WellKnown, url, "well-known")
             // Unreachable source: the warning was logged by fetchRemoteJson; skip this source entirely
             // without merging anything so the local config stays fully usable.
             if (wellknown === undefined) continue
             const remote = yield* Effect.promise(() =>
               substituteWellKnownRemoteConfig({
-                value: wellknown.remote_config,
+                value: wellknown.data.remote_config,
                 dir: url,
                 source: wellknownURL,
                 env: authEnv,
               }),
             )
-            const fetchedConfig = remote
+            const fetched = remote
               ? yield* Effect.gen(function* () {
-                  yield* Effect.logDebug("fetching remote config", { url: remote.url })
-                  const data = yield* fetchRemoteJson(remote.url, remote.headers, Schema.Json, url)
-                  if (data === undefined) return {}
-                  if (isRecord(data) && isRecord(data.config)) return data.config
-                  if (isRecord(data)) return data
+                  yield* Effect.logDebug("fetching remote config", {
+                    digest: RemoteLkg.digest(remote.url),
+                    role: "remote-config",
+                  })
+                  const hit = yield* fetchRemoteJson(remote.url, remote.headers, Schema.Json, url, "remote-config")
+                  if (hit === undefined) return { config: {} }
+                  const data = hit.data
+                  if (isRecord(data) && isRecord(data.config)) {
+                    return {
+                      config: data.config,
+                      cache:
+                        hit.source === "online"
+                          ? { url: remote.url, role: "remote-config" as const, body: hit.body }
+                          : undefined,
+                    }
+                  }
+                  if (isRecord(data)) {
+                    return {
+                      config: data,
+                      cache:
+                        hit.source === "online"
+                          ? { url: remote.url, role: "remote-config" as const, body: hit.body }
+                          : undefined,
+                    }
+                  }
                   return yield* Effect.die(
-                    new Error(`failed to decode remote config from ${remote.url}: expected object`),
+                    new Error(`failed to decode remote config (${RemoteLkg.digest(remote.url)}): expected object`),
                   )
                 })
-              : {}
-            const remoteConfig = mergeConfig(isRecord(wellknown.config) ? wellknown.config : {}, fetchedConfig)
+              : { config: {} }
+            const remoteConfig = mergeConfig(
+              isRecord(wellknown.data.config) ? wellknown.data.config : {},
+              fetched.config,
+            )
             if (!remoteConfig.$schema) remoteConfig.$schema = "https://opencode.ai/config.json"
             const source = wellknownURL
             const next = yield* loadConfig(
@@ -409,8 +478,15 @@ export const layer = Layer.effect(
               },
               authEnv,
             )
+            if (wellknown.source === "online") {
+              yield* RemoteLkg.write({ url: wellknownURL, role: "well-known", body: wellknown.body })
+            }
+            if (fetched.cache) yield* RemoteLkg.write(fetched.cache)
             yield* merge(source, next, "global")
-            yield* Effect.logDebug("loaded remote config from well-known", { url })
+            yield* Effect.logDebug("loaded remote config from well-known", {
+              digest: RemoteLkg.digest(wellknownURL),
+              role: "well-known",
+            })
           }
         }
 

--- a/packages/opencode/src/config/remote-lkg.ts
+++ b/packages/opencode/src/config/remote-lkg.ts
@@ -1,0 +1,140 @@
+export * as RemoteLkg from "./remote-lkg"
+
+import { Global } from "@opencode-ai/core/global"
+import { DateTime, Effect, Option, Schema } from "effect"
+import { chmod, rename, rm } from "fs/promises"
+import path from "path"
+import { randomUUID } from "crypto"
+
+export type Role = "well-known" | "remote-config"
+
+export type UnavailableReason =
+  | "read-failed"
+  | "empty-file"
+  | "invalid-envelope"
+  | "unsupported-version"
+  | "invalid-written-at"
+  | "empty-body"
+
+export type ReadResult =
+  | { readonly status: "missing"; readonly digest: string }
+  | { readonly status: "unavailable"; readonly digest: string; readonly reason: UnavailableReason }
+  | {
+      readonly status: "available"
+      readonly digest: string
+      readonly writtenAt: string
+      readonly ageSeconds: number
+      readonly body: string
+    }
+
+export interface ReadInput {
+  readonly url: string
+  readonly role: Role
+}
+
+export interface WriteInput extends ReadInput {
+  readonly body: string
+}
+
+type Rename = (source: string, target: string) => Promise<void>
+type WriteFailure = "write" | "rename" | "chmod"
+
+export function digest(url: string) {
+  const normalized = new URL(url)
+  normalized.hash = ""
+  return new Bun.CryptoHasher("sha256").update(normalized.href).digest("hex")
+}
+
+export function read(input: ReadInput): Effect.Effect<ReadResult> {
+  const key = digest(input.url)
+  const target = cacheFile(key)
+  return Effect.gen(function* () {
+    if (!(yield* Effect.promise(() => Bun.file(target).exists()))) return { status: "missing", digest: key }
+    const content = yield* Effect.tryPromise({
+      try: () => Bun.file(target).text(),
+      catch: () => "read-failed" as const,
+    }).pipe(Effect.catch((reason) => unavailable(input.role, key, reason)))
+    if (typeof content !== "string") return content
+    if (!content.length) return yield* unavailable(input.role, key, "empty-file")
+
+    const parsed = Schema.decodeUnknownOption(Schema.UnknownFromJsonString)(content)
+    if (Option.isNone(parsed) || !isRecord(parsed.value)) {
+      return yield* unavailable(input.role, key, "invalid-envelope")
+    }
+    if (parsed.value.version !== 1) {
+      return yield* unavailable(
+        input.role,
+        key,
+        typeof parsed.value.version === "number" ? "unsupported-version" : "invalid-envelope",
+      )
+    }
+    if (typeof parsed.value.writtenAt !== "string") {
+      return yield* unavailable(input.role, key, "invalid-envelope")
+    }
+    const writtenAt = Schema.decodeUnknownOption(Schema.DateTimeUtcFromString)(parsed.value.writtenAt)
+    if (Option.isNone(writtenAt)) return yield* unavailable(input.role, key, "invalid-written-at")
+    if (typeof parsed.value.body !== "string") return yield* unavailable(input.role, key, "invalid-envelope")
+    if (!parsed.value.body.length) return yield* unavailable(input.role, key, "empty-body")
+
+    const result: ReadResult = {
+      status: "available",
+      digest: key,
+      writtenAt: parsed.value.writtenAt,
+      ageSeconds: Math.max(0, Math.floor((Date.now() - DateTime.toEpochMillis(writtenAt.value)) / 1000)),
+      body: parsed.value.body,
+    }
+    return result
+  })
+}
+
+export function write(input: WriteInput, move: Rename = rename): Effect.Effect<boolean> {
+  const key = digest(input.url)
+  const target = cacheFile(key)
+  const temporary = path.join(path.dirname(target), `.${key}.${process.pid}.${randomUUID()}.tmp`)
+  const update = Effect.gen(function* () {
+    yield* Effect.tryPromise({
+      try: () =>
+        Bun.write(temporary, JSON.stringify({ version: 1, writtenAt: new Date().toISOString(), body: input.body }), {
+          mode: 0o600,
+          createPath: true,
+        }),
+      catch: () => "write" as const,
+    })
+    yield* Effect.tryPromise({
+      try: () => move(temporary, target),
+      catch: () => "rename" as const,
+    })
+    yield* Effect.tryPromise({
+      try: () => chmod(target, 0o600),
+      catch: () => "chmod" as const,
+    })
+    return true
+  })
+  return update.pipe(
+    Effect.catch((reason: WriteFailure) =>
+      Effect.gen(function* () {
+        yield* Effect.logWarning("failed to update remote config LKG", {
+          digest: key,
+          role: input.role,
+          reason,
+        })
+        yield* Effect.promise(() => rm(temporary, { force: true }).catch(() => undefined))
+        return false
+      }),
+    ),
+  )
+}
+
+function cacheFile(key: string) {
+  return path.join(Global.Path.cache, "remote-config-lkg", `${key}.json`)
+}
+
+function unavailable(role: Role, key: string, reason: UnavailableReason): Effect.Effect<ReadResult> {
+  return Effect.logWarning("remote config LKG unavailable", { digest: key, role, reason }).pipe(
+    Effect.as({ status: "unavailable", digest: key, reason } as const),
+  )
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}

--- a/packages/opencode/test/config/remote-lkg.test.ts
+++ b/packages/opencode/test/config/remote-lkg.test.ts
@@ -1,0 +1,190 @@
+import { expect } from "bun:test"
+import { Global } from "@opencode-ai/core/global"
+import { Effect, Layer, Schema } from "effect"
+import { logLines } from "effect/testing/TestConsole"
+import { readdir, stat } from "fs/promises"
+import path from "path"
+
+import { RemoteLkg } from "@/config/remote-lkg"
+import { testEffect } from "../lib/effect"
+
+const it = testEffect(Layer.empty)
+
+const file = (url: string) => path.join(Global.Path.cache, "remote-config-lkg", `${RemoteLkg.digest(url)}.json`)
+
+const Envelope = Schema.Struct({
+  version: Schema.Literal(1),
+  writtenAt: Schema.String,
+  body: Schema.String,
+})
+
+it.live(
+  "normalizes equivalent URLs to one stable credential-free digest",
+  Effect.sync(() => {
+    const first = RemoteLkg.digest(
+      "HTTPS://LKG-Key.Example.COM:443/path/config?QUERY_CREDENTIAL_MARKER=1#IGNORED_FRAGMENT_MARKER",
+    )
+    const second = RemoteLkg.digest("https://lkg-key.example.com/path/config?QUERY_CREDENTIAL_MARKER=1")
+
+    expect(first).toBe("5eb35456bf3eca724774dbab344826a95d8531c2c37aba3520a3dbeb3055f4b2")
+    expect(second).toBe(first)
+    expect(first).toMatch(/^[a-f0-9]{64}$/)
+    expect(first).not.toContain("QUERY_CREDENTIAL_MARKER")
+    expect(RemoteLkg.digest("https://lkg-key.example.com/path/config?different=1")).not.toBe(first)
+  }),
+)
+
+it.live(
+  "writes the exact pre-expansion body in a minimal private envelope",
+  Effect.gen(function* () {
+    const url = "https://lkg-envelope.example.com/config?QUERY_ENVELOPE_SECRET_MARKER=1"
+    const body = JSON.stringify({
+      username: "{env:TEST_TOKEN}",
+      marker: "RAW_REMOTE_BODY_MARKER",
+    })
+    const expandedSecret = "EXPANDED_ENV_SECRET_MARKER"
+    const headerSecret = "AUTHORIZATION_HEADER_SECRET_MARKER"
+
+    expect(yield* RemoteLkg.write({ url, role: "remote-config", body })).toBe(true)
+
+    const content = yield* Effect.promise(() => Bun.file(file(url)).text())
+    const unknown = Schema.decodeUnknownSync(Schema.UnknownFromJsonString)(content)
+    if (typeof unknown !== "object" || unknown === null || Array.isArray(unknown)) {
+      throw new Error("LKG envelope is not an object")
+    }
+    const envelope = Schema.decodeUnknownSync(Schema.fromJsonString(Envelope))(content)
+    expect(envelope.version).toBe(1)
+    expect(envelope.writtenAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/)
+    expect(envelope.body).toBe(body)
+    expect(Object.keys(unknown).sort()).toEqual(["body", "version", "writtenAt"])
+    expect(content).not.toContain(expandedSecret)
+    expect(content).not.toContain(headerSecret)
+    expect(path.basename(file(url))).not.toContain("QUERY_ENVELOPE_SECRET_MARKER")
+
+    if (process.platform !== "win32") {
+      expect((yield* Effect.promise(() => stat(file(url)))).mode & 0o777).toBe(0o600)
+    }
+    const digest = RemoteLkg.digest(url)
+    expect(
+      (yield* Effect.promise(() => readdir(path.dirname(file(url))))).filter((name) => name.includes(digest)),
+    ).toEqual([`${digest}.json`])
+  }),
+)
+
+it.live(
+  "publishes one complete envelope under concurrent writes",
+  Effect.gen(function* () {
+    const url = "https://lkg-concurrent.example.com/config.json"
+    const bodies = ["CONCURRENT_BODY_ALPHA", "CONCURRENT_BODY_BETA"]
+
+    yield* Effect.all(
+      bodies.map((body) => RemoteLkg.write({ url, role: "remote-config", body })),
+      { concurrency: "unbounded" },
+    )
+
+    const result = yield* RemoteLkg.read({ url, role: "remote-config" })
+    expect(result.status).toBe("available")
+    if (result.status !== "available") return
+    expect(bodies).toContain(result.body)
+    const content = yield* Effect.promise(() => Bun.file(file(url)).text())
+    expect(Schema.decodeUnknownSync(Schema.fromJsonString(Envelope))(content).body).toBe(result.body)
+  }),
+)
+
+it.live(
+  "uses a same-directory rename and preserves the old LKG when rename fails",
+  Effect.gen(function* () {
+    const url = "https://lkg-rename.example.com/config?RENAME_QUERY_SECRET_MARKER=1"
+    const calls: { source?: string; target?: string } = {}
+    expect(yield* RemoteLkg.write({ url, role: "remote-config", body: "OLD_LKG_BODY" })).toBe(true)
+
+    const updated = yield* RemoteLkg.write(
+      { url, role: "remote-config", body: "NEW_LKG_BODY_SECRET_MARKER" },
+      async (source, target) => {
+        calls.source = source
+        calls.target = target
+        throw new Error("RENAME_ERROR_SECRET_MARKER")
+      },
+    )
+
+    expect(updated).toBe(false)
+    const source = calls.source
+    const target = calls.target
+    if (!source || !target) throw new Error("rename was not attempted")
+    expect(path.dirname(source)).toBe(path.dirname(target))
+    expect(target).toBe(file(url))
+    expect(yield* Effect.promise(() => Bun.file(source).exists())).toBe(false)
+    const result = yield* RemoteLkg.read({ url, role: "remote-config" })
+    expect(result.status).toBe("available")
+    if (result.status === "available") expect(result.body).toBe("OLD_LKG_BODY")
+
+    const logs = JSON.stringify(yield* logLines)
+    expect(logs).toContain("failed to update remote config LKG")
+    expect(logs).not.toContain("RENAME_QUERY_SECRET_MARKER")
+    expect(logs).not.toContain("NEW_LKG_BODY_SECRET_MARKER")
+    expect(logs).not.toContain("RENAME_ERROR_SECRET_MARKER")
+  }),
+)
+
+it.live(
+  "classifies empty and damaged cache records without logging their content",
+  Effect.gen(function* () {
+    const cases: { name: string; content: string; reason: RemoteLkg.UnavailableReason }[] = [
+      { name: "empty-file", content: "", reason: "empty-file" },
+      { name: "invalid-envelope", content: "{CORRUPT_ENVELOPE_SECRET_MARKER", reason: "invalid-envelope" },
+      {
+        name: "unsupported-version",
+        content: JSON.stringify({ version: 2, writtenAt: "2026-08-09T00:00:00.000Z", body: "body" }),
+        reason: "unsupported-version",
+      },
+      {
+        name: "invalid-written-at",
+        content: JSON.stringify({ version: 1, writtenAt: "not-a-date", body: "body" }),
+        reason: "invalid-written-at",
+      },
+      {
+        name: "empty-body",
+        content: JSON.stringify({ version: 1, writtenAt: "2026-08-09T00:00:00.000Z", body: "" }),
+        reason: "empty-body",
+      },
+    ]
+
+    yield* Effect.forEach(
+      cases,
+      (scenario) =>
+        Effect.gen(function* () {
+          const url = `https://lkg-unavailable-${scenario.name}.example.com/config.json`
+          yield* Effect.promise(() => Bun.write(file(url), scenario.content, { mode: 0o600 }))
+          const result = yield* RemoteLkg.read({ url, role: "remote-config" })
+          expect(result.status).toBe("unavailable")
+          if (result.status === "unavailable") expect(result.reason).toBe(scenario.reason)
+        }),
+      { discard: true },
+    )
+
+    const logs = JSON.stringify(yield* logLines)
+    expect(logs).toContain("remote config LKG unavailable")
+    expect(logs).not.toContain("CORRUPT_ENVELOPE_SECRET_MARKER")
+  }),
+)
+
+it.live(
+  "returns a very old valid record without applying TTL",
+  Effect.gen(function* () {
+    const url = "https://lkg-no-ttl.example.com/config.json"
+    yield* Effect.promise(() =>
+      Bun.write(
+        file(url),
+        JSON.stringify({ version: 1, writtenAt: "2000-01-01T00:00:00.000Z", body: "VERY_OLD_VALID_BODY" }),
+        { mode: 0o600 },
+      ),
+    )
+
+    const result = yield* RemoteLkg.read({ url, role: "remote-config" })
+    expect(result.status).toBe("available")
+    if (result.status !== "available") return
+    expect(result.body).toBe("VERY_OLD_VALID_BODY")
+    expect(result.writtenAt).toBe("2000-01-01T00:00:00.000Z")
+    expect(result.ageSeconds).toBeGreaterThan(20 * 365 * 24 * 60 * 60)
+  }),
+)

--- a/packages/opencode/test/config/wellknown-offline.test.ts
+++ b/packages/opencode/test/config/wellknown-offline.test.ts
@@ -1,11 +1,14 @@
 import { expect } from "bun:test"
-import { Effect, Exit, Layer } from "effect"
-import * as TestConsole from "effect/testing/TestConsole"
+import { Effect, Exit, Layer, Schema } from "effect"
+import { logLines } from "effect/testing/TestConsole"
 import { NodeFileSystem, NodePath } from "@effect/platform-node"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { EffectFlock } from "@opencode-ai/core/util/effect-flock"
 import { FSUtil } from "@opencode-ai/core/fs-util"
+import { Global } from "@opencode-ai/core/global"
 import { HttpClient, HttpClientError, HttpClientResponse } from "effect/unstable/http"
+import { readdir } from "fs/promises"
+import path from "path"
 
 import { Config } from "@/config/config"
 import { Auth } from "../../src/auth"
@@ -13,6 +16,7 @@ import { AccountTest } from "../fake/account"
 import { AuthTest } from "../fake/auth"
 import { NpmTest } from "../fake/npm"
 import { Env } from "../../src/env"
+import { provideTmpdirInstance } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
 
 const infra = CrossSpawnSpawner.defaultLayer.pipe(
@@ -21,19 +25,19 @@ const infra = CrossSpawnSpawner.defaultLayer.pipe(
 
 const testFlock = EffectFlock.defaultLayer
 
-const wellKnownAuth = (url: string) =>
+const wellKnownAuth = (url: string, token = "test-token") =>
   Layer.mock(Auth.Service)({
     all: () =>
       Effect.succeed({
-        [url]: new Auth.WellKnown({ type: "wellknown", key: "TEST_TOKEN", token: "test-token" }),
+        [url]: new Auth.WellKnown({ type: "wellknown", key: "TEST_TOKEN", token }),
       }),
   })
 
-const configLayer = (client: HttpClient.HttpClient) =>
+const configLayer = (client: HttpClient.HttpClient, url = "https://example.com", token = "test-token") =>
   Config.layer.pipe(
     Layer.provide(testFlock),
     Layer.provide(Env.defaultLayer),
-    Layer.provide(wellKnownAuth("https://example.com")),
+    Layer.provide(wellKnownAuth(url, token)),
     Layer.provide(AccountTest.empty),
     Layer.provideMerge(infra),
     Layer.provide(NpmTest.noop),
@@ -41,7 +45,7 @@ const configLayer = (client: HttpClient.HttpClient) =>
     Layer.provideMerge(FSUtil.defaultLayer),
   )
 
-const it = (client: HttpClient.HttpClient) => testEffect(configLayer(client))
+const it = (client: HttpClient.HttpClient, url?: string, token?: string) => testEffect(configLayer(client, url, token))
 
 const json = (request: Parameters<typeof HttpClientResponse.fromWeb>[0], body: unknown, status = 200) =>
   HttpClientResponse.fromWeb(
@@ -52,6 +56,21 @@ const json = (request: Parameters<typeof HttpClientResponse.fromWeb>[0], body: u
     }),
   )
 
+const jsonText = (request: Parameters<typeof HttpClientResponse.fromWeb>[0], body: string) =>
+  HttpClientResponse.fromWeb(
+    request,
+    new Response(body, {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }),
+  )
+
+const LkgEnvelope = Schema.Struct({
+  version: Schema.Literal(1),
+  writtenAt: Schema.String,
+  body: Schema.String,
+})
+
 const transportFailure = (request: Parameters<typeof HttpClientResponse.fromWeb>[0], description: string) =>
   Effect.fail(
     new HttpClientError.HttpClientError({
@@ -59,11 +78,16 @@ const transportFailure = (request: Parameters<typeof HttpClientResponse.fromWeb>
     }),
   )
 
+const lkgFile = (digest: string) => path.join(Global.Path.cache, "remote-config-lkg", `${digest}.json`)
+
+const writeLkgFile = (digest: string, content: string) =>
+  Effect.promise(() => Bun.write(lkgFile(digest), content, { mode: 0o600 }))
+
 // Well-known endpoint unreachable (DNS/connection failure): the transport never answers.
 const unreachable = HttpClient.make((request) => transportFailure(request, "connect ECONNREFUSED"))
 
 // Well-known endpoint answers, but the remote_config URL is unreachable.
-const remoteConfigUnreachable = (seen: { wellKnown?: string; remote?: string }) =>
+const remoteConfigUnreachable = (seen: { wellKnown?: string; remote?: string }, remoteUrl: string) =>
   HttpClient.make((request) => {
     const parsedUrl = new URL(request.url)
     if (parsedUrl.pathname.includes("/.well-known/opencode")) {
@@ -71,11 +95,11 @@ const remoteConfigUnreachable = (seen: { wellKnown?: string; remote?: string }) 
       return Effect.succeed(
         json(request, {
           config: { model: "embedded/model" },
-          remote_config: { url: "https://config.example.com/opencode.json" },
+          remote_config: { url: remoteUrl },
         }),
       )
     }
-    if (parsedUrl.hostname === "config.example.com") {
+    if (request.url === remoteUrl) {
       seen.remote = request.url
       return transportFailure(request, "connect timeout")
     }
@@ -149,7 +173,323 @@ const bodyReadFails = HttpClient.make((request) => {
   return Effect.succeed(json(request, {}, 404))
 })
 
-const unreachableIt = it(unreachable)
+const onlineThenFailureState = { mode: "online" }
+const onlineThenAllowedFailure = HttpClient.make((request) => {
+  if (request.url.includes("/.well-known/opencode")) {
+    if (onlineThenFailureState.mode === "wellknown-transport") {
+      return transportFailure(request, "offline after initial success")
+    }
+    if (onlineThenFailureState.mode === "wellknown-status") {
+      return Effect.succeed(json(request, { error: "temporarily unavailable" }, 503))
+    }
+    if (onlineThenFailureState.mode === "wellknown-body") {
+      return Effect.succeed(
+        HttpClientResponse.fromWeb(
+          request,
+          new Response("{not-json", { status: 200, headers: { "content-type": "application/json" } }),
+        ),
+      )
+    }
+    return Effect.succeed(
+      json(request, { remote_config: { url: "https://lkg-transport-config.example.com/opencode.json" } }),
+    )
+  }
+  if (new URL(request.url).hostname === "lkg-transport-config.example.com") {
+    if (onlineThenFailureState.mode === "remote-transport") {
+      return transportFailure(request, "remote config offline after initial success")
+    }
+    if (onlineThenFailureState.mode === "remote-status") {
+      return Effect.succeed(json(request, { error: "temporarily unavailable" }, 502))
+    }
+    if (onlineThenFailureState.mode === "remote-body") {
+      return Effect.succeed(
+        HttpClientResponse.fromWeb(
+          request,
+          new Response("{not-json", { status: 200, headers: { "content-type": "application/json" } }),
+        ),
+      )
+    }
+    return Effect.succeed(json(request, { config: { model: "lkg/transport-model" } }))
+  }
+  return Effect.succeed(json(request, {}, 404))
+})
+
+const onlineThenAllowedFailureIt = it(onlineThenAllowedFailure, "https://lkg-transport.example.com")
+
+onlineThenAllowedFailureIt.live(
+  "online success persists both remote responses for allowed-failure reuse in new instances",
+  Effect.gen(function* () {
+    const online = yield* provideTmpdirInstance(() => Config.use.get())
+    expect(online.model).toBe("lkg/transport-model")
+
+    yield* Effect.forEach(
+      ["wellknown-transport", "remote-transport", "wellknown-status", "remote-status", "wellknown-body", "remote-body"],
+      (mode) =>
+        Effect.gen(function* () {
+          onlineThenFailureState.mode = mode
+          const fallback = yield* provideTmpdirInstance(() => Config.use.get())
+          expect(fallback.model).toBe("lkg/transport-model")
+        }),
+      { discard: true },
+    )
+  }),
+)
+
+type HardFailureMode =
+  | "online"
+  | "transport"
+  | "remote-401"
+  | "remote-403"
+  | "remote-html"
+  | "wellknown-schema"
+  | "remote-nonobject"
+  | "final-config-decode"
+
+const hardFailureClient = (origin: string, state: { mode: HardFailureMode }) =>
+  HttpClient.make((request) => {
+    if (state.mode === "transport") return transportFailure(request, "offline after hard failure")
+    if (request.url.includes("/.well-known/opencode")) {
+      if (state.mode === "wellknown-schema") return Effect.succeed(json(request, ["not-an-object"]))
+      return Effect.succeed(json(request, { remote_config: { url: `${origin}/remote-config.json` } }))
+    }
+    if (state.mode === "remote-401") return Effect.succeed(json(request, { error: "sign in" }, 401))
+    if (state.mode === "remote-403") return Effect.succeed(json(request, { error: "forbidden" }, 403))
+    if (state.mode === "remote-html") {
+      return Effect.succeed(
+        HttpClientResponse.fromWeb(
+          request,
+          new Response("<!DOCTYPE html><html><body>Sign in</body></html>", {
+            status: 200,
+            headers: { "content-type": "text/html" },
+          }),
+        ),
+      )
+    }
+    if (state.mode === "remote-nonobject") return Effect.succeed(json(request, ["not-an-object"]))
+    if (state.mode === "final-config-decode") {
+      return Effect.succeed(json(request, { config: { model: 42 } }))
+    }
+    return Effect.succeed(json(request, { config: { model: "lkg/hard-boundary-model" } }))
+  })
+
+const hardFailureCases: { mode: HardFailureMode; title: string }[] = [
+  { mode: "remote-401", title: "401" },
+  { mode: "remote-403", title: "403" },
+  { mode: "remote-html", title: "HTML login" },
+  { mode: "wellknown-schema", title: "well-known schema decode" },
+  { mode: "remote-nonobject", title: "remote non-object" },
+  { mode: "final-config-decode", title: "final config decode" },
+]
+
+hardFailureCases.forEach((scenario) => {
+  const origin = `https://lkg-hard-${scenario.mode}.example.com`
+  const state: { mode: HardFailureMode } = { mode: "online" }
+  const boundaryIt = it(hardFailureClient(origin, state), origin)
+
+  boundaryIt.live(
+    `${scenario.title} remains a hard failure and preserves the previous LKG`,
+    Effect.gen(function* () {
+      const online = yield* provideTmpdirInstance(() => Config.use.get())
+      expect(online.model).toBe("lkg/hard-boundary-model")
+
+      state.mode = scenario.mode
+      const failure = yield* provideTmpdirInstance(() => Config.use.get().pipe(Effect.exit))
+      expect(Exit.isFailure(failure)).toBe(true)
+
+      state.mode = "transport"
+      const fallback = yield* provideTmpdirInstance(() => Config.use.get())
+      expect(fallback.model).toBe("lkg/hard-boundary-model")
+    }),
+  )
+})
+
+const unavailableWellKnownCases = [
+  {
+    title: "empty",
+    origin: "https://lkg-empty-first.example.com",
+    digest: "89173d6feff949ddb9265e9b19b142875971bf40065fd88b76223612d0b0e705",
+    content: "",
+  },
+  {
+    title: "corrupt",
+    origin: "https://lkg-corrupt-first.example.com",
+    digest: "f92edb1dcc30a66dee91cb91d73925019660bcd6a87b9db15dd00e527a89245b",
+    content: "{CORRUPT_CACHE_CREDENTIAL_MARKER",
+  },
+]
+
+unavailableWellKnownCases.forEach((scenario) => {
+  const unavailableIt = it(unreachable, scenario.origin)
+
+  unavailableIt.instance(
+    `${scenario.title} first-hop LKG warns and preserves the existing skip result`,
+    () =>
+      Effect.gen(function* () {
+        yield* writeLkgFile(scenario.digest, scenario.content)
+        const config = yield* Config.use.get()
+        expect(config.model).toBe("local/unavailable-cache-model")
+        const logs = JSON.stringify(yield* logLines)
+        expect(logs).toContain("remote config LKG unavailable")
+        expect(logs).not.toContain("CORRUPT_CACHE_CREDENTIAL_MARKER")
+      }),
+    { config: { model: "local/unavailable-cache-model" } },
+  )
+})
+
+const unavailableRemoteCases = [
+  {
+    title: "empty",
+    origin: "https://lkg-empty-remote.example.com",
+    digest: "8c123b509f8a3a6c1f06c8103d2c1da2f12d4ba58d12d0059da22a986ea8018a",
+    content: "",
+  },
+  {
+    title: "corrupt",
+    origin: "https://lkg-corrupt-remote.example.com",
+    digest: "74f3bb458fa277ba39d92a3874d58a0c0095831a90fa0cbc39ad701ca3d68c8b",
+    content: "{CORRUPT_REMOTE_CACHE_CREDENTIAL_MARKER",
+  },
+]
+
+unavailableRemoteCases.forEach((scenario) => {
+  const client = HttpClient.make((request) => {
+    if (request.url.includes("/.well-known/opencode")) {
+      return Effect.succeed(
+        json(request, {
+          config: { model: "embedded/unavailable-cache-model" },
+          remote_config: { url: `${scenario.origin}/remote-config.json` },
+        }),
+      )
+    }
+    return transportFailure(request, "remote config unavailable")
+  })
+  const unavailableIt = it(client, scenario.origin)
+
+  unavailableIt.live(
+    `${scenario.title} second-hop LKG warns and preserves embedded well-known config`,
+    Effect.gen(function* () {
+      yield* writeLkgFile(scenario.digest, scenario.content)
+      const config = yield* provideTmpdirInstance(() => Config.use.get())
+      expect(config.model).toBe("embedded/unavailable-cache-model")
+      const logs = JSON.stringify(yield* logLines)
+      expect(logs).toContain("remote config LKG unavailable")
+      expect(logs).not.toContain("CORRUPT_REMOTE_CACHE_CREDENTIAL_MARKER")
+    }),
+  )
+})
+
+const oldLkgOrigin = "https://lkg-old.example.com"
+const oldLkgIt = it(unreachable, oldLkgOrigin)
+
+oldLkgIt.live(
+  "very old LKG remains usable and reports only safe age diagnostics",
+  Effect.gen(function* () {
+    yield* writeLkgFile(
+      "1675a350c4b8aa9887c0fad04fa378818761901440a26f5e78e0429786712889",
+      JSON.stringify({
+        version: 1,
+        writtenAt: "2000-01-01T00:00:00.000Z",
+        body: JSON.stringify({ remote_config: { url: `${oldLkgOrigin}/remote-config.json` } }),
+      }),
+    )
+    yield* writeLkgFile(
+      "0c467a2ce6c5e997d510fec8d4d3a3115a53ba26509732ad07b84069605e7ad1",
+      JSON.stringify({
+        version: 1,
+        writtenAt: "2000-01-01T00:00:00.000Z",
+        body: JSON.stringify({ config: { model: "lkg/very-old-model" } }),
+      }),
+    )
+
+    const config = yield* provideTmpdirInstance(() => Config.use.get())
+    expect(config.model).toBe("lkg/very-old-model")
+    const logs = JSON.stringify(yield* logLines)
+    expect(logs).toContain("using remote config LKG")
+    expect(logs).toContain("ageSeconds")
+    expect(logs).not.toContain("lkg/very-old-model")
+  }),
+)
+
+const safetyOrigin = "https://lkg-safety.example.com"
+const safetyRemoteUrl = "https://lkg-safety-config.example.com/opencode.json?credential=QUERY_SECRET_MARKER"
+const safetyToken = "AUTH_TOKEN_SECRET_MARKER"
+const safetyWellKnownBody = JSON.stringify({
+  config: { username: "{env:TEST_TOKEN}" },
+  remote_config: {
+    url: safetyRemoteUrl,
+    headers: {
+      Authorization: "Bearer {env:TEST_TOKEN}",
+      "X-Header-Marker": "HEADER_SECRET_MARKER",
+    },
+  },
+})
+const safetyRemoteBody = JSON.stringify({
+  config: {
+    model: "BODY_MARKER/model",
+    username: "{env:TEST_TOKEN}",
+  },
+})
+const safetyState = { online: true }
+const safetyClient = HttpClient.make((request) => {
+  if (!safetyState.online) return transportFailure(request, "offline for safety diagnostics")
+  if (request.url.includes("/.well-known/opencode")) return Effect.succeed(jsonText(request, safetyWellKnownBody))
+  return Effect.succeed(jsonText(request, safetyRemoteBody))
+})
+const safetyIt = it(safetyClient, safetyOrigin, safetyToken)
+
+safetyIt.live(
+  "cache identity, envelope metadata, and remote diagnostics do not leak credentials or body values",
+  Effect.gen(function* () {
+    const online = yield* provideTmpdirInstance(() => Config.use.get())
+    expect(online.model).toBe("BODY_MARKER/model")
+    expect(online.username).toBe(safetyToken)
+
+    const digests = [
+      "505f8fee6f34341c3236d9240b99654fa1e3d237a020a450b0cc5e0fc373ad0e",
+      "690e1cb0aeb039cd6a0206ada563856113c8f76c7345fadca285e7bf369b54ba",
+    ]
+    const filenames = yield* Effect.promise(() => readdir(path.join(Global.Path.cache, "remote-config-lkg")))
+    expect(filenames.filter((name) => digests.some((digest) => name === `${digest}.json`)).toSorted()).toEqual(
+      digests.map((digest) => `${digest}.json`).toSorted(),
+    )
+    expect(filenames.join(" ")).not.toContain("QUERY_SECRET_MARKER")
+    expect(filenames.join(" ")).not.toContain("HEADER_SECRET_MARKER")
+    expect(filenames.join(" ")).not.toContain("BODY_MARKER")
+    expect(filenames.join(" ")).not.toContain(safetyToken)
+
+    const wellKnownContent = yield* Effect.promise(() => Bun.file(lkgFile(digests[0])).text())
+    const remoteContent = yield* Effect.promise(() => Bun.file(lkgFile(digests[1])).text())
+    const wellKnownUnknown = Schema.decodeUnknownSync(Schema.UnknownFromJsonString)(wellKnownContent)
+    const remoteUnknown = Schema.decodeUnknownSync(Schema.UnknownFromJsonString)(remoteContent)
+    if (typeof wellKnownUnknown !== "object" || wellKnownUnknown === null || Array.isArray(wellKnownUnknown)) {
+      throw new Error("well-known LKG is not an object")
+    }
+    if (typeof remoteUnknown !== "object" || remoteUnknown === null || Array.isArray(remoteUnknown)) {
+      throw new Error("remote-config LKG is not an object")
+    }
+    expect(Object.keys(wellKnownUnknown).sort()).toEqual(["body", "version", "writtenAt"])
+    expect(Object.keys(remoteUnknown).sort()).toEqual(["body", "version", "writtenAt"])
+    expect(Schema.decodeUnknownSync(Schema.fromJsonString(LkgEnvelope))(wellKnownContent).body).toBe(
+      safetyWellKnownBody,
+    )
+    expect(Schema.decodeUnknownSync(Schema.fromJsonString(LkgEnvelope))(remoteContent).body).toBe(safetyRemoteBody)
+    expect(wellKnownContent).not.toContain(safetyToken)
+    expect(remoteContent).not.toContain(safetyToken)
+
+    safetyState.online = false
+    const fallback = yield* provideTmpdirInstance(() => Config.use.get())
+    expect(fallback.model).toBe("BODY_MARKER/model")
+    expect(fallback.username).toBe(safetyToken)
+
+    const logs = JSON.stringify(yield* logLines)
+    for (const marker of ["QUERY_SECRET_MARKER", "HEADER_SECRET_MARKER", "BODY_MARKER", safetyToken]) {
+      expect(logs).not.toContain(marker)
+    }
+  }),
+)
+
+const missingWellKnownOrigin = "https://missing-wellknown.example.com"
+const unreachableIt = it(unreachable, missingWellKnownOrigin)
 
 unreachableIt.instance(
   "wellknown transport failure degrades: config loads, local config intact, warning logged",
@@ -158,9 +498,11 @@ unreachableIt.instance(
       const config = yield* Config.use.get()
       expect(config.model).toBe("local/model")
       expect(config.mcp?.jira?.enabled).toBe(true)
-      const logs = JSON.stringify(yield* TestConsole.logLines)
+      const logs = JSON.stringify(yield* logLines)
       expect(logs).toContain("failed to fetch remote config")
-      expect(logs).toContain("https://example.com/.well-known/opencode")
+      expect(logs).toContain("6b8f8396ae9f582f48dad65f38f88caf722d177638e6d3cadc1d1e7cea36b312")
+      expect(logs).toContain("well-known")
+      expect(logs).not.toContain(`${missingWellKnownOrigin}/.well-known/opencode`)
     }),
   {
     config: {
@@ -171,51 +513,52 @@ unreachableIt.instance(
 )
 
 const remoteUnreachableSeen: { wellKnown?: string; remote?: string } = {}
-const remoteUnreachableIt = it(remoteConfigUnreachable(remoteUnreachableSeen))
+const missingRemoteOrigin = "https://missing-remote.example.com"
+const missingRemoteUrl = "https://missing-remote-config.example.com/opencode.json"
+const remoteUnreachableIt = it(remoteConfigUnreachable(remoteUnreachableSeen, missingRemoteUrl), missingRemoteOrigin)
 
 remoteUnreachableIt.instance(
   "remote_config transport failure degrades: embedded wellknown config still merges, warning logged",
   () =>
     Effect.gen(function* () {
       const config = yield* Config.use.get()
-      expect(remoteUnreachableSeen.wellKnown).toBe("https://example.com/.well-known/opencode")
-      expect(remoteUnreachableSeen.remote).toBe("https://config.example.com/opencode.json")
+      expect(remoteUnreachableSeen.wellKnown).toBe(`${missingRemoteOrigin}/.well-known/opencode`)
+      expect(remoteUnreachableSeen.remote).toBe(missingRemoteUrl)
       expect(config.model).toBe("embedded/model")
-      const logs = JSON.stringify(yield* TestConsole.logLines)
+      const logs = JSON.stringify(yield* logLines)
       expect(logs).toContain("failed to fetch remote config")
-      expect(logs).toContain("https://config.example.com/opencode.json")
+      expect(logs).toContain("f71d054e157edfcdd072de9b3c9ccbe82c4330d9a054116dc0c920236a7a8e92")
+      expect(logs).toContain("remote-config")
+      expect(logs).not.toContain(missingRemoteUrl)
     }),
 )
 
 const remoteOkSeen: { wellKnown?: string; remote?: string } = {}
 const remoteOkIt = it(remoteOk(remoteOkSeen))
 
-remoteOkIt.instance(
-  "success path unchanged: remote config merges, no degradation warning",
-  () =>
-    Effect.gen(function* () {
-      const config = yield* Config.use.get()
-      expect(remoteOkSeen.wellKnown).toBe("https://example.com/.well-known/opencode")
-      expect(remoteOkSeen.remote).toBe("https://config.example.com/opencode.json")
-      expect(config.mcp?.confluence?.enabled).toBe(true)
-      expect(JSON.stringify(yield* TestConsole.logLines)).not.toContain("failed to fetch remote config")
-    }),
+remoteOkIt.instance("success path unchanged: remote config merges, no degradation warning", () =>
+  Effect.gen(function* () {
+    const config = yield* Config.use.get()
+    expect(remoteOkSeen.wellKnown).toBe("https://example.com/.well-known/opencode")
+    expect(remoteOkSeen.remote).toBe("https://config.example.com/opencode.json")
+    expect(config.mcp?.confluence?.enabled).toBe(true)
+    expect(JSON.stringify(yield* logLines)).not.toContain("failed to fetch remote config")
+  }),
 )
 
 const loginPageSeen: { wellKnown?: string; remote?: string } = {}
 const loginPageIt = it(loginPage(loginPageSeen))
 
-loginPageIt.instance(
-  "HTML login page stays a hard auth failure even with degradation enabled",
-  () =>
-    Effect.gen(function* () {
-      const exit = yield* Config.use.get().pipe(Effect.exit)
-      expect(loginPageSeen.remote).toBe("https://config.example.com/opencode.json")
-      expect(Exit.isFailure(exit)).toBe(true)
-    }),
+loginPageIt.instance("HTML login page stays a hard auth failure even with degradation enabled", () =>
+  Effect.gen(function* () {
+    const exit = yield* Config.use.get().pipe(Effect.exit)
+    expect(loginPageSeen.remote).toBe("https://config.example.com/opencode.json")
+    expect(Exit.isFailure(exit)).toBe(true)
+  }),
 )
 
-const bodyReadFailsIt = it(bodyReadFails)
+const bodyReadMissingOrigin = "https://body-read-missing.example.com"
+const bodyReadFailsIt = it(bodyReadFails, bodyReadMissingOrigin)
 
 bodyReadFailsIt.instance(
   "wellknown body-read failure degrades: config loads, local config intact, warning logged",
@@ -224,9 +567,11 @@ bodyReadFailsIt.instance(
       const config = yield* Config.use.get()
       expect(config.model).toBe("local/model")
       expect(config.mcp?.jira?.enabled).toBe(true)
-      const logs = JSON.stringify(yield* TestConsole.logLines)
+      const logs = JSON.stringify(yield* logLines)
       expect(logs).toContain("failed to read remote config")
-      expect(logs).toContain("https://example.com/.well-known/opencode")
+      expect(logs).toContain("d0d0bbaef7a071d010d7223883169215741dd80cbb362b68b93e30d5f531013a")
+      expect(logs).toContain("well-known")
+      expect(logs).not.toContain(`${bodyReadMissingOrigin}/.well-known/opencode`)
     }),
   {
     config: {


### PR DESCRIPTION
## Summary
- persist validated raw remote-config responses as private atomic LKG files
- reuse LKG only for transport, non-auth status, body-read, and JSON syntax failures
- preserve auth/HTML/schema hard failures and credential-safe diagnostics

## Verification
- target tests: 24 passed, 0 failed, repeated three consecutive times
- existing wellknown regression subset: 7 passed, 0 failed
- packages/opencode bun typecheck
- OpenSpec validate --changes and strict change validation

## Scope
- four implementation/test files plus batch-B ticket and spec-progress documentation
- no fixture, dependency, lockfile, core, HTTP, SDK, or generated-file changes