### PR TITLE
docs(dag): 'one objective, one live DAG' downgraded from Invariant to Convention

### DIFF
--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -1,8 +1,7 @@
 version: 1
-delivery: issue368
+delivery: issue348
 context:
   kind: branch
-  branch: feat/368-issue368
+  branch: feat/348-issue348
 issues:
-  - 368
-pr: 369
+  - 348

--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -5,3 +5,4 @@ context:
   branch: feat/348-issue348
 issues:
   - 348
+pr: 373

--- a/packages/opencode/src/dag/CONTEXT.md
+++ b/packages/opencode/src/dag/CONTEXT.md
@@ -22,12 +22,15 @@ Workflow Orchestration turns one user objective into one durable DAG. Its model-
 
 ## Invariants
 
-- One user objective has at most one live DAG; route expansion stays inside that DAG.
 - Block composition is the recommended authoring path and is selected heuristically from the objective; custom Blocks/Nodes remain supported.
 - Workflow Authoring Check is the only raw source-to-Prepared Workflow Graph authority used by tool actions, CLI, generation, and packaging.
 - Parsing, file-only compatibility, strict action decoding, Block compilation, and profile diagnostics are not reimplemented by callers.
 - `portable` validation does not load user environment catalogs. `environment` validation reads current catalogs and verifies actual model availability.
 - No workflow event or durable mutation occurs before a valid Prepared Workflow Graph exists.
+
+## Conventions
+
+- One user objective has at most one live DAG; route expansion stays inside that DAG (issue #348: a modeling convention enforced by orchestrator guidance — workflow-routing and orchestration-policy — not by the engine; `dag.create` and the workflow tool's start accept a session with a live workflow. The runtime tolerates the violation with bounded consequences: the wake model aggregates across workflows and a goal is blocked by any DAG lease. When two live DAGs share one workspace, the plan block's disjoint-write-set discipline does NOT carry across workflows — authors must keep concurrent workflows on disjoint worktrees or serialize them).
 - The model-facing schema contains fields the model owns. Session/Project identity, admission audit state, model assignment, and other runtime-derived fields remain hidden.
 - Model-facing graph actions expose only `spec_path`; graph fields live in YAML so provider tool-call serialization cannot turn a nested graph into a string.
 - Legacy YAML may be adapted at the file boundary without making legacy fields valid inline input.


### PR DESCRIPTION
Closes #348

## Decision (option b — record the truth)

CONTEXT.md's Invariant list claimed "one user objective has at most one live DAG" as an engine guarantee. The implementation is orchestrator guidance (workflow-routing.md / orchestration-policy.md); `dag.create` and the workflow tool's start accept a session that already has a live workflow, nothing cross-process rejects a second one.

The divergence was the defect. This PR moves the statement to a new **Conventions** section with the honest framing:

- convention enforced by orchestrator guidance, not the engine
- violation consequences are bounded (wake model aggregates across workflows; a goal lease is blocked by any DAG)
- the real hazard documented: two live DAGs sharing one workspace get NO cross-workflow write-set disjointness — authors must use disjoint worktrees or serialize

Option (a) — engine enforcement — remains a possible future decision if the convention proves insufficient; nothing here forecloses it.

Docs-only change; no runtime code touched.
