### PR TITLE
fix(goal): wire GoalLoop.node into the server request-context app graph

### DIFF
--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -5,3 +5,4 @@ context:
   branch: feat/340-issue340
 issues:
   - 340
+pr: 357

--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -1,8 +1,7 @@
 version: 1
-delivery: docs-audit-add
+delivery: issue340
 context:
   kind: branch
-  branch: feat/355-docs-audit-add
+  branch: feat/340-issue340
 issues:
-  - 355
-pr: 356
+  - 340

--- a/packages/opencode/src/server/routes/instance/httpapi/server.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/server.ts
@@ -48,6 +48,7 @@ import { Discovery } from "@/skill/discovery"
 import { Snapshot } from "@/snapshot"
 import { Storage } from "@/storage/storage"
 import { Goal } from "@/goal/goal"
+import { GoalLoop } from "@/goal/loop"
 import { SettingsHook } from "@/hook/settings"
 import { HookRewakeLive } from "@/hook/rewake-live"
 import { SessionHooks } from "@/hook/session-hooks"
@@ -297,6 +298,14 @@ export const app = LayerNode.group([
   // here, so live sessions silently degraded to "Memory remains off" /
   // "Memory search is unavailable for this session" (issue #311).
   Memory.node,
+  // GoalLoop: same failure class again (issue #340) — the only consumer is
+  // InstanceBootstrap's `serviceOption(GoalLoop.Service).init()` (idle-event
+  // subscription + startup goal scan), which runs in the request fiber's
+  // ambient context. GoalLoop.node was listed only in AppLayer
+  // (app-runtime.ts provideMerge), so headless serve/web, the desktop
+  // sidecar, and non-CWD TUI directories never armed goal continuation or
+  // the crash-recovery scan: standing goals stalled after their first turn.
+  GoalLoop.node,
 ])
 
 export function createRoutes(

--- a/packages/opencode/test/server/httpapi-goalloop-wiring.test.ts
+++ b/packages/opencode/test/server/httpapi-goalloop-wiring.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect } from "bun:test"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { Effect, Layer, Option } from "effect"
+import { GoalLoop } from "@/goal/loop"
+import { HttpApiApp } from "@/server/routes/instance/httpapi/server"
+import { testEffect } from "../lib/effect"
+
+// Issue #340 regression: standing goals stalled after their first turn on
+// headless serve/web, the desktop sidecar, and non-CWD TUI directories.
+// GoalLoop's only consumer is InstanceBootstrap's
+// `serviceOption(GoalLoop.Service).init()` (idle-event subscription + startup
+// goal scan), which runs in the request fiber's ambient context. GoalLoop.node
+// was listed only in AppLayer, so the service was absent from the server app
+// graph and bootstrap silently skipped goal arming. These tests build the
+// exact node graph the server provides to route handlers and assert the
+// service is present there.
+
+const appLayer = LayerNode.buildLayer(HttpApiApp.app)
+
+const appIt = testEffect(Layer.mergeAll(appLayer, CrossSpawnSpawner.defaultLayer))
+
+describe("server app graph goal loop wiring", () => {
+  appIt.instance("exposes GoalLoop.Service in the ambient context bootstrap runs in", () =>
+    Effect.gen(function* () {
+      const goalLoop = yield* Effect.serviceOption(GoalLoop.Service)
+      expect(Option.isSome(goalLoop)).toBe(true)
+    }),
+  )
+
+  // The init seam resolves through the app-graph output (not a per-consumer
+  // dependency scope): a recorder replacement proves both that serviceOption
+  // resolves THIS instance and that the harness's instance bootstrap reaches
+  // GoalLoop.init() from the request-fiber ambient context (the #340 bug was
+  // exactly that call being a silent no-op).
+  const initCalls: number[] = []
+  const spyIt = testEffect(
+    Layer.mergeAll(
+      LayerNode.buildLayer(HttpApiApp.app, {
+        replacements: [
+          LayerNode.replace(
+            GoalLoop.node,
+            Layer.mock(GoalLoop.Service, {
+              init: () =>
+                Effect.sync(() => {
+                  initCalls.push(initCalls.length)
+                }),
+            }),
+          ),
+        ],
+      }),
+      CrossSpawnSpawner.defaultLayer,
+    ),
+  )
+
+  spyIt.instance("bootstrap's serviceOption path reaches GoalLoop.init()", () =>
+    Effect.gen(function* () {
+      // The test harness performs an instance bootstrap while building this
+      // context; before the fix that bootstrap found GoalLoop absent and
+      // silently skipped init.
+      expect(initCalls.length).toBeGreaterThan(0)
+      initCalls.length = 0
+      const goalLoop = yield* Effect.serviceOption(GoalLoop.Service)
+      expect(Option.isSome(goalLoop)).toBe(true)
+      if (Option.isNone(goalLoop)) return
+      yield* goalLoop.value.init()
+      expect(initCalls).toEqual([0])
+    }),
+  )
+})


### PR DESCRIPTION
Closes #340

## What

- `GoalLoop.node` added to the server request-context app group (server.ts), same slot and rationale as the SettingsHook/Memory fixes for #311. All deps (EventV2Bridge/Session/SessionPrompt/Provider/Goal/SessionStatus + transitive SessionAutomationLease) are already in the graph.
- New wiring probe regression `test/server/httpapi-goalloop-wiring.test.ts`:
  - asserts `GoalLoop.Service` resolves in the ambient context the request handlers (and thus InstanceBootstrap) run in
  - a recorder replacement proves bootstrap's `serviceOption(...).init()` path actually reaches the service (the bug was that call being a silent no-op)

## Verification

- `bun run typecheck` green (packages/opencode)
- `bun test test/server/httpapi-goalloop-wiring.test.ts` 2/2
- `bun test test/server/httpapi-memory-wiring.test.ts` 2/2 (no regression)
- `bun test test/goal/e2e-loop.test.ts` 25/25 (no regression)
