### PR TITLE
test(dag): refresh workflow schema evidence

### DIFF
--- a/packages/opencode/test/tool/fixtures/workflow-parameters-post-change.json
+++ b/packages/opencode/test/tool/fixtures/workflow-parameters-post-change.json
@@ -1,25 +1,25 @@
 {
   "captured_from": "packages/opencode/src/tool/workflow.ts (file-backed discriminated-union Parameters)",
-  "schema_bytes": 4681,
+  "schema_bytes": 4712,
   "branch_count": 10,
   "session_id_exposed": false,
   "project_id_exposed": false,
   "inline_spec_exposed": false,
   "transformed": {
     "openai": {
-      "bytes": 4511,
+      "bytes": 4542,
       "branch_count": 10,
       "start_spec_path_present": true,
       "inline_spec_exposed": false
     },
     "azure": {
-      "bytes": 4511,
+      "bytes": 4542,
       "branch_count": 10,
       "start_spec_path_present": true,
       "inline_spec_exposed": false
     },
     "gemini": {
-      "bytes": 4681,
+      "bytes": 4712,
       "branch_count": 10,
       "start_spec_path_present": true,
       "inline_spec_exposed": false


### PR DESCRIPTION
Refresh the pinned provider-facing workflow schema byte counts after the spec_path guidance text changed. No runtime behavior changes.\n\nVerification:\n- workflow provider schema tests: 7/7\n- git diff --check