### PR TITLE
chore: post-review cleanup — docs drift, CONTEXT.md section order, review nits

### DIFF
--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -5,3 +5,4 @@ context:
   branch: feat/375-issue375
 issues:
   - 375
+pr: 375

--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -1,8 +1,7 @@
 version: 1
-delivery: issue375
+delivery: issue374
 context:
   kind: branch
-  branch: feat/375-issue375
+  branch: feat/374-issue374
 issues:
-  - 375
-pr: 375
+  - 374

--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -2,6 +2,7 @@ version: 1
 delivery: issue374
 context:
   kind: branch
-  branch: feat/374-issue374
+  branch: feat/375-issue375
 issues:
   - 374
+pr: 375

--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -1,8 +1,7 @@
 version: 1
-delivery: issue348
+delivery: issue375
 context:
   kind: branch
-  branch: feat/348-issue348
+  branch: feat/375-issue375
 issues:
-  - 348
-pr: 373
+  - 375

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,22 +4,22 @@
 ## Git Workflow (铁律)
 
 ```
-feat/**, fix/** ──PR(Typecheck 门禁)──▶ dev ──push 触发全量测试──▶
+feat/**, fix/** ──PR(Typecheck + Unit Tests 门禁)──▶ dev ──push 触发全量测试──▶
     dev ──手动 release-fork──▶ prerelease 测试版
     dev ──PR(全量测试门禁)──▶ main ──手动 release-fork──▶ 正式版
 ```
 
-**分层门禁**：`dev` 是快速集成层（仅 Typecheck），`main` 是正式质量门禁（Typecheck + 全量 Unit Tests + E2E）。所有改动通过 PR 流转，禁止直推 `main` 和 `dev`（由 GitHub Rulesets 强制）。
+**分层门禁**：`dev` 是快速集成层（Typecheck + Unit Tests (linux)；E2E 不阻塞），`main` 是正式质量门禁（Typecheck + 全量 Unit Tests + E2E）。所有改动通过 PR 流转，禁止直推 `main` 和 `dev`（由 GitHub Rulesets 强制）。
 
 | Branch | 直推 | PR 门禁 | CI 触发 | Purpose |
 |--------|------|---------|---------|---------|
 | `{type}/**` | ✅ 允许 | — | ❌ 不跑 | 开发分支，频繁变更 |
-| `dev` | ❌ 禁止 | PR 必须通过 **Typecheck** | ✅ push 触发 Typecheck + 全量测试 | 快速集成层 |
+| `dev` | ❌ 禁止 | PR 必须通过 **Typecheck + Unit Tests (linux)** | ✅ push 触发 Typecheck + 全量测试 | 快速集成层 |
 | `main` | ❌ 禁止 | PR 必须通过 **Typecheck + Unit Tests + E2E (linux + windows)** | ✅ push 触发全量 | 正式质量门禁 + 发版 |
 
 **流程**：
 1. 从 `main` 切出 `feat/**` 或 `fix/**` 分支开发
-2. PR → `dev`（Typecheck 门禁，快速合并）
+2. PR → `dev`（Typecheck + Unit Tests (linux) 门禁，快速合并）
 3. push 到 `dev` 自动触发全量测试验证
 4. 从 `dev` 手动 `release-fork` → 产出 **prerelease** 测试版
 5. PR `dev` → `main`（全量测试门禁：Typecheck + Unit Tests + E2E）

--- a/packages/opencode/src/dag/CONTEXT.md
+++ b/packages/opencode/src/dag/CONTEXT.md
@@ -27,15 +27,15 @@ Workflow Orchestration turns one user objective into one durable DAG. Its model-
 - Parsing, file-only compatibility, strict action decoding, Block compilation, and profile diagnostics are not reimplemented by callers.
 - `portable` validation does not load user environment catalogs. `environment` validation reads current catalogs and verifies actual model availability.
 - No workflow event or durable mutation occurs before a valid Prepared Workflow Graph exists.
-
-## Conventions
-
-- One user objective has at most one live DAG; route expansion stays inside that DAG (issue #348: a modeling convention enforced by orchestrator guidance — workflow-routing and orchestration-policy — not by the engine; `dag.create` and the workflow tool's start accept a session with a live workflow. The runtime tolerates the violation with bounded consequences: the wake model aggregates across workflows and a goal is blocked by any DAG lease. When two live DAGs share one workspace, the plan block's disjoint-write-set discipline does NOT carry across workflows — authors must keep concurrent workflows on disjoint worktrees or serialize them).
 - The model-facing schema contains fields the model owns. Session/Project identity, admission audit state, model assignment, and other runtime-derived fields remain hidden.
 - Model-facing graph actions expose only `spec_path`; graph fields live in YAML so provider tool-call serialization cannot turn a nested graph into a string.
 - Legacy YAML may be adapted at the file boundary without making legacy fields valid inline input.
 - Runtime Admission and Workflow Authoring Check have separate names, state, and responsibilities.
 - Dependents of a reporting checkpoint must be gated on its output; authoring rejects ungated shapes at start/validate AND at replan/extend fragment actions, and the runtime replan/extend mutation seam re-checks the merged graph (exempting checkpoints already terminal in the durable graph — they are settled and immutable, the spawn-before-verdict race is past; runtime create remains deliberately unchanged). A gated checkpoint must declare `output_schema` (authoring obligation).
+
+## Conventions
+
+- One user objective has at most one live DAG; route expansion stays inside that DAG (issue #348: a modeling convention enforced by orchestrator guidance — workflow-routing and orchestration-policy — not by the engine; `dag.create` and the workflow tool's start accept a session with a live workflow. The runtime tolerates the violation with bounded consequences: the wake model aggregates across workflows and a goal is blocked by any DAG lease. When two live DAGs share one workspace, the plan block's disjoint-write-set discipline does NOT carry across workflows — authors must keep concurrent workflows on disjoint worktrees or serialize them).
 
 ## Boundaries
 

--- a/packages/opencode/src/dag/blocks.ts
+++ b/packages/opencode/src/dag/blocks.ts
@@ -262,30 +262,7 @@ function compileBlock(
         contract: AGGREGATOR_CONTRACT,
         required: true,
         reportToParent: false,
-        inputMapping: Object.fromEntries(
-          (() => {
-            // #349/BLK-02: writer ids may mix hyphens and underscores
-            // ("foo-bar" vs "foo_bar") whose -→_ normalization collides on
-            // the same mapping key — Object.fromEntries would silently drop
-            // one writer's evidence (and its files escape the aggregator's
-            // overlap detection). Reject the shape at compile time.
-            const seen = new Map<string, string>()
-            for (const writerID of aggregation.writerIDs) {
-              const key = writerID.replace(/-/g, "_")
-              const prior = seen.get(key)
-              if (prior !== undefined) {
-                throw new Error(
-                  `Parallel implementation writers "${prior}" and "${writerID}" normalize to the same input-mapping key "${key}" — their aggregator evidence keys would collide. Rename one of the writers so the ids differ beyond hyphens vs underscores`,
-                )
-              }
-              seen.set(key, writerID)
-            }
-            return aggregation.writerIDs.flatMap((writerID: string) => [
-              [`${writerID.replace(/-/g, "_")}_changed_files`, `${writerID}.output.changed_files`],
-              [`${writerID.replace(/-/g, "_")}_summary`, `${writerID}.output.summary`],
-            ])
-          })(),
-        ),
+        inputMapping: aggregatorEvidenceMapping(aggregation.writerIDs),
         outputSchema: IMPLEMENTATION_SCHEMA,
       }),
       ...lanes,
@@ -447,6 +424,33 @@ interface WriterAggregation {
   aggregatorID: string
   writerIDs: string[]
   verificationID: string
+}
+
+/**
+ * The aggregator's per-writer evidence mapping. #349/BLK-02: writer ids may
+ * mix hyphens and underscores ("foo-bar" vs "foo_bar") whose -→_ normalization
+ * collides on the same mapping key — Object.fromEntries would silently drop
+ * one writer's evidence (and its files escape the aggregator's overlap
+ * detection), so the shape is rejected at compile time.
+ */
+function aggregatorEvidenceMapping(writerIDs: string[]): Record<string, string> {
+  const seen = new Map<string, string>()
+  for (const writerID of writerIDs) {
+    const key = writerID.replace(/-/g, "_")
+    const prior = seen.get(key)
+    if (prior !== undefined) {
+      throw new Error(
+        `Parallel implementation writers "${prior}" and "${writerID}" normalize to the same input-mapping key "${key}" — their aggregator evidence keys would collide. Rename one of the writers so the ids differ beyond hyphens vs underscores`,
+      )
+    }
+    seen.set(key, writerID)
+  }
+  return Object.fromEntries(
+    writerIDs.flatMap((writerID: string) => [
+      [`${writerID.replace(/-/g, "_")}_changed_files`, `${writerID}.output.changed_files`],
+      [`${writerID.replace(/-/g, "_")}_summary`, `${writerID}.output.summary`],
+    ]),
+  )
 }
 
 function aggregateParallelWriters(blocks: WorkflowBlock[]) {

--- a/packages/opencode/src/tool/memory-search.ts
+++ b/packages/opencode/src/tool/memory-search.ts
@@ -33,11 +33,7 @@ export const MemorySearchTool = Tool.define<typeof Parameters, Metadata, never>(
 
         const memory = Option.getOrUndefined(yield* Effect.serviceOption(Memory.Service))
         const sessions = Option.getOrUndefined(yield* Effect.serviceOption(Session.Service))
-        // #350: when the service exists but Memory is inert, say why instead
-        // of a bare "unavailable" — the reason tells the user what to do
-        // (e.g. run /init, then /memory on).
-        if (!memory) return unavailable()
-        if (!sessions) return unavailable()
+        if (!memory || !sessions) return unavailable()
         const current = yield* sessions.get(ctx.sessionID).pipe(Effect.option)
         if (Option.isNone(current) || current.value.parentID) return unavailable()
 


### PR DESCRIPTION
Closes #374

## What

Info-level findings from the two-axis review of `44c58434d..HEAD` (both axes PASS, 0 blocking):

1. **AGENTS.md** — Git Workflow diagram/table/prose updated: dev PR gate is now `Typecheck + Unit Tests (linux)` (drift left by #370's gate raise).
2. **CONTEXT.md** — the `## Conventions` header from #348 was inserted mid-list and accidentally captured 5 original Invariants (model-facing schema, spec_path, legacy YAML, admission separation, and the engine-enforced gated-checkpoint/output_schema obligation). Section reordered: full Invariants list first, Conventions after. Those 5 are Invariants again.
3. **memory-search.ts** — identical if-branches folded back to `||`.
4. **blocks.ts** — BLK-02 collision check extracted from the inline IIFE into `aggregatorEvidenceMapping` (Style Guide: supporting details in small named helpers).
5. **#340 acceptance delta documented** — the "serve-mode goal continuing past turn 1" line is covered by composition (e2e-loop.test.ts behavior suite + the wiring probe asserting the exact failure class); no third harness is built.

## Verification

- typecheck green; blocks tests 23/23; lint delta zero
