### PR TITLE
fix(license): add the SPDX headers to environment-catalogs.ts

### DIFF
--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -5,3 +5,4 @@ context:
   branch: feat/368-issue368
 issues:
   - 368
+pr: 369

--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -1,8 +1,7 @@
 version: 1
-delivery: issue366
+delivery: issue368
 context:
   kind: branch
-  branch: feat/366-issue366
+  branch: feat/368-issue368
 issues:
-  - 366
-pr: 367
+  - 368

--- a/packages/opencode/src/dag/environment-catalogs.ts
+++ b/packages/opencode/src/dag/environment-catalogs.ts
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 LeXwDeX
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 export * as DagEnvironmentCatalogs from "./environment-catalogs"
 
 import { Effect } from "effect"


### PR DESCRIPTION
Closes #368

## What

SPDX `FileCopyrightText` + `License-Identifier: AGPL-3.0-or-later` headers on `packages/opencode/src/dag/environment-catalogs.ts` (the file introduced with #361's catalog-loader extraction).

## Verification

- `bun test test/license-scope.test.ts` (packages/core) 5/5 green
- dev's push-triggered full run should go green on this merge (red since 698713c0, 4 consecutive failures)
