### PR TITLE
fix(dag): block unsafe recovery restart

### DIFF
--- a/packages/opencode/src/dag/runtime/recovery.ts
+++ b/packages/opencode/src/dag/runtime/recovery.ts
@@ -65,7 +65,7 @@ export function reconcileWorkflow(
       // never revisit it if the workflow is about to become terminal.
       if (node.status === "pending" || node.status === "queued") {
         if (node.childSessionId && cancelSession) {
-          yield* cancelSession(node.childSessionId).pipe(Effect.catch(() => Effect.void))
+          yield* cancelSession(node.childSessionId)
         }
         continue
       }

--- a/packages/opencode/test/dag/dag-recovery.test.ts
+++ b/packages/opencode/test/dag/dag-recovery.test.ts
@@ -171,6 +171,24 @@ describe("reconcileWorkflow", () => {
     expect(result).toEqual({ reconciled: 0, ownershipLost: 0 })
   })
 
+  it("aborts recovery when a stale restart-orphan session cannot be cancelled", async () => {
+    const events: TrackedEvent[] = []
+    const nodes = [makeNodeRow({ id: "n1", status: "queued", childSessionId: "ses_stale" })]
+    const dagLayer = makeDagLayer(nodes, events)
+    const checkStatus = () => Effect.succeed("active" as const)
+    const cancelSession = () => Effect.fail(new Error("cancel unavailable"))
+
+    const exit = await Effect.runPromise(
+      reconcileWorkflow("wf-1", checkStatus, cancelSession).pipe(
+        Effect.provide(dagLayer),
+        Effect.exit,
+      ),
+    )
+
+    expect(Exit.isFailure(exit)).toBe(true)
+    expect(events).toEqual([])
+  })
+
   it("cancels and fails a zero-message child classified as unknown exactly once", async () => {
     const events: TrackedEvent[] = []
     const cancelled: string[] = []


### PR DESCRIPTION
## Summary

- propagate stale restart-orphan cancellation failures during recovery
- prevent pending/queued nodes from re-entering scheduling while an old child may still run
- retain a deterministic regression test with no invented node events

## Verification

- `bun test test/dag/dag-recovery.test.ts` — 24 pass
- `bun run test:dag-core` — Core 90, OpenCode DAG 403, Schema 3, TUI 50; SDK unchanged
- `node ../../node_modules/.bin/tsgo --noEmit` — pass
- `bun run lint` — 4852 warnings / 0 errors (ratchet)
- pre-push monorepo typecheck — 29/29 pass

Closes #213