### PR TITLE
fix(dag): sweep terminalizes workflows and releases their lease after a host-level settle

### DIFF
--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -5,3 +5,4 @@ context:
   branch: feat/343-issue343
 issues:
   - 343
+pr: 360

--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -1,8 +1,7 @@
 version: 1
-delivery: issue342
+delivery: issue343
 context:
   kind: branch
-  branch: feat/342-issue342
+  branch: feat/343-issue343
 issues:
-  - 342
-pr: 359
+  - 343

--- a/packages/opencode/src/dag/runtime/supervision-sweep.ts
+++ b/packages/opencode/src/dag/runtime/supervision-sweep.ts
@@ -8,9 +8,11 @@ import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { Database } from "@opencode-ai/core/database/database"
 import { DagStore } from "@opencode-ai/core/dag/store"
 import { WorkflowNodeTable } from "@opencode-ai/core/dag/sql"
+import { isNodeTerminalStatus, isTransitionRejection, isWorkflowTerminalStatus } from "@opencode-ai/core/dag/core/types"
 import { and, eq, sql } from "drizzle-orm"
 import { Dag, parseWorkflowConfig } from "@/dag/dag"
 import { SessionPrompt } from "@/session/prompt"
+import { SessionAutomationLease } from "@/session/automation-lease"
 
 /**
  * Host-level deadline-supervision sweep — the fallback retry for the
@@ -127,6 +129,7 @@ const serviceLayer = Layer.effect(
     const store = yield* DagStore.Service
     const dag = yield* Dag.Service
     const promptSvc = yield* SessionPrompt.Service
+    const automation = yield* SessionAutomationLease.Service
     const scope = yield* Scope.Scope
 
     // nodeKey -> {extensions, flatTicks}: the counter value last observed and
@@ -247,11 +250,66 @@ const serviceLayer = Layer.effect(
           extensions: row.extensions,
         })
         observed.delete(key)
+        // #343: node rot is fixed, workflow rot is next. checkCompletion
+        // lives inside DagLoop — with the owning instance torn down nothing
+        // advances the workflow's terminal state, releases its automation
+        // lease, or tells the parent. Terminalize durably from the host
+        // level once EVERY current-revision node is terminal; parent wake
+        // delivery stays with the owning instance (session context) and
+        // converges through the DagLoop init drain on the next instance
+        // load. A live DagLoop racing this is serialized by the same
+        // workflow lock and its terminal-status guards — double settles
+        // collapse to one.
+        yield* settleWorkflowIfComplete(row.workflowId).pipe(
+          Effect.catchCause((cause) => (Cause.hasInterrupts(cause) ? Effect.interrupt : Effect.void)),
+        )
       }
       // Retain only what is still overdue-running so settled/restarted nodes
       // do not accumulate.
       flatStreak.clear()
       for (const [key, streak] of observed) flatStreak.set(key, streak)
+    })
+
+    // #343 host-level mirror of DagLoop.checkCompletion's durable half: when
+    // every current-revision node is terminal and the workflow row is not,
+    // land the terminal transition (fail on required-node failure, complete
+    // otherwise) and release the workflow's automation lease registration.
+    // Wake delivery to the parent session stays with the owning instance —
+    // it needs session context (ownsSession guard, prompt injection) — and
+    // converges through the DagLoop init drain on the next instance load.
+    // Transition rejections (a live DagLoop completed first, or a replan
+    // re-registered nodes between the reads and the write) are expected and
+    // silent; the next tick re-evaluates from the durable rows.
+    const settleWorkflowIfComplete = Effect.fnUntraced(function* (workflowId: string) {
+      const wf = yield* store.getWorkflow(workflowId).pipe(
+        Effect.catchCause((cause) => (Cause.hasInterrupts(cause) ? Effect.interrupt : Effect.succeed(undefined))),
+      )
+      if (!wf || isWorkflowTerminalStatus(wf.status as never)) return
+      const nodes = yield* store.getCurrentNodes(workflowId).pipe(
+        Effect.catchCause((cause) => (Cause.hasInterrupts(cause) ? Effect.interrupt : Effect.succeed([]))),
+      )
+      if (nodes.length === 0 || nodes.some((node) => !isNodeTerminalStatus(node.status as never))) return
+      const failed = nodes.filter((node) => node.status === "failed" && node.required).map((node) => node.id)
+      const transition = failed.length > 0
+        ? yield* dag.fail(workflowId, `required node(s) failed: ${failed.join(", ")}`).pipe(
+            Effect.as("failed" as const),
+            Effect.catchIf(isTransitionRejection, () => Effect.succeed(undefined)),
+          )
+        : yield* dag.complete(workflowId, { skipReviewGate: true }).pipe(
+            Effect.as("completed" as const),
+            Effect.catchIf(isTransitionRejection, () => Effect.succeed(undefined)),
+          )
+      if (transition === undefined) return
+      yield* Effect.logWarning("DagSupervisionSweep terminalized a workflow whose instance is gone", {
+        dagID: workflowId,
+        outcome: transition,
+      })
+      // The lease registration outlived the owning DagLoop's handlers; this
+      // process's registry entry must not pin the parent session's automation
+      // forever. Cross-process registries are untouched (a no-op here).
+      yield* automation
+        .unregister(wf.sessionId as never, { kind: "dag", id: workflowId })
+        .pipe(Effect.catchCause((cause) => (Cause.hasInterrupts(cause) ? Effect.interrupt : Effect.void)))
     })
 
     let sweepFiber: Fiber.Fiber<void> | undefined
@@ -291,8 +349,15 @@ export const layer = serviceLayer.pipe(
   Layer.provide(DagStore.defaultLayer),
   Layer.provide(Dag.defaultLayer),
   Layer.provide(SessionPrompt.defaultLayer),
+  Layer.provide(SessionAutomationLease.defaultLayer),
 )
 
 export const defaultLayer = layer
 
-export const node = LayerNode.make(serviceLayer, [Database.node, DagStore.node, Dag.node, SessionPrompt.node])
+export const node = LayerNode.make(serviceLayer, [
+  Database.node,
+  DagStore.node,
+  Dag.node,
+  SessionPrompt.node,
+  SessionAutomationLease.node,
+])

--- a/packages/opencode/test/dag/dag-node-supervision.test.ts
+++ b/packages/opencode/test/dag/dag-node-supervision.test.ts
@@ -22,6 +22,7 @@ import { disposeInstance } from "@/effect/instance-registry"
 import { DagSupervisionSweep } from "@/dag/runtime/supervision-sweep"
 import { EventV2Bridge } from "@/event-v2-bridge"
 import { SessionPrompt } from "@/session/prompt"
+import { SessionAutomationLease } from "@/session/automation-lease"
 import { MessageID } from "@/session/schema"
 import { Session } from "@/session/session"
 import { SessionStatus } from "@/session/status"
@@ -145,7 +146,14 @@ function supervisionLayer(input: {
       }),
   })
   const loop = DagLoop.layer.pipe(Layer.provide(base), Layer.provide(session), Layer.provide(prompt), Layer.provide(agent))
-  const sweep = DagSupervisionSweep.layerWithoutDeps.pipe(Layer.provide(base), Layer.provide(prompt))
+  // #343: the sweep terminalizes workflows and releases their automation
+  // lease after a host-level settle — give it the real (process-level) lease
+  // registry so the unregister path is exercised, not a silent mock no-op.
+  const sweep = DagSupervisionSweep.layerWithoutDeps.pipe(
+    Layer.provide(base),
+    Layer.provide(prompt),
+    Layer.provide(SessionAutomationLease.defaultLayer),
+  )
   return Layer.merge(Layer.merge(base, loop), sweep)
 }
 
@@ -335,6 +343,13 @@ describe("DAG node supervision — deadline enforcement (production incident)", 
             "5 seconds",
           )
           expect(swept?.errorClass).toBe("timeout")
+          // #343 (workflow rot): with the owning instance gone, the sweep —
+          // not a dead DagLoop's checkCompletion — must land the workflow's
+          // terminal transition once every current-revision node is terminal.
+          // The incident graph is a single required worker, so its failure is
+          // a workflow FAILURE.
+          const wf = yield* store.getWorkflow(dagID)
+          expect(wf?.status).toBe("failed")
         }),
       ),
     )


### PR DESCRIPTION
Closes #343

## What

After a host-level sweep settle lands, the sweep mirrors `checkCompletion`'s durable half:

- when every current-revision node is terminal and the workflow row is not, it lands the terminal transition — `dag.fail` (required-node failure) or `dag.complete({skipReviewGate:true})` — through the same workflow-lock-serialized command layer a live DagLoop uses (double settles collapse via the terminal-status guards)
- then unregisters the workflow's dag automation lease (this process's registry; cross-process registries are untouched no-ops)

Explicitly out of scope (converge through existing instance-load paths, documented in code):
- parent wake delivery — needs owning-instance session context (`ownsSession` guard + prompt injection); the DagLoop init drain delivers on the next instance load
- cascade skips of pending dependents — orphan-pending legalization + cascade at adopt

## Tests

- dispose-instance integration test extended: after the sweep settles the frozen worker, the workflow itself reaches `failed` (single required node) — 11/11 in the file pass with `--timeout 30000` (CI suite default)
- sweep wiring tests unaffected; checkpoint-gate tests unaffected; typecheck green

Note: the earlier "pre-existing failures" in this file were bun's default 5s per-test timeout; the file's header already mandates `--timeout 30000`.
