### PR TITLE
test(dag): align command routing contracts

### DIFF
--- a/packages/core/src/plugin/command/dag-flow.txt
+++ b/packages/core/src/plugin/command/dag-flow.txt
@@ -4,7 +4,7 @@
 $ARGUMENTS
 </dag-flow-task>
 
-If the task is empty, ask for it and do not start a workflow. Otherwise load
+If the task is empty or contains only whitespace, ask for it and do not start a workflow. Otherwise load
 the `orchestration-router` skill and route the request through one consolidated
 graph. `/dag-flow` explicitly selects DAG execution, but it does not waive a
 material user decision.

--- a/packages/opencode/test/command/command.test.ts
+++ b/packages/opencode/test/command/command.test.ts
@@ -97,23 +97,23 @@ describe("legacy command registry", () => {
       const expanded = SessionPrompt.expandCommandTemplate(CommandPlugin.DagFlowContent, "Run two parallel workers")
 
       expect(expanded).toContain("Do not poll")
-      expect(expanded).toContain("End the current response")
+      expect(expanded).toContain("and end the response")
     }),
   )
 
-  it.effect("requires profile-aware compilation without dropping task constraints", () =>
+  it.effect("requires router-driven compilation without dropping task constraints", () =>
     Effect.sync(() => {
       const expanded = SessionPrompt.expandCommandTemplate(
         CommandPlugin.DagFlowContent,
         "Use @security-reviewer to review this project. Do not modify files.",
       )
 
-      expect(expanded).toContain("classify the task as `brainstorm`, `review`, or `develop`")
-      expect(expanded).toContain("preserve every user constraint")
-      expect(expanded).toContain("eligible configured worker types")
-      expect(expanded).toContain("Do not invent a missing role or model")
-      expect(expanded).toContain("actual error")
-      expect(expanded).toContain("must actually contain the requested synthesis")
+      expect(expanded).toContain("orchestration-router")
+      expect(expanded).toMatch(/Preserve\s+the task, user constraints/)
+      expect(expanded).toContain("worker types or model IDs")
+      expect(expanded).toContain("configured capability or model")
+      expect(expanded).toContain("real error")
+      expect(expanded).toContain("final synthesis block must contain the requested result")
     }),
   )
 
@@ -123,7 +123,7 @@ describe("legacy command registry", () => {
 
       expect(expanded).toContain("<dag-flow-task>\n   \n</dag-flow-task>")
       expect(expanded).toContain("empty or contains only whitespace")
-      expect(expanded).toContain("Do not call the `workflow` tool")
+      expect(expanded).toContain("do not start a workflow")
     }),
   )
 })


### PR DESCRIPTION
## Summary

- align legacy command assertions with the proactive composable router contract
- preserve explicit empty-or-whitespace guarding for /dag-flow
- keep post-start no-poll behavior covered

## Evidence

- RED: command.test.ts reproduced 4 pass / 3 fail locally and in dev CI
- GREEN: OpenCode command tests 7/7
- GREEN: Core command tests 19/19
- GREEN: Core and OpenCode typecheck
- GREEN: repository lint 4850 warnings / 0 errors
- GREEN: full pre-push typecheck 29/29

Root cause: the proactive prompt rewrite intentionally replaced the old fixed profiles, but the legacy registry tests still asserted the removed wording; the whitespace clause also needed to remain explicit.