### PR TITLE
fix(dag): sweep freeze window covers the live watcher's actual cadence

### DIFF
--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -1,8 +1,7 @@
 version: 1
-delivery: issue341
+delivery: issue342
 context:
   kind: branch
-  branch: feat/341-issue341
+  branch: feat/342-issue342
 issues:
-  - 341
-pr: 358
+  - 342

--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -5,3 +5,4 @@ context:
   branch: feat/342-issue342
 issues:
   - 342
+pr: 359

--- a/packages/opencode/src/dag/runtime/supervision-sweep.ts
+++ b/packages/opencode/src/dag/runtime/supervision-sweep.ts
@@ -90,6 +90,36 @@ export const escalateIntervalFromConfig = (raw: string | undefined, nodeId: stri
   return Math.max(1_000, typeof timeoutMs === "number" ? timeoutMs : Dag.DEFAULT_WORKFLOW_CONFIG.nodeTimeoutMs)
 }
 
+/**
+ * An upper bound on the cadence the LIVE watcher actually runs at,
+ * back-derived from durable columns. deadline_ms is only ever written as
+ * `grant time + timeout_ms` — at spawn (started_at + T0) and at each
+ * deadline extension (now + Ti) — while escalations move only the counter,
+ * never the deadline. The granted total (deadline − started_at) is therefore
+ * the sum of the initial grant plus every extension grant, which is always
+ * ≥ the LAST grant, and the last grant's timeout IS the live watcher's
+ * cadence (a re-time replaces the watcher at the new timeout). Issue #342:
+ * replan can lower a running node's persisted timeout_ms while the A1/Q2
+ * re-time gate deliberately keeps the old watcher on its old (longer)
+ * cadence — a config-only window would then be shorter than the live
+ * watcher's cycle and sweep a healthy node. Taking the max with the config
+ * cadence covers both shapes: re-timed watchers match the config (the
+ * durable value merely over-estimates by the accumulated grants, delaying —
+ * never causing — a settle), gate-skipped ones are caught by the durable
+ * bound. Returns 0 when the columns are missing (legacy rows) so the config
+ * value decides alone.
+ */
+export const escalateIntervalDurable = (
+  deadlineMs: number | null | undefined,
+  startedAt: number | null | undefined,
+) => {
+  if (deadlineMs == null || startedAt == null) return 0
+  if (!Number.isFinite(deadlineMs) || !Number.isFinite(startedAt)) return 0
+  const granted = deadlineMs - startedAt
+  if (granted <= 0) return 0
+  return Math.max(1_000, granted)
+}
+
 const serviceLayer = Layer.effect(
   Service,
   Effect.gen(function* () {
@@ -124,6 +154,8 @@ const serviceLayer = Layer.effect(
           nodeId: WorkflowNodeTable.id,
           childSessionId: WorkflowNodeTable.child_session_id,
           extensions: WorkflowNodeTable.timeout_extensions,
+          deadlineMs: WorkflowNodeTable.deadline_ms,
+          startedAt: WorkflowNodeTable.started_at,
         })
         .from(WorkflowNodeTable)
         .where(
@@ -158,7 +190,14 @@ const serviceLayer = Layer.effect(
         // Only nodes already flat for a tick pay the config lookup.
         if (flatTicks < 1) continue
         const escalateIntervalMs = yield* escalateIntervalFor(row.workflowId, row.nodeId)
-        if (flatTicks < frozenTicksNeeded(escalateIntervalMs)) continue
+        // #342: the window must cover the LIVE watcher's actual cadence, not
+        // just the current config's — replan may have lowered the persisted
+        // timeout while the re-time gate kept the old watcher.
+        const windowIntervalMs = Math.max(
+          escalateIntervalMs,
+          escalateIntervalDurable(row.deadlineMs, row.startedAt),
+        )
+        if (flatTicks < frozenTicksNeeded(windowIntervalMs)) continue
         // Frozen across the full window: cancel the (possibly dead) child and
         // settle the node. Same-host races (a live watcher) are serialized by
         // the workflow's in-process lock; another host's sweep is collapsed

--- a/packages/opencode/test/dag/dag-node-supervision.test.ts
+++ b/packages/opencode/test/dag/dag-node-supervision.test.ts
@@ -470,4 +470,46 @@ describe("DagSupervisionSweep cadence derivation (pure)", () => {
     expect(DagSupervisionSweep.frozenTicksNeeded(Dag.DEFAULT_WORKFLOW_CONFIG.nodeTimeoutMs)).toBe(11)
     expect(DagSupervisionSweep.frozenTicksNeeded(1_800_000)).toBe(31)
   })
+
+  it("#342: back-derives a safe cadence bound from durable columns", () => {
+    // Spawned at a 30-minute timeout, no extensions: granted total is
+    // exactly one cadence.
+    expect(DagSupervisionSweep.escalateIntervalDurable(1_800_000, 0)).toBe(1_800_000)
+    // Escalations move only the counter, never the deadline — after three
+    // escalations with no extension the granted total is still one cadence
+    // (NOT the average; dividing would under-estimate and un-safety the
+    // window).
+    expect(DagSupervisionSweep.escalateIntervalDurable(1_800_000, 0)).toBe(1_800_000)
+    // An extension grants another timeout: the total over-estimates the
+    // current cadence, which delays (never causes) a settle — safe.
+    expect(DagSupervisionSweep.escalateIntervalDurable(3_600_000, 0)).toBe(3_600_000)
+    // Sub-second derivation floors to the watcher's 1s minimum.
+    expect(DagSupervisionSweep.escalateIntervalDurable(500, 0)).toBe(1_000)
+    // Legacy/edge rows are not derivable: 0 lets the config value decide.
+    expect(DagSupervisionSweep.escalateIntervalDurable(undefined, 0)).toBe(0)
+    expect(DagSupervisionSweep.escalateIntervalDurable(1_800_000, undefined)).toBe(0)
+    expect(DagSupervisionSweep.escalateIntervalDurable(null, null)).toBe(0)
+    expect(DagSupervisionSweep.escalateIntervalDurable(0, 1_800_000)).toBe(0)
+  })
+
+  it("#342: a replan-lowered config never shortens the window below the live watcher's cadence", () => {
+    // The incident shape: spawned at a 30-minute cadence, replan lowers the
+    // persisted timeout to 10 minutes, the A1/Q2 re-time gate keeps the old
+    // watcher. The config alone would give an 11-tick window (~11 minutes)
+    // and prematurely sweep a healthy node; the durable bound recovers the
+    // 30-minute cadence and the window stays 31 ticks.
+    const configInterval = DagSupervisionSweep.escalateIntervalFromConfig(
+      JSON.stringify({ nodes: [{ id: "worker", depends_on: [], worker_config: { timeout_ms: 600_000 } }] }),
+      "worker",
+    )
+    const durableInterval = DagSupervisionSweep.escalateIntervalDurable(1_800_000, 0)
+    const windowInterval = Math.max(configInterval, durableInterval)
+    expect(configInterval).toBe(600_000)
+    expect(durableInterval).toBe(1_800_000)
+    expect(DagSupervisionSweep.frozenTicksNeeded(windowInterval)).toBe(31)
+    // Re-timed watcher (watcher matches the lowered config): the config
+    // decides, the durable over-estimate only delays detection.
+    const reTimedWindow = Math.max(600_000, DagSupervisionSweep.escalateIntervalDurable(600_000, 0))
+    expect(DagSupervisionSweep.frozenTicksNeeded(reTimedWindow)).toBe(11)
+  })
 })


### PR DESCRIPTION
Closes #342

## What

The sweep's freeze window derived solely from the **current persisted config** cadence. Replan can lower a running node's `timeout_ms` while the A1/Q2 re-time gate deliberately keeps the old watcher on its old (longer) cadence — a config-only window is then shorter than the live watcher's cycle and sweeps a healthy node mid-decision-window.

Fix: `window = max(config cadence, escalateIntervalDurable(deadline_ms, started_at))`.

`deadline_ms` is only ever written as `grant time + timeout_ms` — at spawn and at each deadline extension (escalations move only the counter, never the deadline; verified in `projector.ts` `NodeTimeoutEscalated` vs `NodeDeadlineExtended` folds). So `(deadline − started_at)` — the sum of the initial grant plus every extension grant — is always ≥ the last grant, and the last grant's timeout IS the live watcher's cadence. The bound over-estimates after extensions (delays detection, never causes a premature settle); missing columns (legacy rows) return 0 so the config decides alone.

## Tests

- Pure: durable-bound derivation (spawn-only, escalations-don't-move-deadline, extension over-estimate, 1s floor, legacy fallbacks)
- Pure: the #342 incident math — config lowered 30min→10min with a live 30min watcher keeps the 31-tick window (was 11); re-timed watcher keeps 11
- `bun run typecheck` green; new pure tests 2/2

Note: the 3 wall-clock-sensitive integration cases in this file fail on this loaded local machine at `f25f37d7e` too (pre-date this change); CI is the arbiter.
