### PR TITLE
fix(test): declare per-test timeouts for dag-node-supervision long tests

### DIFF
--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -1,11 +1,8 @@
 version: 1
-delivery: issue378
+delivery: issue384
 context:
   kind: branch
-  branch: feat/378-issue378
+  branch: feat/384-issue384
 issues:
-  - 378
-  - 379
-  - 380
-  - 381
-pr: 382
+  - 384
+pr: 385

--- a/packages/opencode/test/dag/dag-node-supervision.test.ts
+++ b/packages/opencode/test/dag/dag-node-supervision.test.ts
@@ -240,7 +240,9 @@ const supervisionProgress = (store: DagStore.Interface, dagID: string, nodeID: s
   })
 
 // bun's default per-test timeout is 5s; several bodies here need 8-40s at a
-// 2s deadline — run this file with --timeout 30000 (the CI suite default).
+// 2s deadline — the long tests below declare their own per-test timeout
+// (it(..., 30000), matching the CI suite's --timeout 30000) so bare focused
+// invocations don't red-fail them.
 describe("DAG node supervision — deadline enforcement (production incident)", () => {
   it("healthy: a node past its deadline gets escalated by the watcher", async () => {
     await Effect.runPromise(
@@ -353,7 +355,7 @@ describe("DAG node supervision — deadline enforcement (production incident)", 
         }),
       ),
     )
-  })
+  }, 30_000)
 
   // Review R4 issue 1 (P0): the sweep's layer-scoped fiber has no ambient
   // InstanceRef, so a real SessionPrompt.cancel DIES at
@@ -396,7 +398,7 @@ describe("DAG node supervision — deadline enforcement (production incident)", 
         }),
       ),
     )
-  })
+  }, 30_000)
 
   // Review R1 issue 2 (false-positive kill): a LIVE watcher on a node whose
   // escalation cadence spans multiple sweep intervals must never be swept —
@@ -444,7 +446,7 @@ describe("DAG node supervision — deadline enforcement (production incident)", 
         }),
       ),
     )
-  })
+  }, 30_000)
 })
 
 describe("DagSupervisionSweep cadence derivation (pure)", () => {


### PR DESCRIPTION
## Summary
- #384: the three long-running incident-harness tests (`dispose-instance`, `cancel-defect`, `freeze window`) need 12-15s by design but relied on a comment-only contract to be run with `--timeout 30000`. Bare focused invocation hit bun's default 5s per-test timeout and red-failed three healthy tests.
- Declares `it(..., 30000)` per-test timeouts on the three tests and syncs the header comment.

## Verification
- `bun test test/dag/dag-node-supervision.test.ts` (bare, previously 8 pass / 3 fail) → **11 pass / 0 fail**
- Canonical runner (`--timeout 30000`) unchanged green; file lints 0 warnings

Closes #384
