### PR TITLE
fix(dag): adversarial verification clause on reporting checkpoints (issue #323)

### DIFF
--- a/packages/opencode/src/dag/blocks.ts
+++ b/packages/opencode/src/dag/blocks.ts
@@ -327,6 +327,14 @@ function node(input: {
   outputSchema?: Record<string, unknown>
 }): NodeConfig {
   const instruction = input.instruction?.trim() ? "Block-specific instruction:\n{{instruction}}" : ""
+  // issue #323: a reporting checkpoint adjudicates a direction, so its
+  // prompt must demand adversarial independent verification. The production
+  // incident: a gate confirmed parent-supplied "defect evidence" that was a
+  // production no-op because it re-read the parent's narrative instead of
+  // the source. Upstream claims are hypotheses, not facts.
+  const adversarial = input.reportToParent
+    ? "As a reporting checkpoint you adjudicate this direction: treat upstream and parent-supplied claims as hypotheses to verify, never facts to confirm. independently read the relevant source before endorsing the most load-bearing claims, cite what you actually inspected, and replan or reject the direction when a load-bearing claim does not survive inspection."
+    : ""
   return {
     id: input.id,
     name: input.name,
@@ -339,6 +347,7 @@ function node(input: {
         "Workflow objective:\n{{objective}}",
         instruction,
         input.contract,
+        adversarial,
         "Use dependency outputs as evidence and return a concise artifact that downstream blocks can consume. Do not ask the user questions from this child session.",
       ]
         .filter(Boolean)

--- a/packages/opencode/src/dag/blocks.ts
+++ b/packages/opencode/src/dag/blocks.ts
@@ -333,7 +333,7 @@ function node(input: {
   // production no-op because it re-read the parent's narrative instead of
   // the source. Upstream claims are hypotheses, not facts.
   const adversarial = input.reportToParent
-    ? "As a reporting checkpoint you adjudicate this direction: treat upstream and parent-supplied claims as hypotheses to verify, never facts to confirm. independently read the relevant source before endorsing the most load-bearing claims, cite what you actually inspected, and replan or reject the direction when a load-bearing claim does not survive inspection."
+    ? "As a reporting checkpoint you adjudicate this direction: treat upstream and parent-supplied claims as hypotheses to verify, never facts to confirm. Independently read the relevant source before endorsing, spot-check at least three of the most load-bearing claims (name the count you actually inspected), cite what you actually inspected, and replan or reject the direction when a load-bearing claim does not survive inspection."
     : ""
   return {
     id: input.id,

--- a/packages/opencode/test/dag/blocks.test.ts
+++ b/packages/opencode/test/dag/blocks.test.ts
@@ -44,6 +44,54 @@ describe("workflow blocks", () => {
     ])
   })
 
+  // issue #323: a reporting checkpoint adjudicates a direction — its prompt
+  // must demand adversarial independent verification, not self-confirmation
+  // of upstream claims. The production incident: cp-after-exploration
+  // confirmed a parent-supplied "defect" that was a production no-op because
+  // the gate re-read the parent's narrative instead of reading the source.
+  it("compiles reporting checkpoints with an adversarial verification clause", () => {
+    const nodes = DagBlocks.compileWorkflowBlocks({
+      objective: "Ship the feature",
+      blocks: [
+        { id: "cp-after-exploration", kind: "explore", report_to_parent: true },
+        { id: "stage", kind: "coding", depends_on: ["cp-after-exploration"] },
+      ],
+    })
+    const checkpoint = nodes.find((node) => node.id === "cp-after-exploration")
+    expect(checkpoint?.report_to_parent).toBe(true)
+    // Upstream claims are hypotheses to verify, not facts to confirm.
+    expect(checkpoint?.prompt_template.inline).toContain("hypotheses to verify")
+    // Independent source inspection is mandatory for load-bearing claims.
+    expect(checkpoint?.prompt_template.inline).toContain("independently read the relevant source")
+    // A claim that fails inspection must fail the direction, not pass it.
+    expect(checkpoint?.prompt_template.inline).toContain("replan or reject")
+  })
+
+  it("keeps the adversarial clause off non-reporting nodes", () => {
+    const nodes = DagBlocks.compileWorkflowBlocks({
+      objective: "Ship the feature",
+      blocks: [
+        { id: "map", kind: "explore" },
+        { id: "stage", kind: "coding", depends_on: ["map"] },
+      ],
+    })
+    // Only adjudicating checkpoints pay the adversarial cost; evidence
+    // producers (a plain explore) and executors (coding) do not.
+    for (const node of nodes) {
+      expect(node.report_to_parent).toBe(false)
+      expect(node.prompt_template.inline).not.toContain("hypotheses to verify")
+    }
+  })
+
+  it("gives default-reporting synthesize nodes the adversarial clause", () => {
+    const nodes = DagBlocks.compileWorkflowBlocks({
+      objective: "Ship the feature",
+      blocks: [{ id: "closing", kind: "synthesize" }],
+    })
+    expect(nodes[0]?.report_to_parent).toBe(true)
+    expect(nodes[0]?.prompt_template.inline).toContain("hypotheses to verify")
+  })
+
   it("composes configured design delivery capabilities without new lifecycle kinds", () => {
     const nodes = DagBlocks.compileWorkflowBlocks({
       objective: "Design, implement, and review project-owned memory",

--- a/packages/opencode/test/dag/blocks.test.ts
+++ b/packages/opencode/test/dag/blocks.test.ts
@@ -62,7 +62,9 @@ describe("workflow blocks", () => {
     // Upstream claims are hypotheses to verify, not facts to confirm.
     expect(checkpoint?.prompt_template.inline).toContain("hypotheses to verify")
     // Independent source inspection is mandatory for load-bearing claims.
-    expect(checkpoint?.prompt_template.inline).toContain("independently read the relevant source")
+    expect(checkpoint?.prompt_template.inline).toContain("Independently read the relevant source")
+    // A quantified spot-check floor on the most load-bearing claims.
+    expect(checkpoint?.prompt_template.inline).toContain("at least three")
     // A claim that fails inspection must fail the direction, not pass it.
     expect(checkpoint?.prompt_template.inline).toContain("replan or reject")
   })


### PR DESCRIPTION
## 概要

按 issue #323 维护者批准的拆分处置（triage notes 在案）：本 PR 偿付**本仓库部分**——修法选项 1 的 prompt 层，落在 block 编译器；选项 2（provisional 标记）与 curated 模板覆写审查按分工移交 `LeXwDeX/opencode-dag-config`。

## 改动

- `blocks.ts` `node()`：`reportToParent` 节点（门/检查点语义——显式 `report_to_parent: true` 的任意 block + 默认 reporting 的 synthesize）的内联 prompt 追加对抗性验证子句，四个硬要求对应 issue 修法：
  1. 上游/父会话声明 = **待检验假设**，绝非待确认事实
  2. 背书前**独立读源码**
  3. 最承重声明**抽查数量下限**（至少 3 条，须报出实际检查数）
  4. 承重声明不通过检验 → **replan/reject 该方向**
- 非 reporting 节点 prompt 字节不变（空串经既有 `.filter(Boolean)` 滤除）。

## 测试（结构断言，按批准的 mock 形态）

- reporting explore：四个硬要求各有 `toContain` 断言（变异可验证）
- 非 reporting 节点排除（零成本外溢）
- 默认 reporting 的 synthesize 同获子句

## 证据

- 红（子句缺失 2 测试红）→ 绿 → 变异（子句置空 → 翻红）
- dag 簇 578/578 绿 + `bun typecheck` + turbo 29/29
- 双镜审阅 2 轮：R1 BLOCKING（抽查数量要求缺失——已补"at least three"下限+断言）→ **R2 零 findings**

## 关联

- 结构面（同形状 authoring 期拒启动）已由 #335 偿付
- config 仓库移交清单已记入 issue #323：curated 模板 instruction 覆写审查、provisional follow-up、e2e 由其模板校验 CI 承接