### PR TITLE
fix(provider): object-root union schemas for all openai-compatible backends

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1537,11 +1537,13 @@ export function schema(model: Provider.Model, schema: JSONSchema7): JSONSchema7 
     schema = sanitizeGemini(schema)
   }
 
-  // DeepSeek rejects function schemas whose root type is implicit. Effect
-  // emits object-only discriminated unions as a root `anyOf`; retaining the
-  // union while declaring its shared object type preserves every branch.
+  // OpenAI-compatible backends (DeepSeek, GLM, and other relays) reject
+  // function schemas whose root type is implicit — the model emits empty
+  // tool arguments instead of erroring. Effect emits object-only
+  // discriminated unions as a root `anyOf`; retaining the union while
+  // declaring its shared object type preserves every branch.
   if (
-    model.api.id.toLowerCase().includes("deepseek") &&
+    model.api.npm === "@ai-sdk/openai-compatible" &&
     schema.type === undefined &&
     Array.isArray(schema.anyOf) &&
     schema.anyOf.length > 0 &&

--- a/packages/opencode/test/tool/workflow-provider-schema.test.ts
+++ b/packages/opencode/test/tool/workflow-provider-schema.test.ts
@@ -15,6 +15,10 @@ const deepseekModel = {
   providerID: "deepseek",
   api: { id: "deepseek-v4-pro", npm: "@ai-sdk/openai-compatible" },
 } as never
+const glmModel = {
+  providerID: "local-proxy",
+  api: { id: "glm-5.3", npm: "@ai-sdk/openai-compatible" },
+} as never
 
 type JsonSchemaNode = {
   anyOf?: JsonSchemaNode[]
@@ -124,6 +128,16 @@ describe("workflow provider-facing schema", () => {
   test("DeepSeek transformation presents the workflow union as an object-root function schema", () => {
     const transformed = ProviderTransform.schema(
       deepseekModel,
+      ToolJsonSchema.fromSchema(Parameters as never),
+    ) as JsonSchemaNode
+    expect(transformed.type).toBe("object")
+    expect(branches(transformed)).toHaveLength(10)
+    expect(branchByAction(transformed, "start", "spec_path")).toHaveLength(1)
+  })
+
+  test("OpenAI-compatible transports (GLM relay) also get the object-root union", () => {
+    const transformed = ProviderTransform.schema(
+      glmModel,
       ToolJsonSchema.fromSchema(Parameters as never),
     ) as JsonSchemaNode
     expect(transformed.type).toBe("object")


### PR DESCRIPTION
## Summary
- Generalize the implicit-root `anyOf` → `type: "object"` normalization from DeepSeek-only id matching to the whole `@ai-sdk/openai-compatible` transport.
- Root cause (reproduced live): GLM via local-proxy receives the workflow tool's root-`anyOf` function schema with no root type, and silently emits **empty tool arguments** — the model retried 5x, every call decoded as `got {}`. DeepSeek had the identical failure and was fixed in #259; GLM and other relays were outside the guard.
- Keep every union branch; only declare the shared object type at the root.

## Evidence
- `ProviderTransform.schema` output for `glm-5.3` (`@ai-sdk/openai-compatible`): root type implicit before, `object` after; 10 branches preserved both ways.
- New test: "OpenAI-compatible transports (GLM relay) also get the object-root union".

## Test plan
- [x] `bun test test/tool/workflow-provider-schema.test.ts` — 9 pass
- [x] `bun typecheck` — clean