### PR TITLE
fix(dag): synthesize final-gate binding and review gate error wording

### DIFF
--- a/packages/opencode/src/dag/blocks.ts
+++ b/packages/opencode/src/dag/blocks.ts
@@ -276,6 +276,14 @@ function compileBlock(
 
   const verifyAggregatorIDs = verifyAggregators.get(block.id)
   const verifyAggregator = verifyAggregatorIDs && verifyAggregatorIDs.length > 0 ? verifyAggregatorIDs[0] : undefined
+  // A synthesize that follows a review is the route's final gate: it must map
+  // the review output so unresolvedReviewOutcomes/finalReviewGates recognize
+  // an ACCEPTed review as resolved (issue #304) — the same binding contract
+  // the verify aggregation path already honors.
+  const synthesizeGateBinding =
+    block.kind === "synthesize" && reviewDependency
+      ? { [`${reviewDependency.replace(/-/g, "_")}_review`]: `${reviewDependency}.output` }
+      : undefined
   return [
     node({
       id: block.id,
@@ -293,7 +301,7 @@ function compileBlock(
             implementation_changed_files: `${verifyAggregator}.output.changed_files`,
             implementation_fingerprint: `${verifyAggregator}.output.fingerprint`,
           }
-        : undefined,
+        : synthesizeGateBinding,
       outputSchema: WRITER_KINDS.has(block.kind)
         ? IMPLEMENTATION_SCHEMA
         : block.kind === "verify"

--- a/packages/opencode/src/dag/dag.ts
+++ b/packages/opencode/src/dag/dag.ts
@@ -112,7 +112,7 @@ export class ReviewGateError extends Error {
   readonly reviewIDs: string[]
 
   constructor(dagID: string, reviewIDs: string[]) {
-    super(`Cannot complete deep workflow ${dagID}: unresolved review outcome(s): ${reviewIDs.join(", ")}`)
+    super(`Cannot complete workflow ${dagID}: unresolved review outcome(s): ${reviewIDs.join(", ")}`)
     this.name = "ReviewGateError"
     this.dagID = dagID
     this.reviewIDs = reviewIDs

--- a/packages/opencode/test/dag/blocks.test.ts
+++ b/packages/opencode/test/dag/blocks.test.ts
@@ -161,6 +161,27 @@ describe("workflow blocks", () => {
     expect(nodes.find((node) => node.id === "report")?.condition).toBe('decision.output.verdict == "ACCEPT"')
   })
 
+  // Issue #304: a synthesize following a review is the route's final gate —
+  // it must map the review output, otherwise an ACCEPTed review stays listed
+  // as an unresolved review outcome forever.
+  it("binds the review output into a following synthesize as the final gate", () => {
+    const nodes = DagBlocks.compileWorkflowBlocks({
+      objective: "Deliver a reviewed change with a bound final report",
+      blocks: [
+        { id: "implementation", kind: "coding" },
+        { id: "verification", kind: "verify", depends_on: ["implementation"] },
+        { id: "decision", kind: "review", depends_on: ["verification"] },
+        { id: "report", kind: "synthesize", depends_on: ["decision"] },
+        { id: "side-note", kind: "synthesize", depends_on: ["verification"] },
+      ],
+    })
+
+    expect(nodes.find((node) => node.id === "report")?.input_mapping).toEqual({
+      decision_review: "decision.output",
+    })
+    expect(nodes.find((node) => node.id === "side-note")?.input_mapping).toBeUndefined()
+  })
+
   it("keeps every downstream branch behind a reporting scope gate", () => {
     const nodes = DagBlocks.compileWorkflowBlocks({
       objective: "Deliver only while the bounded route remains valid",

--- a/packages/opencode/test/dag/dag-wake-integration.test.ts
+++ b/packages/opencode/test/dag/dag-wake-integration.test.ts
@@ -788,6 +788,8 @@ describe("DagLoop atomic wake integration", () => {
         expect(completion).toBeInstanceOf(Error)
         if (!(completion instanceof Error)) throw new Error("deep completion unexpectedly succeeded")
         expect(completion.message).toContain("unresolved review outcome")
+        // Issue #305: the gate message must not claim a mode it does not check.
+        expect(completion.message).not.toContain("deep workflow")
         expect((yield* store.getWorkflow(dagID))?.status).toBe("running")
         expect((yield* store.getNode(dagID, "review-diff"))?.status).toBe("pending")
       }),


### PR DESCRIPTION
Closes #304 and #305 — both discovered by live end-to-end testing of v1.0.21.

## #304 — false unresolved_reviews after ACCEPT

`workflow(action="status")` reported `unresolved_reviews` for a diff review that settled ACCEPT and completed the graph. Root cause: `finalReviewGates` requires the final gate to map the review's output; the block compiler emitted the follow-up `synthesize` with no `input_mapping`, so no gate was ever found and an ACCEPTed review stayed "unresolved" forever. Same contract-vs-binding pattern as the pre-#299 verify gap.

Fix: a `synthesize` depending on a review now binds that review's output into its `input_mapping` (its condition is already `<review>.output.verdict == "ACCEPT"`), satisfying all three `finalReviewGates` axes. Side effect: block routes shaped `… → review → synthesize` become valid under deep-mode `validateFinalReviewGate` too, removing the mode cliff.

Tests: new compile-seam case asserts the binding exists (and is absent without a review dependency); existing `unresolvedReviewOutcomes` cases already prove the resolver accepts this shape.

## #305 — gate message claimed "deep workflow" in all modes

`ReviewGateError` wording dropped the unsupported mode claim (gate behavior unchanged). The wake-integration test now pins the message free of the "deep workflow" wording.

## Verification

- 550 DAG/tool tests green (72 focused), `bun typecheck` clean.
