### PR TITLE
docs(policy): add verdict-disposal classifier and explicit tier escalation

### DIFF
--- a/packages/core/src/plugin/command/orchestration-policy.md
+++ b/packages/core/src/plugin/command/orchestration-policy.md
@@ -267,6 +267,22 @@ of it in the same wake turn with exactly one of:
 4. A reasoned stop — tell the user, finding by finding, why no further wave
    is warranted. Silence is not a stop decision.
 
+Classify the findings first; the class selects the option:
+
+| Finding nature | Disposal |
+| --- | --- |
+| Bounded within the current scope | Option 1, same graph, tier unchanged |
+| Reveals cross-module, contract, persistence, or boundary risk the current shape cannot cover | Option 1 escalated: append full-shaped assurance lanes (broader review axes, extra verification) instead of the lite correction alone |
+| The situation itself was misclassified (a change assumed, an unknown-cause defect found; a repair assumed, a design gap found) | Option 3 only — the single legitimate route switch; start the workflow whose backbone matches the real deliverable and name which prior evidence carries over |
+| Unbounded or foggy — findings that no bounded wave can discharge | Option 4, or escalate to the user with a decision request; do not launder fog into a speculative wave |
+
+Route reselection is never the default: same-objective work stays in one
+workflow, and escalation keeps additive semantics — full-shaped assurance
+lanes are appended waves, not replacement graphs. The tier discriminator is
+risk only (reversibility, module span, public contracts, concurrency,
+persistence, migration, identity, authorization, upstream executables,
+CI/release). Role or block count never selects a tier.
+
 Merely summarizing a non-ACCEPT verdict and ending the turn is an
 orchestration failure. The runtime's `orchestrator_unresponsive` guard only
 fires for workflows that are still live; a checkpoint that terminalizes its

--- a/packages/core/src/plugin/command/workflow-routing.md
+++ b/packages/core/src/plugin/command/workflow-routing.md
@@ -53,12 +53,18 @@ suffice, work is reversible, and no high-risk boundary is involved. Use `full`
 when any are true: requirements or design are uncertain; work crosses modules
 or write owners; a public contract, concurrency, persistence, migration,
 identity, authorization, upstream executable dependencies, CI/release, or
-production behavior is in scope. A single matching custom workflow has no tier
-to infer: read and retarget it directly.
+production behavior is in scope. Only these risk dimensions select a tier —
+never role count or block count, which are consequences of risk, not causes.
+A single matching custom workflow has no tier to infer: read and retarget it
+directly.
 
-If a lite reporting gate returns non-`ACCEPT`, let that graph finish and use
-additive `extend` with new node IDs after reassessing the live library. Do not
-pause or replan a completed workflow; the parent owns this control decision.
+If a lite reporting gate returns non-`ACCEPT`, let that graph finish and
+dispose of the verdict under the Verdict Disposal Contract. When the findings
+cross any `full` criterion above, the correction wave MUST be full-shaped:
+escalate by appending full-shaped assurance lanes with new node IDs in the
+same workflow — a tier escalation is an additive wave, never a replacement
+workflow. Do not pause or replan a completed workflow; the parent owns this
+control decision.
 
 The primary reference follows the final artifact, not every concern. For code
 or repairs, review, security, and performance are secondary assurance in that

--- a/packages/core/test/plugin/command.test.ts
+++ b/packages/core/test/plugin/command.test.ts
@@ -118,8 +118,10 @@ describe("CommandPlugin.Plugin", () => {
       expect(CommandPlugin.WorkflowContent).toContain("upstream executable dependencies")
       expect(CommandPlugin.WorkflowContent).toContain("single matching custom workflow")
       expect(CommandPlugin.WorkflowContent).toContain("Do not concatenate two complete references")
-      expect(CommandPlugin.WorkflowContent).toContain("additive `extend` with new node IDs")
-      expect(CommandPlugin.WorkflowContent).toContain("Do not\npause or replan a completed workflow")
+      expect(CommandPlugin.WorkflowContent).toContain("never role count or block count, which are consequences of risk")
+      expect(CommandPlugin.WorkflowContent).toContain("dispose of the verdict under the Verdict Disposal Contract")
+      expect(CommandPlugin.WorkflowContent).toContain("the correction wave MUST be full-shaped")
+      expect(CommandPlugin.WorkflowContent).toContain("Do not pause or replan a completed workflow")
     }),
   )
 
@@ -249,6 +251,9 @@ describe("CommandPlugin.Plugin", () => {
       )
       expect(CommandPlugin.OrchestrationPolicyContent).toContain("escapes that guard")
       expect(CommandPlugin.OrchestrationPolicyContent).toContain("Silence is not a stop decision")
+      expect(CommandPlugin.OrchestrationPolicyContent).toContain("Classify the findings first; the class selects the option")
+      expect(CommandPlugin.OrchestrationPolicyContent).toContain("The situation itself was misclassified")
+      expect(CommandPlugin.OrchestrationPolicyContent).toContain("Role or block count never selects a tier")
       expect(CommandPlugin.WorkflowFactsContent).toContain("Verdict Disposal Contract")
     }),
   )


### PR DESCRIPTION
Closes #296

## Summary

The Verdict Disposal Contract listed four disposal options for a non-ACCEPT checkpoint verdict but gave no rule for choosing among them — so parents either stopped at summarizing (the failure the contract forbids) or reached for a replacement workflow when a bounded in-graph wave was right. Separately, lite→full escalation existed only as a hint.

## Change (guide text only, no runtime code)

- `orchestration-policy.md`: findings classification table inserted into the Verdict Disposal Contract — bounded → same-graph extend; boundary-revealing → escalated full-shaped lanes; misclassified situation → the single legitimate route switch (new workflow); foggy → reasoned stop or user escalation. Adds: route reselection is never the default; escalation is additive; the tier discriminator is risk only — role or block count never selects a tier.
- `workflow-routing.md`: tier escalation promoted from hint to an explicit rule (non-ACCEPT lite gate → dispose under the contract; findings crossing a full criterion MUST append full-shaped assurance lanes in the same workflow).

## Verification

- Command-plugin invariant tests updated to pin the new doctrine (classifier presence, risk-only discriminator, full-shaped correction wave) — `bun test test/plugin/command.test.ts` 21/21, `bun typecheck` clean from `packages/core`.

## Note

Wording-only; behavior enforcement lives in #300 (REJECT reachability) — this PR documents how to use it.