### PR TITLE
chore(specgit): pin the acceptance workflow's specgit CLI to ^0.5.0

### DIFF
--- a/.github/workflows/specgit-accept.yml
+++ b/.github/workflows/specgit-accept.yml
@@ -31,9 +31,12 @@ jobs:
           node-version: '22'
 
       # This repo is a bun workspace and does not vendor the SpecGit CLI;
-      # install the published CLI instead of building from source.
+      # install the published CLI instead of building from source. Pinned
+      # with a caret floor (#366): the CLI releases multiple times a day and
+      # an unpinned install would let an unnoticed upstream change flip CI
+      # acceptance verdicts repo-wide.
       - name: Install specgit CLI
-        run: npm install -g specgit
+        run: npm install -g specgit@^0.5.0
 
       - name: Wait for sibling checks
         # The verdict must see the OTHER required checks in a terminal

--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -1,8 +1,7 @@
 version: 1
-delivery: issue350
+delivery: issue366
 context:
   kind: branch
-  branch: feat/350-issue350
+  branch: feat/366-issue366
 issues:
-  - 350
-pr: 365
+  - 366

--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -5,3 +5,4 @@ context:
   branch: feat/366-issue366
 issues:
   - 366
+pr: 367


### PR DESCRIPTION
Closes #366

## What

- Acceptance workflow installs `specgit@^0.5.0` instead of unpinned `specgit`. Rationale: the CLI ships multiple releases a day (0.2.0→0.5.0 within one day); an unpinned install lets an unnoticed upstream change flip CI acceptance verdicts repo-wide with no change in this repo. A caret floor follows the CLI's evolution (per the maintainer's direction to track latest) while keeping each run reproducible.
- Restores this repo's bun/npm harness adaptation (node 22 + `npm i -g` + minimal policy parse) that a local `specgit issue` run under 0.5.0 had overwritten with the pnpm template — 0.5.0 regenerates the harness on `issue`, so the repo adaptation is now treated as a delivery-reviewed artifact: regenerated content gets reviewed like code and restored in the same PR.

## Verification

- YAML parses; the delivery PR itself exercises the pinned install.
