### PR TITLE
test(memory): stamp the instance store with the already-resolved identity (CI fix)

### DIFF
--- a/packages/opencode/test/fixture/fixture.ts
+++ b/packages/opencode/test/fixture/fixture.ts
@@ -162,9 +162,11 @@ export function tmpdirScoped<E = never, R = never>(options?: {
 }
 
 export const provideInstance =
-  (directory: string) =>
+  (input: string | InstanceStore.LoadInput) =>
   <A, E, R>(self: Effect.Effect<A, E, R>): Effect.Effect<A, E, R | InstanceStore.Service> =>
-    InstanceStore.Service.use((store) => store.provide({ directory }, self))
+    InstanceStore.Service.use((store) =>
+      store.provide(typeof input === "string" ? { directory: input } : input, self),
+    )
 
 export const provideInstanceEffect =
   (directory: string) =>

--- a/packages/opencode/test/memory/memory-global-identity.test.ts
+++ b/packages/opencode/test/memory/memory-global-identity.test.ts
@@ -149,15 +149,21 @@ describe("MEM-PR01-R1-03: memory is inert once the identity row is retired", () 
     () =>
       Effect.gen(function* () {
         const dir = yield* tmpdirScoped({ git: true })
-        yield* provideInstance(dir)(
+        // Resolve the identity ONCE and hand it to the instance store: the
+        // boot-time resolution runs in a separate Effect graph (own Database)
+        // and can transiently degrade to the global identity on loaded CI
+        // runners (git failures are silently swallowed), which would make the
+        // stamped context and this body disagree — failing the search closed.
+        const project = yield* Project.Service
+        const { project: info } = yield* project.fromDirectory(dir)
+        expect(info.id).not.toBe(ProjectV2.ID.global)
+        yield* provideInstance({ directory: dir, worktree: info.worktree, project: info })(
           Effect.gen(function* () {
             const project = yield* Project.Service
             const memory = yield* Memory.Service
             const configStore = yield* MemoryConfig.Service
             const { db } = yield* Database.Service
 
-            const { project: info } = yield* project.fromDirectory(dir)
-            expect(info.id).not.toBe(ProjectV2.ID.global)
             yield* project.setInitialized(info.id)
             yield* configStore.writeGlobal(baseConfig)
 
@@ -193,14 +199,15 @@ describe("MEM-PR01-R1-23: the runtime admission snapshot covers every registered
       Effect.gen(function* () {
         const dir = yield* tmpdirScoped({ git: true })
         const sandbox = yield* tmpdirScoped()
-        yield* provideInstance(dir)(
+        const project = yield* Project.Service
+        const { project: info } = yield* project.fromDirectory(dir)
+        yield* provideInstance({ directory: dir, worktree: info.worktree, project: info })(
           Effect.gen(function* () {
             const project = yield* Project.Service
             const memory = yield* Memory.Service
             const configStore = yield* MemoryConfig.Service
             const store = yield* MemoryStore.Service
 
-            const { project: info } = yield* project.fromDirectory(dir)
             yield* project.setInitialized(info.id)
             yield* project.addSandbox(info.id, sandbox)
             yield* configStore.writeGlobal(baseConfig)
@@ -353,14 +360,15 @@ describe("MEM-PR01-00: memory is inert under the shared global identity", () => 
     () =>
       Effect.gen(function* () {
         const dir = yield* tmpdirScoped({ git: true })
-        yield* provideInstance(dir)(
+        const project = yield* Project.Service
+        const { project: info } = yield* project.fromDirectory(dir)
+        expect(info.id).not.toBe(ProjectV2.ID.global)
+        yield* provideInstance({ directory: dir, worktree: info.worktree, project: info })(
           Effect.gen(function* () {
             const project = yield* Project.Service
             const memory = yield* Memory.Service
             const configStore = yield* MemoryConfig.Service
 
-            const { project: info } = yield* project.fromDirectory(dir)
-            expect(info.id).not.toBe(ProjectV2.ID.global)
             yield* project.setInitialized(info.id)
             yield* configStore.writeGlobal(baseConfig)
 


### PR DESCRIPTION
dev 推 CI（linux Unit）在 MEM-PR01-R1-03 隔离复现失败：实例库 boot 时身份解析在独立 Effect 图（独立 :memory: DB）中，git 子进程瞬态失败被静默吞掉→降级为 global 身份→memory fail-closed。修复：测试体解析一次身份并传入 instance store（provideInstance 现接受完整 LoadInput，boot 跳过自身 fromDirectory）；应用于三个断言 active 的身份作用域测试。产品加固（git 身份解析不静默降级）已登记为独立项。验证：memory+project 191 全绿；typecheck 干净。

Fixes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)