### PR TITLE
fix(core): encode GitLab version-endpoint auth in dag-init probe

### DIFF
--- a/packages/core/src/plugin/command/dag-init.txt
+++ b/packages/core/src/plugin/command/dag-init.txt
@@ -15,12 +15,17 @@ Arguments (optional): $ARGUMENTS
    - Not a git repo, or no `origin` → STOP: "`/dag-*` requires a git remote."
    - Host is `github.com` → platform `github`, CLI `gh`.
    - Host is `gitlab.com` → platform `gitlab`, CLI `glab`.
-   - Any other host → probe whether it is a self-hosted GitLab:
-     `curl -sSf https://<host>/api/v4/version` (or `glab api version` against
-     that host once authed). Responds as GitLab → platform `gitlab`
-     (self-hosted), CLI `glab` pinned to that host. Otherwise → STOP:
-     "unsupported platform: only GitHub and GitLab (self-hosted included)
-     are supported." Bitbucket/Gitea/other remotes are rejected here.
+   - Any other host → decide whether it is a self-hosted GitLab. GitLab's
+     `/api/v4/version` endpoint REQUIRES authentication by API design, so a
+     healthy instance answers a bare request with 401 — that 401 is POSITIVE
+     evidence (the endpoint exists and answers), not a failure. Probe order:
+     `curl -sSf https://<host>/api/v4/version`; a version JSON response OR a
+     401/GitLab-shaped error → classify as GitLab; connection refused or a
+     non-GitLab answer → STOP: "unsupported platform: only GitHub and GitLab
+     (self-hosted included) are supported." Bitbucket/Gitea/other remotes are
+     rejected here. Once classified, re-verify with `glab api version` after
+     step 2 auth passes. Platform `gitlab` (self-hosted), CLI `glab` pinned
+     to that host.
    - When `origin` and a different `upstream` exist and point at different
      repositories, ask the user ONCE which remote `/dag-auto` should bind to
      and record the choice; otherwise bind `origin`.

--- a/packages/core/test/plugin/command.test.ts
+++ b/packages/core/test/plugin/command.test.ts
@@ -61,6 +61,8 @@ describe("CommandPlugin.Plugin", () => {
       })
       expect(CommandPlugin.DagInitContent).toContain("$ARGUMENTS")
       expect(CommandPlugin.DagInitContent).toContain("unsupported platform: only GitHub and GitLab")
+      expect(CommandPlugin.DagInitContent).toContain("401 is POSITIVE")
+      expect(CommandPlugin.DagInitContent).toContain("re-verify with `glab api version`")
       expect(CommandPlugin.DagInitContent).toContain(".opencode/dag-init.json")
       expect(CommandPlugin.DagInitContent).toContain("merge_policy")
       expect(yield* command.get("dag-auto")).toMatchObject({


### PR DESCRIPTION
Closes #312

## 问题

`/dag-init` 自建 GitLab 探测段把裸 curl 放第一位、认证调用写成"或者"——而 GitLab 的 `/api/v4/version` **按 API 设计要求认证**，健康实例对裸请求返回 401 是标准行为。照文本执行的 agent 必吃一次失败才反应过来（git.ycgame.com 实弹已复现：curl 401 → glab 认证通道兜底）。

## 修复（提示词卫生）

改写 `dag-init.txt` 探测段，编码两个认知点：

1. **401 是阳性证据**——端点存在且在应答，恰好证明是 GitLab；version JSON 或 401/GitLab 形状错误 → 判定 GitLab；连接拒绝/非 GitLab 应答 → STOP
2. **认证调用是复核主路径**——判定为 GitLab 且 step 2 鉴权通过后 `glab api version` 复核

## 验证

- packages/core `bun typecheck` ✅
- `bun test test/plugin/command.test.ts` 21/21 ✅（新增两条锚点断言：`401 is POSITIVE`、`re-verify with glab api version`）

后续 agent 按文本一次通过自建实例探测，不再消耗失败回合。