### PR TITLE
fix(dag): crash recovery preserves a schemaless node's string verdict

### DIFF
--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -5,3 +5,4 @@ context:
   branch: feat/345-issue345
 issues:
   - 345
+pr: 362

--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -1,8 +1,7 @@
 version: 1
-delivery: issue344
+delivery: issue345
 context:
   kind: branch
-  branch: feat/344-issue344
+  branch: feat/345-issue345
 issues:
-  - 344
-pr: 361
+  - 345

--- a/packages/opencode/src/dag/runtime/loop.ts
+++ b/packages/opencode/src/dag/runtime/loop.ts
@@ -34,7 +34,7 @@ import { sanitizeInput } from "../templates/sanitize"
 import { DagConfig } from "../config"
 import { spawnNode, makeDeadlineWatcher } from "./spawn"
 import { evaluateCondition, resolveInputMapping } from "./eval"
-import { reconcileWorkflow, makeSessionStatusChecker } from "./recovery"
+import { reconcileWorkflow, makeSessionStatusChecker, makeLastAssistantTextReader } from "./recovery"
 
 // A reporting checkpoint's replan verdict vetoes the current direction: the
 // workflow pauses durably before any downstream spawn (see NodeCompleted
@@ -369,6 +369,9 @@ const serviceLayer = Layer.effect(
         })
 
         const checkSessionStatus = makeSessionStatusChecker(sessionSvc)
+        // #345: schemaless recovered nodes settle with the child's last
+        // assistant text, mirroring the live spawn path.
+        const lastAssistantText = makeLastAssistantTextReader(sessionSvc)
 
         // Best-effort abort of a durable child session, independent of whether
         // a local wrapper fiber still exists.  Used at every replacement,
@@ -414,7 +417,10 @@ const serviceLayer = Layer.effect(
               dagID,
               checkSessionStatus,
               (sid) => promptSvc.cancel(sid as never),
-              config,
+              // null (not undefined) marks an unparseable row so recovery
+              // fails such nodes loudly instead of undefined-completing them.
+              config ?? null,
+              lastAssistantText,
             ).pipe(
               Effect.provideService(Dag.Service, dag),
             )

--- a/packages/opencode/src/dag/runtime/recovery.ts
+++ b/packages/opencode/src/dag/runtime/recovery.ts
@@ -37,7 +37,8 @@ export function reconcileWorkflow(
   dagID: string,
   checkSessionStatus: (childSessionID: string) => Effect.Effect<"active" | "completed" | "failed" | "unknown", Error>,
   cancelSession?: (sessionID: string) => Effect.Effect<void, Error>,
-  workflowConfig?: { nodes: Pick<NodeConfig, "id" | "output_schema" | "review" | "input_mapping">[] } | undefined,
+  workflowConfig?: { nodes: Pick<NodeConfig, "id" | "output_schema" | "review" | "input_mapping">[] } | null,
+  lastAssistantText?: (childSessionID: string) => Effect.Effect<string | undefined, Error>,
 ): Effect.Effect<{ reconciled: number; ownershipLost: number }, Error, Dag.Service> {
   return Effect.gen(function* () {
     const dag = yield* Dag.Service
@@ -90,6 +91,24 @@ export function reconcileWorkflow(
       const sessionStatus = yield* checkSessionStatus(node.childSessionId)
 
       if (sessionStatus === "completed") {
+        // #345 parity with the live path: an unparseable workflow row must
+        // not degrade into the schemaless completion below — a schema-
+        // carrying node would bypass settleCapturedOutput and land as an
+        // undefined output. Fail loudly instead of inventing a settlement.
+        if (workflowConfig === null) {
+          ownershipLost++
+          yield* settle(
+            node.id,
+            dag.nodeFailed(
+              dagID,
+              node.id,
+              "child session completed but the workflow config is unparseable on recovery — cannot settle safely",
+              "exec_failed",
+            ),
+          )
+          reconciled++
+          continue
+        }
         const nodeConfig = workflowConfig?.nodes.find((n) => n.id === node.id)
         if (nodeConfig?.output_schema) {
           // Same settlement decision as spawn's completion gate — recovery
@@ -102,7 +121,17 @@ export function reconcileWorkflow(
               : dag.nodeFailed(dagID, node.id, settlement.reason, "verdict_fail"),
           )
         } else {
-          yield* settle(node.id, dag.nodeCompleted(dagID, node.id, undefined))
+          // #345: the live path (spawn.ts) completes a schemaless node with
+          // the child's last assistant text; recovery must mirror it instead
+          // of completing with undefined — a schemaless checkpoint's string
+          // verdict (e.g. a bare {"verdict":"replan"} reply) would silently
+          // vanish after a crash otherwise: no pause, no warning, and gated
+          // dependents resolve no fields. Callers that inject no reader keep
+          // the legacy undefined settlement.
+          const rawText = lastAssistantText
+            ? (yield* lastAssistantText(node.childSessionId)) ?? ""
+            : undefined
+          yield* settle(node.id, dag.nodeCompleted(dagID, node.id, rawText))
         }
         reconciled++
       } else if (sessionStatus === "failed") {
@@ -215,5 +244,23 @@ export function makeSessionStatusChecker(
       if (finish === "error" || finish === "content-filter") return "failed" as const
       // stop, length, and any other terminal finish → completed
       return "completed" as const
+    })
+}
+
+/**
+ * #345: the schemaless-node completion mirror of the live path — the child's
+ * last assistant text part, the exact value spawn.ts settles a schemaless
+ * node with. Recovery reads it so a crash cannot erase a string verdict.
+ */
+export function makeLastAssistantTextReader(
+  sessions: Session.Interface,
+): (childSessionID: string) => Effect.Effect<string | undefined, Error> {
+  return (childSessionID) =>
+    Effect.gen(function* () {
+      const msgs = yield* sessions
+        .messages({ sessionID: SessionID.make(childSessionID), limit: 20 })
+        .pipe(Effect.catchTag("NotFoundError", () => Effect.succeed([] as SessionV1.WithParts[])))
+      const last = [...msgs].reverse().find((msg) => msg.info.role === "assistant")
+      return last?.parts.findLast((part): part is Extract<typeof part, { type: "text" }> => part.type === "text")?.text
     })
 }

--- a/packages/opencode/test/dag/dag-recovery.test.ts
+++ b/packages/opencode/test/dag/dag-recovery.test.ts
@@ -429,4 +429,83 @@ describe("rehydration via toSchedulingNodes", () => {
     expect(rt.isPaused()).toBe(true)
     expect(rt.getReadyNodes()).toEqual([])
   })
+
+  // #345: the live path (spawn.ts) settles a schemaless node with the child's
+  // last assistant text; recovery must mirror it — a crash between the child's
+  // final reply and the NodeCompleted publish must not erase a string verdict
+  // (a bare {"verdict":"replan"} checkpoint reply would otherwise vanish).
+  it("settles a completed schemaless node with the child's last assistant text", async () => {
+    const events: TrackedEvent[] = []
+    const nodes = [makeNodeRow({ id: "cp", status: "running", childSessionId: "ses_1" })]
+    const dagLayer = makeDagLayer(nodes, events)
+    const checkStatus = () => Effect.succeed<"active" | "completed" | "failed" | "unknown">("completed")
+    const verdict = '{"verdict":"replan","reason":"wrong file"}'
+
+    await Effect.runPromise(
+      reconcileWorkflow(
+        "wf-1",
+        checkStatus,
+        undefined,
+        { nodes: [{ id: "cp" }] },
+        () => Effect.succeed(verdict),
+      ).pipe(Effect.provide(dagLayer)),
+    )
+
+    expect(events).toContainEqual({ type: "nodeCompleted", nodeID: "cp", output: verdict })
+    expect(events).not.toContainEqual({ type: "nodeFailed", nodeID: "cp" })
+  })
+
+  it("floors a missing text part to the live path's empty string, not undefined", async () => {
+    const events: TrackedEvent[] = []
+    const nodes = [makeNodeRow({ id: "n1", status: "running", childSessionId: "ses_1" })]
+    const dagLayer = makeDagLayer(nodes, events)
+    const checkStatus = () => Effect.succeed<"active" | "completed" | "failed" | "unknown">("completed")
+
+    await Effect.runPromise(
+      reconcileWorkflow("wf-1", checkStatus, undefined, { nodes: [{ id: "n1" }] }, () => Effect.succeed(undefined)).pipe(
+        Effect.provide(dagLayer),
+      ),
+    )
+
+    expect(events).toContainEqual({ type: "nodeCompleted", nodeID: "n1", output: "" })
+  })
+
+  // #345 degenerate branch: an unparseable workflow row (explicit null) must
+  // fail loudly — undefined-completing a schema-carrying node would bypass
+  // settleCapturedOutput's review contract.
+  it("fails a completed node whose workflow config is unparseable (null), not undefined-complete", async () => {
+    const events: TrackedEvent[] = []
+    const nodes = [makeNodeRow({ id: "n1", status: "running", childSessionId: "ses_1" })]
+    const dagLayer = makeDagLayer(nodes, events)
+    const checkStatus = () => Effect.succeed<"active" | "completed" | "failed" | "unknown">("completed")
+
+    const result = await Effect.runPromise(
+      reconcileWorkflow("wf-1", checkStatus, undefined, null, () => Effect.succeed("text")).pipe(
+        Effect.provide(dagLayer),
+      ),
+    )
+
+    expect(events).toContainEqual({
+      type: "nodeFailed",
+      nodeID: "n1",
+      reason: expect.stringContaining("unparseable"),
+      trigger: "exec_failed",
+    })
+    expect(events).not.toContainEqual({ type: "nodeCompleted", nodeID: "n1" })
+    expect(result.ownershipLost).toBe(1)
+  })
+
+  // Legacy callers that inject no reader keep the undefined settlement.
+  it("keeps the legacy undefined settlement when no text reader is injected", async () => {
+    const events: TrackedEvent[] = []
+    const nodes = [makeNodeRow({ id: "n1", status: "running", childSessionId: "ses_1" })]
+    const dagLayer = makeDagLayer(nodes, events)
+    const checkStatus = () => Effect.succeed<"active" | "completed" | "failed" | "unknown">("completed")
+
+    await Effect.runPromise(
+      reconcileWorkflow("wf-1", checkStatus, undefined, { nodes: [{ id: "n1" }] }).pipe(Effect.provide(dagLayer)),
+    )
+
+    expect(events).toContainEqual({ type: "nodeCompleted", nodeID: "n1" })
+  })
 })


### PR DESCRIPTION
Closes #345

## What

- The recovery path for a completed child session now mirrors the live path for schemaless nodes: `reconcileWorkflow` takes an injected `lastAssistantText` reader (`makeLastAssistantTextReader(sessions)`, provided by DagLoop) and settles with the child's last assistant text (`""` floor, exactly like `spawn.ts`). A crash between the child's final reply and the NodeCompleted publish no longer erases a string verdict — a bare `{"verdict":"replan"}` checkpoint keeps its veto, gated dependents resolve fields, input_mapping stops degrading to placeholders.
- The degenerate branch: an explicitly unparseable workflow row (DagLoop now passes `parseWorkflowConfig(wf.config) ?? null`) fails the node loudly (`exec_failed`, counted as ownershipLost so P2-2 recovery-pause applies) instead of undefined-completing a schema-carrying node past `settleCapturedOutput`.
- Legacy callers that inject no reader/config keep the previous settlement semantics.

## Tests

- string verdict preserved through recovery (nodeCompleted carries the exact text)
- missing text part floors to `""` (live-path parity)
- unparseable (null) config → loud nodeFailed + ownershipLost=1, never nodeCompleted
- legacy no-reader call → undefined settlement unchanged
- dag-loop-recovery-integration unchanged (38/38 across both files); typecheck green; lint delta zero (budget is exactly at cap)
