### PR TITLE
chore(specgit): record PR 405 binding for issue 404 delivery

### DIFF
--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -5,3 +5,4 @@ context:
   branch: fix/404-headless-init-does
 issues:
   - 404
+pr: 405


### PR DESCRIPTION
Commits the .specgit.yaml pr: 405 field that specgit pr wrote locally but was never committed, so the dev record is complete for SpecGit Acceptance on the promotion PR (#407). Companion to #405/#404.