### PR TITLE
fix(dag): build DagSupervisionSweep in the server app graph

### DIFF
--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -5,3 +5,4 @@ context:
   branch: feat/341-issue341
 issues:
   - 341
+pr: 358

--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -1,8 +1,7 @@
 version: 1
-delivery: issue340
+delivery: issue341
 context:
   kind: branch
-  branch: feat/340-issue340
+  branch: feat/341-issue341
 issues:
-  - 340
-pr: 357
+  - 341

--- a/packages/opencode/src/server/routes/instance/httpapi/server.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/server.ts
@@ -49,6 +49,7 @@ import { Snapshot } from "@/snapshot"
 import { Storage } from "@/storage/storage"
 import { Goal } from "@/goal/goal"
 import { GoalLoop } from "@/goal/loop"
+import { DagSupervisionSweep } from "@/dag/runtime/supervision-sweep"
 import { SettingsHook } from "@/hook/settings"
 import { HookRewakeLive } from "@/hook/rewake-live"
 import { SessionHooks } from "@/hook/session-hooks"
@@ -306,6 +307,17 @@ export const app = LayerNode.group([
   // sidecar, and non-CWD TUI directories never armed goal continuation or
   // the crash-recovery scan: standing goals stalled after their first turn.
   GoalLoop.node,
+  // DagSupervisionSweep: host-level deadline supervision (2026-08-18
+  // orphaned-nodes incident) was constructed only in AppLayer, but the
+  // desktop sidecar (packages/desktop/src/main/sidecar.ts) calls
+  // Server.listen without effectCmd, so AppLayer never existed there and
+  // the sweep never ran on the desktop default path (issue #341). Listing
+  // it here makes every serving process build it with the listener scope.
+  // Processes that also build AppLayer (serve/web via AppRuntime) get a
+  // second instance; settle is convergent (withWorkflowLock + guardNode +
+  // conditional projector UPDATE), so the duplicate is safe — see the sweep
+  // header's multi-host convergence notes.
+  DagSupervisionSweep.node,
 ])
 
 export function createRoutes(

--- a/packages/opencode/test/server/httpapi-sweep-wiring.test.ts
+++ b/packages/opencode/test/server/httpapi-sweep-wiring.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect } from "bun:test"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { Effect, Layer, Option } from "effect"
+import { DagSupervisionSweep } from "@/dag/runtime/supervision-sweep"
+import { HttpApiApp } from "@/server/routes/instance/httpapi/server"
+import { testEffect } from "../lib/effect"
+
+// Issue #341 regression: the host-level deadline supervision sweep (response
+// to the 2026-08-18 orphaned-nodes incident) was constructed only in AppLayer.
+// The desktop sidecar calls Server.listen without effectCmd, so AppLayer never
+// existed there — the sweep never ran on the desktop default path. Any process
+// that serves HTTP builds the server app graph exactly once per listener, so
+// listing DagSupervisionSweep.node there covers serve/web/TUI/sidecar alike.
+
+const appIt = testEffect(
+  Layer.mergeAll(LayerNode.buildLayer(HttpApiApp.app), CrossSpawnSpawner.defaultLayer),
+)
+
+describe("server app graph supervision sweep wiring", () => {
+  appIt.instance("exposes DagSupervisionSweep.Service in the serving context", () =>
+    Effect.gen(function* () {
+      const sweep = yield* Effect.serviceOption(DagSupervisionSweep.Service)
+      expect(Option.isSome(sweep)).toBe(true)
+    }),
+  )
+
+  // The real graph now forks a live sweep fiber (per-listener scope). A
+  // recorder replacement proves the app graph resolves THIS node's output —
+  // i.e. the sidecar's Server.listen path reaches the sweep construction —
+  // without depending on tick timing.
+  const sweepInits: number[] = []
+  const spyIt = testEffect(
+    Layer.mergeAll(
+      LayerNode.buildLayer(HttpApiApp.app, {
+        replacements: [
+          LayerNode.replace(
+            DagSupervisionSweep.node,
+            Layer.mock(DagSupervisionSweep.Service, {
+              sweepOnce: () =>
+                Effect.sync(() => {
+                  sweepInits.push(sweepInits.length)
+                }),
+            }),
+          ),
+        ],
+      }),
+      CrossSpawnSpawner.defaultLayer,
+    ),
+  )
+
+  spyIt.instance("resolves DagSupervisionSweep.Service from the app-graph output", () =>
+    Effect.gen(function* () {
+      const sweep = yield* Effect.serviceOption(DagSupervisionSweep.Service)
+      expect(Option.isSome(sweep)).toBe(true)
+      if (Option.isNone(sweep)) return
+      yield* sweep.value.sweepOnce()
+      expect(sweepInits.length).toBeGreaterThanOrEqual(1)
+    }),
+  )
+})


### PR DESCRIPTION
Closes #341

## What

- `DagSupervisionSweep.node` added to the server app group (server.ts). The desktop sidecar (`packages/desktop/src/main/sidecar.ts`) calls `Server.listen` without effectCmd — AppLayer never exists there, so the sweep (2026-08-18 orphaned-nodes incident response) never ran on the desktop default path. Every serving process builds the app graph once per listener, which now includes the sweep (fiber lives in the listener scope).
- Deps (`Database/DagStore/Dag/SessionPrompt` nodes) resolve via the sweep node's own dependency list within the shared buildLayer cache.
- serve/web also build AppLayer → a second sweep instance there; settle is convergent (withWorkflowLock + guardNode + conditional projector UPDATE per the sweep header's multi-host convergence notes), so the duplicate is safe and noted in the code comment.
- New wiring probe regression `test/server/httpapi-sweep-wiring.test.ts` (presence + recorder replacement resolving through the app-graph output).

## Verification

- `bun run typecheck` green (packages/opencode)
- `bun test test/server/httpapi-sweep-wiring.test.ts` 2/2
- goalloop/memory wiring tests unaffected

Note: `test/dag/dag-node-supervision.test.ts` has 3 wall-clock-sensitive cases (5s budgets) that fail on this loaded local machine at `f25f37d7e` too (pre-dating this change, no runtime code between); CI (green at `cb17d3ca`) is the arbiter.
