### PR TITLE
fix(test): watchdog silent stand-down on missing heartbeat + teardown heartbeats

### DIFF
--- a/packages/opencode/test/server/httpapi-exercise/backend.ts
+++ b/packages/opencode/test/server/httpapi-exercise/backend.ts
@@ -57,10 +57,23 @@ type CachedApp = BackendApp & { readonly dispose: () => Promise<void> }
 
 const appCache: Partial<Record<string, CachedApp>> = {}
 
-export async function disposeApps() {
+export async function disposeApps(heartbeat?: (label: string) => void) {
   const apps = Object.values(appCache)
   for (const key of Object.keys(appCache)) delete appCache[key]
-  await Promise.all(apps.flatMap((app) => (app === undefined ? [] : [app.dispose()])))
+  heartbeat?.(`teardown: disposing ${apps.filter((app) => app !== undefined).length} app(s)`)
+  await Promise.all(
+    apps.flatMap((app, i) =>
+      app === undefined
+        ? []
+        : [
+            app.dispose().then(
+              () => heartbeat?.(`teardown: app[${i}] disposed`),
+              (err) => heartbeat?.(`teardown: app[${i}] dispose error: ${err}`),
+            ),
+          ],
+    ),
+  )
+  heartbeat?.("teardown: all apps disposed")
 }
 
 function app(modules: Runtime, options: CallOptions) {

--- a/packages/opencode/test/server/httpapi-exercise/index.ts
+++ b/packages/opencode/test/server/httpapi-exercise/index.ts
@@ -2151,7 +2151,13 @@ const llmScenarios = new Set([
 ])
 
 const main = Effect.gen(function* () {
-  yield* Effect.addFinalizer(() => Effect.promise(() => disposeApps()).pipe(Effect.andThen(cleanupExercisePaths)))
+  yield* Effect.addFinalizer(() =>
+    Effect.promise(() => disposeApps(options.heartbeat)).pipe(
+      Effect.andThen(Effect.sync(() => options.heartbeat?.("teardown: cleanupExercisePaths"))),
+      Effect.andThen(cleanupExercisePaths),
+      Effect.andThen(Effect.sync(() => options.heartbeat?.("teardown: complete"))),
+    ),
+  )
   const parsed = parseOptions(Bun.argv.slice(2))
   const options: Options = parsed.progress ? { ...parsed, heartbeat: startProgressWatchdog() } : parsed
   const modules = yield* Effect.promise(() => runtime())

--- a/packages/opencode/test/server/httpapi-exercise/watchdog.ts
+++ b/packages/opencode/test/server/httpapi-exercise/watchdog.ts
@@ -24,6 +24,11 @@ const pid = Number(process.env.WATCHDOG_PID)
 const file = process.env.WATCHDOG_FILE
 const timeoutMs = Number(process.env.WATCHDOG_TIMEOUT_MS)
 const pollMs = Number(process.env.WATCHDOG_POLL_MS)
+// A missing heartbeat file is treated as stalled (tracked via missingSince),
+// never as healthy: CI runners can reclaim tmpdir files, and silently
+// standing down when the file disappears is what let the 2026-08-17
+// teardown hang burn the full 15m step timeout without a kill.
+let missingSince = 0
 setInterval(() => {
   let alive = true
   try {
@@ -36,12 +41,18 @@ setInterval(() => {
   try {
     mtime = fs.statSync(file).mtimeMs
   } catch {}
-  if (!mtime || Date.now() - mtime <= timeoutMs) return
+  if (mtime) {
+    missingSince = 0
+    if (Date.now() - mtime <= timeoutMs) return
+  } else {
+    if (!missingSince) missingSince = Date.now()
+    if (Date.now() - missingSince <= timeoutMs) return
+  }
   let last = "<none>"
   try {
     last = fs.readFileSync(file, "utf8")
   } catch {}
-  console.error("[watchdog] no progress for " + Math.round((Date.now() - mtime) / 1000) + "s; last activity: " + last + " — killing pid " + pid)
+  console.error("[watchdog] no progress for " + Math.round((Date.now() - (mtime || missingSince)) / 1000) + "s; last activity: " + last + " — killing pid " + pid)
   try {
     process.kill(pid, "SIGKILL")
   } catch {}


### PR DESCRIPTION
Closes 首个 #316 交付物（挂起可诊断化）；#316 根因继续开放。

## 问题

2026-08-17 CI：httpapi exerciser 在 `summary pass=229` 后静默挂起 15 分钟被 step timeout 杀掉（run 31994077328，同 commit 孪生 run 绿）。 已武装进程外看门狗，但**全程未开火**。

## 根因之一（已修）

看门狗仔脚本把**心跳文件缺失当健康**：

```js
if (!mtime || Date.now() - mtime <= timeoutMs) return  // 文件没了 = 永久静默
```

CI runner 回收 tmpdir 文件即解除武装。本机独立验证复现：正常场景 3 秒开火 ✅；删除心跳文件后静默不作为（漏洞）→ 修复后 3 秒开火 ✅。

## 修复

1. **缺失即停滞**：记录 missing-since，超过 timeout 照杀——静默路径不存在了
2. **teardown 心跳**：disposeApps 逐 app + cleanup + complete 各写心跳标签——下次挂起直接点名卡在 teardown 哪一段

## 验证

- packages/opencode `bun typecheck` ✅
- `--mode effect --include dag --progress`：exit 0、22 pass、零误触发 ✅
- 缺文件场景：3 秒开火并报告 `last activity: <none>` ✅

## 对 #316 的意义

下一个真实挂起将被看门狗在 120s 内终结并**带出现场归因**（哪个 app 的 dispose、哪段 cleanup），根因从现场钉死，不再依赖低命中率复现。