### PR TITLE
fix(ci): restore proven specgit-accept install strategy

### DIFF
--- a/.github/workflows/specgit-accept.yml
+++ b/.github/workflows/specgit-accept.yml
@@ -2,6 +2,10 @@ name: SpecGit Acceptance
 
 on:
   pull_request:
+    # Delivery PRs target dev (fast-integration layer); the acceptance
+    # verdict runs only on the dev→main promotion PR, where protect-main's
+    # checks apply. Keep the trigger main-only (d6ce53a83): running it on
+    # dev PRs duplicated the verdict against the lighter dev gate.
     branches: [main]
 
 permissions:
@@ -11,7 +15,10 @@ jobs:
   specgit-acceptance:
     name: SpecGit Acceptance
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # Must exceed the slowest required sibling (Unit Tests (linux) runs
+    # ~28min on PRs): the verdict waits for every policy check to reach a
+    # terminal state before evaluating.
+    timeout-minutes: 45
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -23,20 +30,18 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
-
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20.19.0'
-          cache: 'pnpm'
+          node-version: '22'
 
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Build CLI
-        run: pnpm run build
+      # This repo is a bun workspace and does not vendor the SpecGit CLI;
+      # install the published CLI instead of building from source. Pinned
+      # with a caret floor (#366): the CLI releases multiple times a day and
+      # an unpinned install would let an unnoticed upstream change flip CI
+      # acceptance verdicts repo-wide.
+      - name: Install specgit CLI
+        run: npm install -g specgit@^0.5.0
 
       - name: Wait for sibling checks
         # The verdict must see the OTHER required checks in a terminal
@@ -51,9 +56,11 @@ jobs:
         run: |
           node --input-type=module <<'EOF'
           import { readFileSync } from 'node:fs';
-          import { parse } from 'yaml';
-          const policy = parse(readFileSync('spec_git/policy.yaml', 'utf8'));
-          const required = policy.required_checks ?? [];
+          // Minimal parse of policy.yaml's required_checks block list —
+          // avoids a yaml dependency in this bun-based repo.
+          const policy = readFileSync('spec_git/policy.yaml', 'utf8');
+          const section = policy.slice(policy.indexOf('required_checks:'));
+          const required = [...section.matchAll(/^\s*-\s*(.+)$/gm)].map((m) => m[1].trim());
           const headers = {
             authorization: 'Bearer ' + process.env.GH_TOKEN,
             accept: 'application/vnd.github+json',
@@ -66,7 +73,9 @@ jobs:
             const retried = [...byName.keys()].find((k) => k.startsWith(name + ' ('));
             return retried !== undefined && terminal.has(byName.get(retried));
           };
-          const deadline = Date.now() + 15 * 60 * 1000;
+          // Must outlast the slowest required sibling (Unit Tests (linux)
+          // runs ~28min on PRs); the job timeout above bounds this too.
+          const deadline = Date.now() + 40 * 60 * 1000;
           while (Date.now() < deadline) {
             const res = await fetch(url, { headers });
             if (!res.ok) throw new Error('check-runs API ' + res.status);
@@ -85,6 +94,6 @@ jobs:
           EOF
 
       - name: specgit finish
-        run: node bin/specgit.js finish --json
+        run: specgit finish --json
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
d6ce53a83 rewrote specgit-accept.yml to pnpm + build-from-source, but this is a bun workspace (no pnpm-lock, no pinned pnpm version): the first main-target PR (#399) failed at 'Setup pnpm — No pnpm version is specified', and the wait step's 'yaml' import would also not resolve. Restores the verified node22 + npm i -g specgit@^0.5.0 + regex policy parse + 40min wait, keeping the main-only trigger. Workflow-only change; Typecheck is the dev gate.