### PR TITLE
chore(specgit): enable SpecGit delivery harness

### DIFF
--- a/.github/workflows/specgit-accept.yml
+++ b/.github/workflows/specgit-accept.yml
@@ -1,0 +1,90 @@
+name: SpecGit Acceptance
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  specgit-acceptance:
+    name: SpecGit Acceptance
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Check out the PR head branch by name so HEAD is on the branch
+          # (not the detached merge ref): the execution context gate reads
+          # live git. Falls back to the default ref on non-PR events.
+          ref: ${{ github.head_ref || github.ref }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '20.19.0'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build CLI
+        run: pnpm run build
+
+      - name: Wait for sibling checks
+        # The verdict must see the OTHER required checks in a terminal
+        # state. Sibling jobs start in parallel AND may not have registered
+        # their check-runs yet, so an empty poll is not "done": wait until
+        # every name in spec_git/policy.yaml is present with a terminal
+        # conclusion. This job is not in the policy, so no self-deadlock.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          WAIT_REPO: ${{ github.repository }}
+          WAIT_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          node --input-type=module <<'EOF'
+          import { readFileSync } from 'node:fs';
+          import { parse } from 'yaml';
+          const policy = parse(readFileSync('spec_git/policy.yaml', 'utf8'));
+          const required = policy.required_checks ?? [];
+          const headers = {
+            authorization: 'Bearer ' + process.env.GH_TOKEN,
+            accept: 'application/vnd.github+json',
+          };
+          const url = 'https://api.github.com/repos/' + process.env.WAIT_REPO
+            + '/commits/' + process.env.WAIT_SHA + '/check-runs?per_page=100';
+          const terminal = new Set(['completed']);
+          const terminalHas = (byName, name) => {
+            if (byName.has(name)) return terminal.has(byName.get(name));
+            const retried = [...byName.keys()].find((k) => k.startsWith(name + ' ('));
+            return retried !== undefined && terminal.has(byName.get(retried));
+          };
+          const deadline = Date.now() + 15 * 60 * 1000;
+          while (Date.now() < deadline) {
+            const res = await fetch(url, { headers });
+            if (!res.ok) throw new Error('check-runs API ' + res.status);
+            const payload = await res.json();
+            const byName = new Map(payload.check_runs.map((r) => [r.name, r.status]));
+            const missing = required.filter((n) => !terminalHas(byName, n));
+            if (missing.length === 0) {
+              console.log('All required checks are in a terminal state.');
+              process.exit(0);
+            }
+            console.log('Waiting for: ' + missing.join(', '));
+            await new Promise((r) => setTimeout(r, 10000));
+          }
+          console.error('Timed out waiting for sibling checks.');
+          process.exit(1);
+          EOF
+
+      - name: specgit finish
+        run: node bin/specgit.js finish --json
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/specgit-accept.yml
+++ b/.github/workflows/specgit-accept.yml
@@ -2,7 +2,9 @@ name: SpecGit Acceptance
 
 on:
   pull_request:
-    branches: [main]
+    # Delivery PRs target dev (fast-integration layer); dev→main promotion
+    # stays governed by the protect-main Ruleset's four required checks.
+    branches: [dev]
 
 permissions:
   contents: read

--- a/.github/workflows/specgit-accept.yml
+++ b/.github/workflows/specgit-accept.yml
@@ -25,20 +25,15 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
-
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20.19.0'
-          cache: 'pnpm'
+          node-version: '22'
 
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Build CLI
-        run: pnpm run build
+      # This repo is a bun workspace and does not vendor the SpecGit CLI;
+      # install the published CLI instead of building from source.
+      - name: Install specgit CLI
+        run: npm install -g specgit
 
       - name: Wait for sibling checks
         # The verdict must see the OTHER required checks in a terminal
@@ -53,9 +48,11 @@ jobs:
         run: |
           node --input-type=module <<'EOF'
           import { readFileSync } from 'node:fs';
-          import { parse } from 'yaml';
-          const policy = parse(readFileSync('spec_git/policy.yaml', 'utf8'));
-          const required = policy.required_checks ?? [];
+          // Minimal parse of policy.yaml's required_checks block list —
+          // avoids a yaml dependency in this bun-based repo.
+          const policy = readFileSync('spec_git/policy.yaml', 'utf8');
+          const section = policy.slice(policy.indexOf('required_checks:'));
+          const required = [...section.matchAll(/^\s*-\s*(.+)$/gm)].map((m) => m[1].trim());
           const headers = {
             authorization: 'Bearer ' + process.env.GH_TOKEN,
             accept: 'application/vnd.github+json',
@@ -87,6 +84,6 @@ jobs:
           EOF
 
       - name: specgit finish
-        run: node bin/specgit.js finish --json
+        run: specgit finish --json
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.opencode/command/specgit-finish.md
+++ b/.opencode/command/specgit-finish.md
@@ -1,0 +1,27 @@
+---
+description: Run the SpecGit evidence verdict and drive the fix loop to exit 0
+---
+
+# /specgit-finish
+
+Thin trigger for the acceptance verdict. The canonical behavior lives in the
+AGENTS.md SpecGit block; this command only launches it.
+
+## Steps
+
+1. Run from the delivery branch:
+
+   ```bash
+   specgit finish --json
+   ```
+
+2. Branch on the exit code:
+   - `exit 0` → produce the merge brief (issues + PR + CI run links + the
+     verdict) and ask the user to approve the merge. Do not merge yourself
+     without approval.
+   - `exit 1` → read `errors[].fix` / gate failures, fix exactly what they
+     name, re-run. Loop until exit 0.
+   - `exit 3` → report the environment problem (gh auth / network); never
+     edit the record or the policy to work around it.
+3. Iron rules: never weaken `spec_git/policy.yaml` to pass; `--json` is the
+   only parse surface; a non-zero verdict never merges.

--- a/.opencode/command/specgit-issue.md
+++ b/.opencode/command/specgit-issue.md
@@ -1,0 +1,22 @@
+---
+description: Start a SpecGit delivery from a title or existing issue number
+---
+
+# /specgit-issue
+
+Thin trigger for the delivery bootstrap. The canonical behavior lives in the
+AGENTS.md SpecGit block; this command only launches it.
+
+## Steps
+
+1. Collect the argument: `$ARGUMENTS` is either an issue title (create) or a
+   pure number (reuse). Multiple arguments = N issues in one delivery.
+2. Run from the repo root:
+
+   ```bash
+   specgit issue "$ARGUMENTS" --json
+   ```
+
+3. On success report the brief: issue URL(s), PR URL (draft), branch name.
+4. Switch to the delivery branch and begin the TDD loop.
+5. On error, read `errors[].fix` and follow it — never bypass the record.

--- a/.opencode/hooks/specgit-merge-guard.sh
+++ b/.opencode/hooks/specgit-merge-guard.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# SpecGit merge guard (managed by specgit init). Exit 2 = block with reason.
+command=$(printf '%s' "$1" | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{try{const j=JSON.parse(s);process.stdout.write((j.tool_input&&j.tool_input.command)||'')}catch{process.stdout.write('')}})")
+
+case "$command" in
+  gh\ pr\ merge*)
+    # Real-time verdict: re-evaluate the delivery before letting a merge
+    # through. Verdicts are never persisted, so compute one now.
+    if specgit finish >/dev/null 2>&1; then
+      exit 0
+    fi
+    echo "specgit: merge blocked - 'specgit finish' does not exit 0 right now. Fix what the failures name; never weaken spec_git/policy.yaml to pass." >&2
+    exit 2
+    ;;
+  git\ push\ origin\ main*|git\ push\ origin\ +main*|git\ push\ origin\ HEAD:main*)
+    echo "specgit: direct push to main is not the delivery path. Deliveries go: specgit issue -> PR -> CI -> specgit finish (exit 0) -> merge." >&2
+    exit 2
+    ;;
+esac
+exit 0

--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -5,3 +5,4 @@ context:
   branch: feat/353-chore-specgit-enable
 issues:
   - 353
+pr: 354

--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -1,7 +1,7 @@
 version: 1
-delivery: fix-opencode-auto
+delivery: chore-specgit-enable
 context:
   kind: branch
-  branch: feat/351-fix-opencode-auto
+  branch: feat/353-chore-specgit-enable
 issues:
-  - 351
+  - 353

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,3 +240,41 @@ Triage uses the five canonical labels `needs-triage`, `needs-info`, `ready-for-a
 ### Domain docs
 
 This repository uses a multi-context domain-document layout rooted at `CONTEXT-MAP.md`. See `docs/agents/domain.md`.
+
+<!-- specgit:block:start -->
+## SpecGit delivery harness
+
+Managed by `specgit init`. Everything between the markers is rewritten on
+re-init; keep manual guidance outside them.
+
+### The delivery story
+
+- Start with `specgit issue <title-or-number>...`: it creates or reuses
+  the issues, branches, opens the draft pull request that closes every
+  bound issue, and writes `.specgit.yaml`. Re-running resumes; it is
+  idempotent.
+- Finish with `specgit finish`: the verdict, derived from real git, PR,
+  and CI evidence. Exit code 0 is the only "done".
+
+### Repair and diagnostics
+
+- `specgit pr` repairs the pull-request binding: with no arguments it
+  auto-discovers the pull request for this head branch, errors with a fix
+  when none is found, and refuses with a list when several match.
+- `specgit status` shows local evidence only: record, state, drift,
+  origin. `specgit doctor` probes git, repository, origin, gh, and
+  policy.
+
+### Issue granularity
+
+One issue = one independently verifiable WHY. If a deliverable cannot be
+verified on its own evidence, split it before binding.
+
+### Iron rules
+
+- `specgit finish` exit code other than 0: never request merge. Fix the
+  delivery, not the gate.
+- Never weaken `spec_git/policy.yaml` to make a verdict pass.
+- `--json` is the only parse surface: stdout is exactly one JSON
+  document; never scrape human-readable output.
+<!-- specgit:block:end -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,3 +175,41 @@ pushes to `main`/`dev` are blocked by GitHub Rulesets. Branch names: `{type}/{sh
 (`feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `release`, `hotfix`), enforced by
 Ruleset. Commits/PR titles: conventional `type(scope): summary`. All PRs must reference an
 existing issue (`Fixes #N`). Curated DAG configs are owned by the `opencode-dag-config` repo.
+
+<!-- specgit:block:start -->
+## SpecGit delivery harness
+
+Managed by `specgit init`. Everything between the markers is rewritten on
+re-init; keep manual guidance outside them.
+
+### The delivery story
+
+- Start with `specgit issue <title-or-number>...`: it creates or reuses
+  the issues, branches, opens the draft pull request that closes every
+  bound issue, and writes `.specgit.yaml`. Re-running resumes; it is
+  idempotent.
+- Finish with `specgit finish`: the verdict, derived from real git, PR,
+  and CI evidence. Exit code 0 is the only "done".
+
+### Repair and diagnostics
+
+- `specgit pr` repairs the pull-request binding: with no arguments it
+  auto-discovers the pull request for this head branch, errors with a fix
+  when none is found, and refuses with a list when several match.
+- `specgit status` shows local evidence only: record, state, drift,
+  origin. `specgit doctor` probes git, repository, origin, gh, and
+  policy.
+
+### Issue granularity
+
+One issue = one independently verifiable WHY. If a deliverable cannot be
+verified on its own evidence, split it before binding.
+
+### Iron rules
+
+- `specgit finish` exit code other than 0: never request merge. Fix the
+  delivery, not the gate.
+- Never weaken `spec_git/policy.yaml` to make a verdict pass.
+- `--json` is the only parse surface: stdout is exactly one JSON
+  document; never scrape human-readable output.
+<!-- specgit:block:end -->

--- a/spec_git/policy.yaml
+++ b/spec_git/policy.yaml
@@ -1,0 +1,3 @@
+version: 1
+required_checks:
+  - Typecheck


### PR DESCRIPTION
Closes #353

## What

Enables the SpecGit delivery harness for this repository (delivery = issue + branch + PR binding + evidence-gated finish):

- `spec_git/policy.yaml` — required check `Typecheck`, matching the dev-layer PR gate (feat/** → dev). dev→main promotion stays governed by the protect-main Ruleset's four checks.
- `.github/workflows/specgit-accept.yml` — acceptance evaluation on PRs to **dev** (retargeted from main for this repo's layered gating).
- `.opencode/command/specgit-issue.md`, `specgit-finish.md` — opencode command entry points (installed by `specgit setup --tool opencode`).
- `.opencode/hooks/specgit-merge-guard.sh` — PreToolUse merge guard script; `.opencode/hooks.json` wiring is gitignored by repo policy and installed locally via `specgit setup`.
- `AGENTS.md` / `CLAUDE.md` — specgit managed block (rewritten on re-init; manual guidance stays outside the markers).

## Verification

- `specgit doctor` six probes green (git, repo, origin, gh_present, gh_authenticated, policy)
- This PR itself exercises the acceptance workflow for the first time