### PR TITLE
fix(goal): retry ESC pause persistence before giving up the goal

### DIFF
--- a/packages/opencode/src/goal/goal.ts
+++ b/packages/opencode/src/goal/goal.ts
@@ -1,6 +1,6 @@
 export * as Goal from "./goal"
 
-import { Effect, Layer, Context, Schema, Fiber } from "effect"
+import { Effect, Layer, Context, Schema, Fiber, Cause, Exit } from "effect"
 import { desc, eq, sql } from "drizzle-orm"
 import { SessionTable } from "@opencode-ai/core/session/sql"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
@@ -227,22 +227,39 @@ const serviceLayer = Layer.effect(
       return GoalPrompts.GOAL_TURN_MAX_STEPS
     })
 
-    // ESC-on-goal-turn: durable pause + lease release + mark clear, failure-
-    // absorbed. Called from SessionPrompt.cancel so a user ESC on a goal turn
-    // pauses the goal instead of letting the post-cancel idle event resurrect
-    // it with an unwanted continuation.
+    // ESC-on-goal-turn: durable pause + lease release + mark clear. Called
+    // from SessionPrompt.cancel so a user ESC on a goal turn pauses the goal
+    // instead of letting the post-cancel idle event resurrect it with an
+    // unwanted continuation.
+    //
+    // GOAL-FP-01-19: a transient DB failure must not silently lose the pause
+    // — the mark would clear, the pause never persist, and the next idle
+    // would resurrect the goal against the user's explicit intent
+    // (shouldPreempt cannot catch it: ESC adds no user message). Retry the
+    // pause twice with a short backoff; if it still fails, log LOUDLY — the
+    // goal may resurrect, but it will never do so invisibly.
     const pauseForUserCancel = Effect.fnUntraced(function* (sessionID: SessionID, reason: string) {
-      const paused = yield* pauseAndPublish(sessionID, reason).pipe(
-        Effect.catchCause((cause) =>
-          Effect.logWarning("goal pause on cancel failed", { sessionID, cause: String(cause) }).pipe(
-            Effect.as(undefined),
-          ),
-        ),
-      )
-      if (paused)
+      let paused: GoalState.Info | undefined
+      let lastCause: Cause.Cause<never> | undefined
+      for (let attempt = 0; attempt < 3; attempt++) {
+        const exit = yield* pauseAndPublish(sessionID, reason).pipe(Effect.exit)
+        if (Exit.isSuccess(exit)) {
+          paused = exit.value
+          break
+        }
+        lastCause = exit.cause
+        if (attempt < 2) yield* Effect.sleep("50 millis")
+      }
+      if (paused) {
         yield* automation.unregister(sessionID, { kind: "goal", id: paused.goal_id ?? "legacy" }).pipe(
           Effect.ignore,
         )
+      } else {
+        yield* Effect.logError(
+          "goal pause on cancel failed after retries — goal may resurrect on next idle",
+          { sessionID, cause: lastCause ? Cause.pretty(lastCause) : "unknown" },
+        )
+      }
       turnDriven.delete(sessionID)
       return paused
     })


### PR DESCRIPTION
## Problem
审计发现 F5：`pauseForUserCancel`（ESC 暂停 goal）若遇到瞬时 DB 写失败，会静默丢失暂停——turnDriven 标记已清、暂停未落库，下一个 idle 事件让 goal 违背用户明确的 ESC 意图而复活。`shouldPreempt` 无法捕获 ESC（ESC 不产生 user 消息，lastUser 必早于 assistant）。

## Fix
`pauseForUserCancel` 改为显式重试循环：最多 3 次尝试（初次 + 2 次重试，50ms 退避）。用 `Effect.exit` 捕获完整 Cause（含 defect，避开 `Effect.retry` 对 defect 的歧义）；成功才 unregister lease；重试用尽改为 `logError` 高亮记录——goal 即使复活也绝不隐形。

## Evidence
- typecheck 干净；`test/goal` 103 pass（happy-path 由 turn-scope.test.ts 覆盖）
- 重试分支无干净故障注入缝隙：测试 DB 为 `:memory:`，`pauseAndPublish` 是 drizzle `orDie` 之上的 layer 闭包。按诊断纪律记录缝隙缺失，未硬造测试。

## 上下文
继 GOAL-FP-01-17（#283）后的收尾。goal-loop 静默失败面收敛计划的一环。