### PR TITLE
Delivery dagid-schema-pattern

### DIFF
--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -1,8 +1,7 @@
 version: 1
-delivery: headless-init-does
+delivery: dagid-schema-pattern
 context:
   kind: branch
-  branch: fix/404-headless-init-does
+  branch: fix/412-dagid-schema-pattern
 issues:
-  - 404
-pr: 405
+  - 412

--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -5,3 +5,4 @@ context:
   branch: fix/412-dagid-schema-pattern
 issues:
   - 412
+pr: 413

--- a/packages/opencode/test/tool/__snapshots__/parameters.test.ts.snap
+++ b/packages/opencode/test/tool/__snapshots__/parameters.test.ts.snap
@@ -485,7 +485,7 @@ exports[`tool parameters JSON Schema (wire shape) workflow 1`] = `
             },
             "workflow_id": {
               "description": "Target workflow ID",
-              "pattern": "^dag",
+              "pattern": "^dag.*$",
               "type": "string",
             },
           },
@@ -518,7 +518,7 @@ exports[`tool parameters JSON Schema (wire shape) workflow 1`] = `
             },
             "workflow_id": {
               "description": "Target workflow ID",
-              "pattern": "^dag",
+              "pattern": "^dag.*$",
               "type": "string",
             },
           },
@@ -552,7 +552,7 @@ exports[`tool parameters JSON Schema (wire shape) workflow 1`] = `
             },
             "workflow_id": {
               "description": "Target workflow ID",
-              "pattern": "^dag",
+              "pattern": "^dag.*$",
               "type": "string",
             },
           },
@@ -574,7 +574,7 @@ exports[`tool parameters JSON Schema (wire shape) workflow 1`] = `
             },
             "workflow_id": {
               "description": "Target workflow ID",
-              "pattern": "^dag",
+              "pattern": "^dag.*$",
               "type": "string",
             },
           },
@@ -609,7 +609,7 @@ exports[`tool parameters JSON Schema (wire shape) workflow 1`] = `
             },
             "workflow_id": {
               "description": "Target workflow ID",
-              "pattern": "^dag",
+              "pattern": "^dag.*$",
               "type": "string",
             },
           },

--- a/packages/schema/src/dag-event.ts
+++ b/packages/schema/src/dag-event.ts
@@ -17,7 +17,10 @@ import { Model } from "./model"
 // Branded IDs
 // ============================================================================
 
-export const DagID = Schema.String.check(Schema.isStartsWith("dag")).pipe(
+// Fully anchored pattern: llama.cpp's tool-schema conversion rejects any
+// `pattern` that doesn't start with '^' and end with '$'. `^dag.*$` keeps the
+// exact starts-with("dag") semantics of the previous isStartsWith filter.
+export const DagID = Schema.String.check(Schema.isPattern(/^dag.*$/)).pipe(
   Schema.brand("DagID"),
   withStatics((schema) => {
     const create = () => schema.make("dag_" + descending())

--- a/packages/schema/test/dag-id-pattern.test.ts
+++ b/packages/schema/test/dag-id-pattern.test.ts
@@ -1,0 +1,31 @@
+import { test, expect } from "bun:test"
+import { Schema } from "effect"
+import { DagEvent } from "../src/dag-event"
+
+// llama.cpp's OpenAI-compatible server rejects tool JSON Schemas whose `pattern`
+// is not anchored at both ends ("Pattern must start with '^' and end with '$'").
+// DagID flows into the workflow tool's workflow_id parameters, so every pattern
+// it serializes must carry both anchors while keeping starts-with("dag") semantics.
+const BOTH_ANCHORS = /^\^.*\$$/
+
+function patternsOf(node: unknown): string[] {
+  if (Array.isArray(node)) return node.flatMap(patternsOf)
+  if (typeof node !== "object" || node === null) return []
+  const record = node as Record<string, unknown>
+  const own = typeof record.pattern === "string" ? [record.pattern] : []
+  return [...own, ...Object.values(record).flatMap(patternsOf)]
+}
+
+test("DagID serializes to fully anchored JSON Schema patterns", () => {
+  const patterns = patternsOf(Schema.toJsonSchemaDocument(DagEvent.DagID))
+  expect(patterns.length).toBeGreaterThan(0)
+  for (const pattern of patterns) expect(pattern).toMatch(BOTH_ANCHORS)
+})
+
+test("DagID keeps starts-with validation semantics", () => {
+  const isDagID = Schema.is(DagEvent.DagID)
+  expect(isDagID("dag_000ffffffffffffff0000")).toBe(true)
+  expect(isDagID("dag_anything")).toBe(true)
+  expect(isDagID("ses_abc123")).toBe(false)
+  expect(isDagID("")).toBe(false)
+})


### PR DESCRIPTION
Closes #412

## Why
llama.cpp's OpenAI-compatible server rejects tool JSON Schemas whose `pattern` is not anchored at both ends. `DagID`'s `Schema.isStartsWith("dag")` serialized to `pattern: "^dag"` (start-anchored only), so every request carrying the workflow tool (5 parameters reference `Dag.ID`) failed with `JSON schema conversion failed: Pattern must start with '^' and end with '$'`.

## What changed
- `packages/schema/src/dag-event.ts`: `DagID` filter switched from `isStartsWith("dag")` to `isPattern(/^dag.*$/)` — fully anchored pattern, identical starts-with validation semantics.
- `packages/schema/test/dag-id-pattern.test.ts`: regression test asserting every serialized pattern is `^...$`-anchored and validation semantics are unchanged.

## Evidence
- New test red before the fix (pattern `^dag` failed both-anchors assertion), green after.
- `bun test` in packages/schema: 19 pass.
- `bun test test/dag` in packages/opencode: 615 pass; `bun run test:dag-core`: gate passed.
- `bun typecheck` in packages/schema and packages/opencode: clean.
- End-to-end: streaming chat completion against the llama.cpp server (192.168.33.110:8081) with a `^dag.*$` tool pattern is accepted (previously 400).

## Checklist
- [x] Reproduced the failure (mitm capture showed 5 unanchored `^dag` patterns)
- [x] Fix verified against the real llama.cpp endpoint
- [x] Typecheck + unit tests green locally
- [ ] CI gates green