### PR TITLE
fix(dag): close two CI-only failures from the DAG-LOC-01 merge

### DIFF
--- a/packages/opencode/src/dag/location.ts
+++ b/packages/opencode/src/dag/location.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 LeXwDeX
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 export * as DagLocation from "./location"
 
 /**

--- a/packages/opencode/test/project/bootstrap-dag-wiring.test.ts
+++ b/packages/opencode/test/project/bootstrap-dag-wiring.test.ts
@@ -52,6 +52,7 @@ describe("instance bootstrap DAG wiring", () => {
                     id: workflowID,
                     project_id: context.project.id as never,
                     session_id: parent.id as never,
+                    directory: context.directory,
                     title: "condition false",
                     status: "running",
                     config: JSON.stringify({


### PR DESCRIPTION
## Summary

Two failures surfaced by the dev full-test run (31830294131) after merging #266, both outside that PR's gate set:

1. **license-scope** (linux unit job): `packages/opencode/src/dag/location.ts` was created without the repository's SPDX copyright banner — AGPL source missing headers.
2. **bootstrap-dag-wiring** `recovers a persisted workflow`: the test seeds its WorkflowTable row via raw SQL without the new `directory` column, so the fail-closed NULL-stamp policy (a NULL stamp matches no instance) leaves the workflow unadopted — "bootstrap did not start the DAG scheduler".

Fixes: standard SPDX header; stamp the seed with the instance directory (same sibling-test idiom as dag-wake-integration).

Root cause of both escaping #266: its verify gates ran `test/dag test/goal test/tool` but not `test/project` or the core license manifest.

## Test plan
- [x] core `bun test test/license-scope.test.ts` 5/5
- [x] opencode `bun test test/project/bootstrap-dag-wiring.test.ts` 1/1 (was failing pre-fix)
- [x] opencode `bun test test/dag test/goal` 607/0
- [x] root `bun run lint` 4849/4852
- [x] full turbo typecheck 29/29