### PR TITLE
fix(dag): cancel orphan child after start failure

### DIFF
--- a/packages/opencode/src/dag/runtime/spawn.ts
+++ b/packages/opencode/src/dag/runtime/spawn.ts
@@ -393,6 +393,7 @@ export function spawnNode(
                   return true
                 }),
             ),
+            Effect.onError(() => promptSvc.cancel(childSession.id).pipe(Effect.ignore)),
           )
           if (terminalized) return
 

--- a/packages/opencode/test/dag/spawn-completion.test.ts
+++ b/packages/opencode/test/dag/spawn-completion.test.ts
@@ -316,4 +316,42 @@ describe("spawnNode terminalization during spawn window", () => {
     expect(events.filter((e) => e.type === "nodeCompleted")).toEqual([])
     expect(cancelCalled).toBe(true)
   })
+
+  it("cancels the child session when nodeStarted fails after session creation", async () => {
+    const events: TrackedEvent[] = []
+    let cancelCalled = false
+    let promptCalled = false
+    const dagLayer = Layer.mock(Dag.Service, {
+      store: {} as DagStore.Interface,
+      nodeQueued: () => Effect.void,
+      nodeStarted: () => Effect.fail(new Error("nodeStarted write failed")),
+      nodeCompleted: Effect.fn("stub.nodeCompleted")((dagID: string, nodeID: string) =>
+        Effect.sync(() => events.push({ type: "nodeCompleted", dagID, nodeID })),
+      ),
+      nodeFailed: Effect.fn("stub.nodeFailed")((dagID: string, nodeID: string, reason: string) =>
+        Effect.sync(() => events.push({ type: "nodeFailed", dagID, nodeID, reason })),
+      ),
+    })
+    const promptLayer = Layer.mock(SessionPrompt.Service, {
+      prompt: () =>
+        Effect.sync(() => {
+          promptCalled = true
+          return reply("unexpected")
+        }),
+      cancel: () => Effect.sync(() => { cancelCalled = true }),
+    })
+
+    await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const result = yield* spawnNode(Semaphore.makeUnsafe(1), makeSpawnInput())
+          yield* Fiber.await(result.fiber)
+        }),
+      ).pipe(Effect.provide(Layer.mergeAll(dagLayer, agentLayer, sessionLayer, promptLayer))) as Effect.Effect<never>,
+    )
+
+    expect(promptCalled).toBe(false)
+    expect(findEvent(events, "nodeFailed")?.reason).toContain("nodeStarted write failed")
+    expect(cancelCalled).toBe(true)
+  })
 })


### PR DESCRIPTION
## Summary

- cancel a child Session when NodeStarted persistence fails after Session creation
- retain transition-rejection behavior and avoid duplicate terminal events
- add a deterministic regression test at the public spawn seam

## Verification

- bun run test:dag-core: Core 90, OpenCode DAG 402, Schema 3, TUI 50
- generated SDK unchanged
- packages/opencode bun typecheck
- repository pre-push typecheck: 29/29

Closes #212