### PR TITLE
fix(dag): aggregator contract reconciles declared write-sets against git status

### DIFF
--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -1,8 +1,7 @@
 version: 1
-delivery: issue346
+delivery: issue347
 context:
   kind: branch
-  branch: feat/346-issue346
+  branch: feat/347-issue347
 issues:
-  - 346
-pr: 363
+  - 347

--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -5,3 +5,4 @@ context:
   branch: feat/347-issue347
 issues:
   - 347
+pr: 364

--- a/packages/opencode/src/dag/blocks.ts
+++ b/packages/opencode/src/dag/blocks.ts
@@ -405,11 +405,14 @@ function requireValidBlockGraph(graph: WorkflowBlockGraph, options: WorkflowBloc
 }
 
 // Injected between parallel implementation writers and their verification
-// gate: mechanically detects declared write-set overlap (loud node failure)
-// and publishes the union with one fingerprint computed at the convergence
-// point, so diff review binds to a single post-merge state.
+// gate: an explore-type worker enforcing the contract below. Detection is a
+// behavioral contract, not an engine guarantee (#347) — the engine computes
+// no intersection or union itself. The contract makes the worker reconcile
+// the declared write-sets against the workspace's actual git status so
+// undeclared edits fail loudly instead of escaping the union+fingerprint
+// review binding, and computes the fingerprint over the actually-changed set.
 const AGGREGATOR_CONTRACT =
-  "Collect the supplied changed-file lists and summaries from each parallel implementation writer. If any file path appears in more than one list, do not submit; fail the node naming the exact overlapping paths. Otherwise submit the union of all changed files and one stable fingerprint computed at this convergence point (for example a sha256 over the sorted union of current file contents, reporting the exact commands used). Do not modify any file."
+  "Collect the supplied changed-file lists and summaries from each parallel implementation writer. Run git status --porcelain in the workspace to observe the actually-changed set. If any file path appears in more than one declared list, do not submit; fail the node naming the exact overlapping paths. If the actually-changed set contains paths no writer declared, do not submit; fail the node naming the undeclared paths — undeclared edits must not slip past the review binding. Otherwise submit the union of the actually-changed set and one stable fingerprint computed at this convergence point over exactly that set (for example a sha256 over the sorted union of current file contents, reporting the exact commands used). Do not modify any file."
 
 interface WriterAggregation {
   aggregatorID: string

--- a/packages/opencode/src/dag/docs/adr/0002-parallel-writers-aggregator.md
+++ b/packages/opencode/src/dag/docs/adr/0002-parallel-writers-aggregator.md
@@ -31,8 +31,11 @@ compiler injects one aggregation node per review route:
 - The aggregator depends on every writer of the route, runs read-only with
   shell access, is required, and reuses the implementation output schema.
 - It receives each writer's declared `changed_files` and fails its node
-  loudly on any non-empty write-set intersection; otherwise it publishes the
-  union plus one fingerprint computed at the convergence point.
+  loudly on any non-empty declared write-set intersection. It also observes
+  the workspace's actual `git status --porcelain` output: any
+  actually-changed path no writer declared fails the node (undeclared edits
+  must not escape the review binding), and the published union plus the
+  convergence-point fingerprint are computed over the actually-changed set.
 - The verify block's writer dependencies are re-pointed to the aggregator,
   the diff review's implementation reference points at the aggregator, and
   the verify node receives the implementation fingerprint binding.
@@ -44,9 +47,12 @@ check.
 
 Author discipline for parallel writers is the triple-disjoint rule — source
 files, generated artifacts, and lockfiles disjoint, and no shared build —
-owned by the plan block's work packages. Mechanical enforcement is the
-aggregator's changed-file intersection check; shared-cache and lock-contention
-races remain plan discipline.
+owned by the plan block's work packages. Enforcement is the aggregator
+worker's behavioral contract (declared-set intersection plus the git-status
+reconciliation of actual workspace changes); the engine itself computes no
+intersection or union, so the contract is only as strong as the worker's
+compliance with it. Shared-cache and lock-contention races remain plan
+discipline.
 
 ## Consequences
 

--- a/packages/opencode/test/dag/blocks-parallel-writers.test.ts
+++ b/packages/opencode/test/dag/blocks-parallel-writers.test.ts
@@ -40,7 +40,13 @@ describe("parallel workspace writers (issue #293)", () => {
       slice_c_changed_files: "slice-c.output.changed_files",
       slice_c_summary: "slice-c.output.summary",
     })
+    // #347: the contract must make the worker reconcile the declared
+    // write-sets against the workspace's actual git status — undeclared
+    // edits fail loudly instead of escaping the union+fingerprint binding,
+    // and the fingerprint covers the actually-changed set.
     expect(aggregate?.prompt_template.inline).toContain("overlapping paths")
+    expect(aggregate?.prompt_template.inline).toContain("git status --porcelain")
+    expect(aggregate?.prompt_template.inline).toContain("undeclared paths")
 
     expect(byID.get("gates")?.depends_on).toEqual(["decision--aggregate"])
     const decision = byID.get("decision")


### PR DESCRIPTION
Closes #347

## What

**Truth in wording** (the "minimal" fix):
- `blocks.ts` comment no longer claims the injector "mechanically detects declared write-set overlap" — it now states plainly that detection is an explore-type worker's behavioral contract and the engine computes no intersection or union itself.
- ADR-0002's "Mechanical enforcement is the aggregator's changed-file intersection check" replaced with the accurate statement, including the contract's strength being bounded by worker compliance.

**The preferred fix — mechanical reconciliation inside the contract**:
- `AGGREGATOR_CONTRACT` now requires the worker to run `git status --porcelain` and treat the actually-changed set as ground truth:
  - any actually-changed path no writer declared → fail the node naming the undeclared paths (previously undeclared edits escaped the union+fingerprint review binding entirely — including files left behind by a writer that failed mid-node)
  - the published union and the convergence-point fingerprint are computed over the actually-changed set, not the declared lists
- the declared-set intersection check (fail on overlapping declared paths) is unchanged.

## Tests

- `blocks-parallel-writers.test.ts` asserts the contract text carries the new obligations (`git status --porcelain`, `undeclared paths`) alongside the existing `overlapping paths` anchor — 23/23 across blocks tests; typecheck green; lint delta zero (budget at cap)
