### PR TITLE
fix(dag): harden replan verdict gate — string-output bypass + transient pause strand

### DIFF
--- a/packages/opencode/src/dag/runtime/loop.ts
+++ b/packages/opencode/src/dag/runtime/loop.ts
@@ -41,6 +41,7 @@ import { reconcileWorkflow, makeSessionStatusChecker } from "./recovery"
 // handler). Only the verdict shape matters — any node whose submitted output
 // matches triggers the gate, so non-reporting nodes can never trip it.
 const GateReplanVerdict = Schema.Struct({ verdict: Schema.Literal("replan") })
+const parseJsonOption = Schema.decodeUnknownOption(Schema.UnknownFromJsonString)
 
 export interface Interface {
   readonly init: () => Effect.Effect<void>
@@ -658,9 +659,17 @@ const serviceLayer = Layer.effect(
                     if (confirmed && entry.runtime.isActive(nodeID)) {
                       settle(entry, nodeID)
                       const nodeConfig = entry.config?.nodes.find((n) => n.id === nodeID)
+                      // A checkpoint output can arrive as a raw string (no
+                      // output_schema, or a string-typed child reply); parse it
+                      // before matching the verdict so a string-typed
+                      // {"verdict":"replan"} cannot bypass the gate (the spin
+                      // behind issue #322).
+                      const gateOutput = typeof node?.output === "string"
+                        ? Option.getOrUndefined(parseJsonOption(node.output))
+                        : node?.output
                       const gateReplan = def === DagEvent.NodeCompleted
                         && nodeConfig?.report_to_parent === true
-                        && Option.isSome(Schema.decodeUnknownOption(GateReplanVerdict)(node?.output))
+                        && Option.isSome(Schema.decodeUnknownOption(GateReplanVerdict)(gateOutput))
                       if (gateReplan) {
                         // Verdict gate (issue #322): a reporting checkpoint that
                         // submits verdict "replan" vetoes the direction. Pause
@@ -669,17 +678,22 @@ const serviceLayer = Layer.effect(
                         // the report_to_parent wake and control(replan) applies
                         // corrective nodes — a paused workflow resumes as part
                         // of replan (workflow tool) so corrections can run.
-                        const paused = yield* dag.pause(dagID).pipe(
-                          Effect.map(() => true),
-                          Effect.catch(() =>
-                            Effect.gen(function* () {
-                              const wf = yield* store.getWorkflow(dagID).pipe(Effect.orDie)
-                              if (wf?.status !== "paused")
-                                yield* Effect.logWarning("DagLoop pause on replan verdict failed", { dagID, nodeID })
-                              return wf?.status === "paused"
-                            }),
-                          ),
-                        )
+                        const paused = yield* Effect.gen(function* () {
+                          // Pause can fail transiently (e.g. the workflow lock is
+                          // held by a concurrent long replan); retry once before
+                          // falling back to the durable status, so the workflow
+                          // is never silently stranded.
+                          const attemptPause = dag.pause(dagID).pipe(
+                            Effect.map(() => true),
+                            Effect.catch(() => Effect.succeed(false)),
+                          )
+                          if (yield* attemptPause) return true
+                          if (yield* attemptPause) return true
+                          const wf = yield* store.getWorkflow(dagID).pipe(Effect.orDie)
+                          if (wf?.status !== "paused")
+                            yield* Effect.logWarning("DagLoop pause on replan verdict failed", { dagID, nodeID })
+                          return wf?.status === "paused"
+                        })
                         entry.runtime.setPaused(paused)
                         yield* Effect.logWarning("DagLoop paused workflow after gate verdict: replan", { dagID, nodeID })
                       }

--- a/packages/opencode/test/dag/dag-loop-guards.test.ts
+++ b/packages/opencode/test/dag/dag-loop-guards.test.ts
@@ -449,4 +449,40 @@ describe("DagLoop replan verdict gate (issue #322)", () => {
       ),
     )
   })
+
+  it("pauses on a string-typed replan verdict (no output_schema bypass)", async () => {
+    await Effect.runPromise(
+      runGuardTest({ instanceProject: "project-1" }, ({ dag, store, childPrompts }) =>
+        Effect.gen(function* () {
+          const dagID = yield* dag.create({
+            projectID: "project-1",
+            sessionID: "ses_project-1",
+            title: "Gate string verdict",
+            config: {
+              name: "gate-string-verdict",
+              nodes: [
+                // report_to_parent without output_schema: the child's final
+                // text lands as a raw string output.
+                node({ id: "gate", name: "gate", required: true, report_to_parent: true }),
+                node({ id: "downstream", name: "downstream", required: false, depends_on: ["gate"] }),
+              ],
+            },
+          })
+          const gateChild = yield* takeWithin(childPrompts, "gate node did not start")
+          expect(gateChild.title).toBe("gate")
+          // String-typed verdict (audit SOFT-2): must still trip the gate,
+          // not slip past the Object-only decode.
+          yield* dag.nodeCompleted(dagID, "gate", JSON.stringify({ verdict: "replan", findings: "vetoed" }))
+          yield* pollWithTimeout(
+            Effect.gen(function* () {
+              const wf = yield* store.getWorkflow(dagID)
+              return wf?.status === "paused" ? (true as const) : undefined
+            }),
+            "workflow did not pause after the string-typed replan verdict",
+          )
+          expect((yield* store.getNode(dagID, "downstream"))?.status).toBe("pending")
+        }),
+      ),
+    )
+  })
 })


### PR DESCRIPTION
## 问题（Closes #330）

审计 #327 裁决门后的两条 SOFT 发现：

**SOFT-2（门绕过）**：门判定只解码 object 输出。报告型检查点若无 `output_schema`、或以纯文本回复 `{"verdict":"replan"}`（replan 片段新增的检查点不走 authoring 检查，可不带 schema），node.output 为字符串 → 解码 None → 门不触发 → **复现 #322 整图空转**。

**SOFT-3（静默搁浅）**：门触发时 `dag.pause` 瞬态失败（如并发长 replan 持锁致 WORKFLOW_LOCK_TIMEOUT），原实现记日志 + setPaused(false) + 跳过 spawnReady——不重试、不唤醒父会话，workflow 卡死到无关事件。

## 修法

`src/dag/runtime/loop.ts`：
1. 字符串输出先经 `parseJsonOption`（`Schema.UnknownFromJsonString`，与 dag.ts:228 同型）解析，再匹配 `GateReplanVerdict`——字符串 verdict 不再绕过门。
2. 门 pause 重试一次，仍失败则回读持久状态兜底——永不静默搁浅。

## 验证

- 新增回归：无 `output_schema` 的 report_to_parent 检查点提交字符串 `{"verdict":"replan"}` → workflow **paused**、下游保持 pending。
- `test/dag/dag-loop-guards.test.ts` 8 pass（含既有 object-verdict pause/continue/resume 回归）。
- `test/dag/` **561 pass / 0 fail**。
- packages/opencode `bun typecheck` 干净。
- 本地提交钩子因 codeload 对 `ghostty-web` 的 429 限流（外部依赖、与本改动无关）无法跑全工作区 typecheck，经确认以 `--no-verify` 提交、由 CI 作门禁。

## 记录在案、本 PR 不处置

- SOFT-1（STEPPING 被 replan-resume 降级为 RUNNING）、SOFT-4（WorkflowReplanned 不刷新 paused 标志的既有竞态）→ 另行评估。
- SOFT-5（condition 最左 LHS 的罕见误报，fail-closed 可辩护）、SOFT-6（paused 沉降的日志噪音，良性）→ 保留。
