### PR TITLE
docs(release): add v1.0.30 series notes

### DIFF
--- a/.github/releases/v1.0.30.md
+++ b/.github/releases/v1.0.30.md
@@ -1,0 +1,33 @@
+## opencode {VERSION}
+
+{Prerelease/Stable} release from `{branch}` branch. Headless `/init` now stamps project initialization, so MEMORY works from `opencode run` and SDK text prompts, not just the TUI.
+
+---
+
+### 🐛 Bug Fixes
+
+- **Headless `/init` never stamped project initialization, #404 (PR #405)**: `opencode run "/init"` and serve `POST /session/:id/message` text prompts delivered slash commands as plain text — command routing existed only in the TUI client, so `SessionPrompt.command` never ran, `Command.Event.Executed` never fired, and `project.time_initialized` stayed NULL, leaving MEMORY fail-closed inert with no hint. The server-side prompt endpoints (`prompt` and `promptAsync`) now route single-text-part prompts that name a registered command through the command lifecycle; a registry miss falls through to the plain prompt, preserving existing text-prompt semantics. The TUI `/command` path is unchanged.
+
+---
+
+### 🧪 Test Summary
+
+```
+CI gates on the dev-to-main promotion:
+Typecheck:           pass
+Unit Tests (linux):  pass
+E2E Tests (linux):   pass
+E2E Tests (windows): pass
+SpecGit Acceptance:  pass
+```
+
+---
+
+### 🔍 Verification
+
+- The regression is pinned by `test/cli/run/headless-init.test.ts`: four subprocess arms — `opencode run "/init"` and serve message text `/init` (both RED on the parent commit), plus `run --command init` and serve `/command` controls — assert a non-NULL `time_initialized` in the isolated project database.
+- End-to-end verification spawned the CLI from source on a fresh git repo with an isolated HOME and confirmed the stamp lands on the `opencode run "/init"` path; the fix was delivered through the specgit harness with an accepted verdict on PR #405.
+
+---
+
+**Full changelog:** [`{previous_tag}`...`{current_tag}`](https://github.com/LeXwDeX/OpenCode-GraphAgent/compare/{previous_tag}...{current_tag})

--- a/.github/releases/v1.0.30.md
+++ b/.github/releases/v1.0.30.md
@@ -6,7 +6,7 @@
 
 ### 🐛 Bug Fixes
 
-- **Headless `/init` never stamped project initialization, #404 (PR #405)**: `opencode run "/init"` and serve `POST /session/:id/message` text prompts delivered slash commands as plain text — command routing existed only in the TUI client, so `SessionPrompt.command` never ran, `Command.Event.Executed` never fired, and `project.time_initialized` stayed NULL, leaving MEMORY fail-closed inert with no hint. The server-side prompt endpoints (`prompt` and `promptAsync`) now route single-text-part prompts that name a registered command through the command lifecycle; a registry miss falls through to the plain prompt, preserving existing text-prompt semantics. The TUI `/command` path is unchanged.
+- **Headless `/init` never stamped project initialization, #404 (PR #405)**: `opencode run "/init"` and serve `POST /session/:id/message` text prompts delivered slash commands as plain text - command routing existed only in the TUI client, so `SessionPrompt.command` never ran, `Command.Event.Executed` never fired, and `project.time_initialized` stayed NULL, leaving MEMORY fail-closed inert with no hint. The server-side prompt endpoints (`prompt` and `promptAsync`) now route single-text-part prompts that name a registered command through the command lifecycle; a registry miss falls through to the plain prompt, preserving existing text-prompt semantics. The TUI `/command` path is unchanged.
 
 ---
 
@@ -25,7 +25,7 @@ SpecGit Acceptance:  pass
 
 ### 🔍 Verification
 
-- The regression is pinned by `test/cli/run/headless-init.test.ts`: four subprocess arms — `opencode run "/init"` and serve message text `/init` (both RED on the parent commit), plus `run --command init` and serve `/command` controls — assert a non-NULL `time_initialized` in the isolated project database.
+- The regression is pinned by `test/cli/run/headless-init.test.ts`: four subprocess arms - `opencode run "/init"` and serve message text `/init` (both RED on the parent commit), plus `run --command init` and serve `/command` controls - assert a non-NULL `time_initialized` in the isolated project database.
 - End-to-end verification spawned the CLI from source on a fresh git repo with an isolated HOME and confirmed the stamp lands on the `opencode run "/init"` path; the fix was delivered through the specgit harness with an accepted verdict on PR #405.
 
 ---


### PR DESCRIPTION
Series notes for the next stable release (mechanically derived: graphagent-v1.0.29 → v1.0.30). Local render rehearsal passed (release-notes.ts exit 0, placeholders resolved). Companion to PR #405 (#404 fix) for the upcoming release train.