### PR TITLE
chore(specgit): acceptance also runs on PRs to main

### DIFF
--- a/.github/workflows/specgit-accept.yml
+++ b/.github/workflows/specgit-accept.yml
@@ -2,9 +2,12 @@ name: SpecGit Acceptance
 
 on:
   pull_request:
-    # Delivery PRs target dev (fast-integration layer); dev→main promotion
-    # stays governed by the protect-main Ruleset's four required checks.
-    branches: [dev]
+    # Delivery PRs target dev (fast-integration layer) and are promoted to
+    # main via the release PR — main's legacy branch protection also requires
+    # the SpecGit Acceptance check, so the verdict must run on both targets.
+    # dev→main promotion stays governed by the protect-main Ruleset's four
+    # required checks.
+    branches: [dev, main]
 
 permissions:
   contents: read


### PR DESCRIPTION
main's legacy branch protection requires the SpecGit Acceptance check, but the workflow only triggered on PRs to dev — the dev->main release PR (#376) is permanently BLOCKED with all four Ruleset checks green. Adds main to the pull_request trigger set (the verdict logic is target-agnostic; policy.yaml unchanged).

Hotfix for the blocked release promotion; docs-only-equivalent workflow change.