### PR TITLE
fix(provider): object-root union schemas for all openai-compatible backends

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1537,11 +1537,13 @@ export function schema(model: Provider.Model, schema: JSONSchema7): JSONSchema7 
     schema = sanitizeGemini(schema)
   }
 
-  // DeepSeek rejects function schemas whose root type is implicit. Effect
-  // emits object-only discriminated unions as a root `anyOf`; retaining the
-  // union while declaring its shared object type preserves every branch.
+  // OpenAI-compatible backends (DeepSeek, GLM, and other relays) reject
+  // function schemas whose root type is implicit — the model emits empty
+  // tool arguments instead of erroring. Effect emits object-only
+  // discriminated unions as a root `anyOf`; retaining the union while
+  // declaring its shared object type preserves every branch.
   if (
-    model.api.id.toLowerCase().includes("deepseek") &&
+    model.api.npm === "@ai-sdk/openai-compatible" &&
     schema.type === undefined &&
     Array.isArray(schema.anyOf) &&
     schema.anyOf.length > 0 &&

--- a/packages/opencode/test/tool/workflow-provider-schema.test.ts
+++ b/packages/opencode/test/tool/workflow-provider-schema.test.ts
@@ -15,6 +15,10 @@ const deepseekModel = {
   providerID: "deepseek",
   api: { id: "deepseek-v4-pro", npm: "@ai-sdk/openai-compatible" },
 } as never
+const glmModel = {
+  providerID: "local-proxy",
+  api: { id: "glm-5.3", npm: "@ai-sdk/openai-compatible" },
+} as never
 
 type JsonSchemaNode = {
   anyOf?: JsonSchemaNode[]
@@ -124,6 +128,16 @@ describe("workflow provider-facing schema", () => {
   test("DeepSeek transformation presents the workflow union as an object-root function schema", () => {
     const transformed = ProviderTransform.schema(
       deepseekModel,
+      ToolJsonSchema.fromSchema(Parameters as never),
+    ) as JsonSchemaNode
+    expect(transformed.type).toBe("object")
+    expect(branches(transformed)).toHaveLength(10)
+    expect(branchByAction(transformed, "start", "spec_path")).toHaveLength(1)
+  })
+
+  test("OpenAI-compatible transports (GLM relay) also get the object-root union", () => {
+    const transformed = ProviderTransform.schema(
+      glmModel,
       ToolJsonSchema.fromSchema(Parameters as never),
     ) as JsonSchemaNode
     expect(transformed.type).toBe("object")


### PR DESCRIPTION
## Summary
Promote to main: generalize the implicit-root `anyOf` → `type: "object"` normalization from DeepSeek-only id matching to the whole `@ai-sdk/openai-compatible` transport.

- GLM (via local-proxy) received the workflow tool's root-`anyOf` function schema without a root type and silently emitted **empty tool arguments** (live repro: 5 consecutive calls, all `got {}`). #259 fixed the identical failure for DeepSeek only.
- The fix keeps every union branch and only declares the shared object type at the root. Validated on dev in PR #260.

## Dev validation
- PR #260 Typecheck: pass
- dev full test run 31780935188: Unit Tests (linux), E2E Tests (linux), E2E Tests (windows) — all success

Closes #260 (cherry-picked content merged via dev).