### PR TITLE
fix(hook): apply prompt-hook timeout, surface dropped HookCommand fields

### DIFF
--- a/packages/opencode/src/hook/settings.ts
+++ b/packages/opencode/src/hook/settings.ts
@@ -968,6 +968,16 @@ export function detectUnsupportedFields(
     for (const m of matchers) {
       for (const h of m.hooks ?? []) {
         if (h.shell !== undefined) unsupported.push({ field: "shell", value: h.shell, eventName })
+        // issue #286 — schema-accepted but executor-dropped fields. Surfaced
+        // here instead of silently swallowed: allowedEnvVars/statusMessage have
+        // zero consumers anywhere; per-command `once` is never read (only the
+        // entry-level _sessionEntry?.once is consumed). `timeout` is NOT
+        // flagged — every handler type applies it (incl. prompt).
+        if (h.allowedEnvVars !== undefined)
+          unsupported.push({ field: "allowedEnvVars", value: h.allowedEnvVars, eventName })
+        if (h.statusMessage !== undefined)
+          unsupported.push({ field: "statusMessage", value: h.statusMessage, eventName })
+        if (h.once !== undefined) unsupported.push({ field: "once", value: h.once, eventName })
         // `if` is implemented (condition-filter); async/asyncRewake implemented.
         // All 5 known types now have handlers; type-level unsupported set is empty by design.
       }
@@ -1537,10 +1547,19 @@ const promptHandler: HookHandler = {
         schema: HookJSONOutputZodSchema,
       } satisfies Parameters<typeof generateObject>[0]
 
+      // issue #286 — the header doc promises `timeout` for every hook type,
+      // but promptHandler was the only executor never applying it. Honor it
+      // with the same idiom as command/mcp/http; on expiry the TimeoutException
+      // is captured by Effect.exit below and degrades to the non-blocking warn.
+      const timeoutMs = entry.timeout ? entry.timeout * 1000 : DEFAULT_TIMEOUT_MS
+
       const llmExit = yield* Effect.tryPromise({
         try: () => generateObject(params).then((r) => r.object),
         catch: (e) => e,
-      }).pipe(Effect.exit)
+      }).pipe(
+        Effect.timeout(timeoutMs),
+        Effect.exit,
+      )
 
       if (llmExit._tag === "Failure") {
         log.warn("prompt hook failed (non-blocking)", { error: String(llmExit.cause) })

--- a/packages/opencode/test/hook/warn-unsupported.test.ts
+++ b/packages/opencode/test/hook/warn-unsupported.test.ts
@@ -38,4 +38,16 @@ describe("detectUnsupportedFields", () => {
     expect(detectUnsupportedFields(undefined)).toEqual([])
     expect(detectUnsupportedFields({})).toEqual([])
   })
+
+  // GOAL-FP/issue #286: HookCommand fields accepted by the schema but dropped
+  // by every executor must be surfaced, not silently swallowed. `timeout` for
+  // type "prompt" is implemented (excluded here); allowedEnvVars/statusMessage
+  // have zero consumers anywhere, and per-command `once` is never read (only
+  // the entry-level _sessionEntry?.once is consumed).
+  test("allowedEnvVars / statusMessage / per-command once are flagged (dropped by executors)", () => {
+    const unsupported = detectUnsupportedFields(
+      hooks({ allowedEnvVars: ["FOO"], statusMessage: "hi", once: true }),
+    )
+    expect(unsupported.map((u) => u.field).sort()).toEqual(["allowedEnvVars", "once", "statusMessage"])
+  })
 })


### PR DESCRIPTION
修复 issue #286（HookCommand schema 接受但执行器静默丢弃的字段）。

## Fix
1. **prompt-timeout 落地**：`promptHandler` 补 `Effect.timeout(entry.timeout ? entry.timeout*1000 : DEFAULT_TIMEOUT_MS)`——头部文档承诺所有 hook 类型都支持 timeout，此前唯 prompt 型未执行；超时经 `Effect.exit` 捕获后降级为既有非阻塞 warn。
2. **静默丢弃字段显式告警**：`detectUnsupportedFields` 追加 `allowedEnvVars`/`statusMessage`/per-command `once`（全仓库零消费者；entry 级 once 才有效）——配置者得到 warn 而非静默 no-op。`timeout` 不列入（已完整落地）。

## Evidence（/tdd）
- 红测先行：`test/hook/warn-unsupported.test.ts` 新增 flagging 用例（先 fail 后绿）
- `bun test test/hook` 146 pass / 0 fail；typecheck 干净
- 双轴自检（/code-review 纪律）：无 `any`、沿用既有 timeout 成语式、真实函数无 mock