### PR TITLE
test(opencode): isolate memory in cli fixtures

### DIFF
--- a/packages/opencode/test/lib/cli-process.ts
+++ b/packages/opencode/test/lib/cli-process.ts
@@ -201,6 +201,23 @@ export function withCliFixture<A, E>(
 
     const configJson = JSON.stringify(testProviderConfig(llm.url))
     const env = isolatedEnv(home, configJson)
+    const memoryConfigDir = path.join(home, ".config/opencode")
+    yield* fs.makeDirectory(memoryConfigDir, { recursive: true })
+    // CLI tests own the provider response queue, while dedicated MEMORY tests
+    // cover first-run model selection. Seed a valid global config so unrelated
+    // background initialization cannot consume a CLI test's prompt response.
+    yield* fs.writeFileString(
+      path.join(memoryConfigDir, "memory.jsonc"),
+      JSON.stringify({
+        schema_version: 1,
+        enabled: true,
+        model: testModelID,
+        topic_limit: 10,
+        topic_limit_floor: 10,
+        turn_interval: 5,
+        injection: { max_topics: 3, max_tokens: 1_200 },
+      }),
+    )
 
     const spawn = Effect.fn("opencode.spawn")(function* (args: string[], opts?: SpawnOpts) {
       const start = Date.now()
@@ -532,10 +549,5 @@ export const cliIt = {
     name: string,
     body: (input: CliFixture) => Effect.Effect<A, E, Scope.Scope | HttpClient.HttpClient>,
     opts?: number | TestOptions,
-  ) =>
-    test(
-      name,
-      () => Effect.runPromise(Effect.scoped(withCliFixture(body))),
-      opts,
-    ),
+  ) => test(name, () => Effect.runPromise(Effect.scoped(withCliFixture(body))), opts),
 }


### PR DESCRIPTION
## Summary

- seed a valid global MEMORY config in the shared CLI subprocess fixture
- keep asynchronous MEMORY startup from consuming prompt responses owned by CLI tests
- leave first-run MEMORY model selection covered by the dedicated MEMORY suite

## Diagnosis

After PR #215, every fresh CLI test home started MEMORY initialization against the same FIFO fake-LLM queue used by the foreground prompt. The hidden initializer consumed the response prepared for `opencode run`, so the foreground request received the fixture fallback `ok`.

## Verification

- red: `run-process.test.ts` reproduced the CI result with 5 pass / 8 fail
- green: `run-process.test.ts` 13 pass / 0 fail
- CLI + MEMORY suite: 377 pass / 5 skip / 0 fail
- repository lint: 4852 warnings / 0 errors (ratchet met)
- pre-commit package typechecks: 29 / 29 passed
- Prettier and `git diff --check`: passed

The desktop sandbox cannot provide a valid full-package run because nested Bun, PTY, and LSP subprocesses inherit restricted parent-directory/preload access. The post-merge Linux Unit Tests job remains the authoritative full-suite verification.
