### PR TITLE
Delivery init-stamp-is

### DIFF
--- a/.github/releases/v1.0.31.md
+++ b/.github/releases/v1.0.31.md
@@ -1,0 +1,34 @@
+## opencode {VERSION}
+
+{Prerelease/Stable} release from `{branch}` branch. Tool JSON Schemas now use fully anchored patterns, so OpenAI-compatible backends with strict schema validation (llama.cpp server) accept tool-carrying requests instead of rejecting them.
+
+---
+
+### 🐛 Bug Fixes
+
+- **DagID pattern only start-anchored, broke llama.cpp tool schema validation, #412 (PR #413)**: `DagID`'s `Schema.isStartsWith("dag")` filter serialized to `pattern: "^dag"` with only a start anchor. Backends that convert tool JSON Schemas to grammars (llama.cpp's OpenAI-compatible server) require `^...$` anchoring and rejected every request carrying the workflow tool with `JSON schema conversion failed: Pattern must start with '^' and end with '$'`. The filter is now `Schema.isPattern(/^dag.*$/)` with identical starts-with validation semantics.
+
+---
+
+### 🧪 Test Summary
+
+```
+CI gates on the dev-to-main promotion:
+Typecheck:           pass
+Unit Tests (linux):  pass
+E2E Tests (linux):   pass
+E2E Tests (windows): pass
+SpecGit Acceptance:  pass
+```
+
+---
+
+### 🔍 Verification
+
+- Regression pinned by `packages/schema/test/dag-id-pattern.test.ts`: every serialized pattern must match `^.*$` both-anchored form, and DagID still accepts any `dag`-prefixed string while rejecting others.
+- Workflow tool wire-shape snapshots updated (`^dag` to `^dag.*$`, 5 occurrences).
+- End-to-end: streaming chat completion against a real llama.cpp server (192.168.33.110:8081) with a `^dag.*$` tool pattern accepted (previously 400); delivered through the specgit harness with an accepted verdict on PR #413.
+
+---
+
+**Full changelog:** [`{previous_tag}`...`{current_tag}`](https://github.com/LeXwDeX/OpenCode-GraphAgent/compare/{previous_tag}...{current_tag})

--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -1,8 +1,7 @@
 version: 1
-delivery: headless-init-does
+delivery: dagid-schema-pattern
 context:
   kind: branch
-  branch: fix/404-headless-init-does
+  branch: fix/412-dagid-schema-pattern
 issues:
-  - 404
-pr: 405
+  - 412

--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -5,3 +5,4 @@ context:
   branch: fix/412-dagid-schema-pattern
 issues:
   - 412
+pr: 413

--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -1,8 +1,7 @@
 version: 1
-delivery: dagid-schema-pattern
+delivery: init-stamp-is
 context:
   kind: branch
-  branch: fix/412-dagid-schema-pattern
+  branch: fix/415-init-stamp-is
 issues:
-  - 412
-pr: 413
+  - 415

--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -5,3 +5,4 @@ context:
   branch: fix/415-init-stamp-is
 issues:
   - 415
+pr: 416

--- a/packages/opencode/src/memory/memory.ts
+++ b/packages/opencode/src/memory/memory.ts
@@ -1,9 +1,11 @@
 export * as Memory from "./memory"
 
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { FSUtil } from "@opencode-ai/core/fs-util"
 import { ProjectV2 } from "@opencode-ai/core/project"
 import { SessionV1 } from "@opencode-ai/core/v1/session"
 import { Cause, Context, Deferred, Effect, Exit, Layer, Option, Ref, Schema, Scope, Semaphore } from "effect"
+import path from "node:path"
 import { stringify } from "yaml"
 import { Config } from "@/config/config"
 import { Provider } from "@/provider/provider"
@@ -788,8 +790,32 @@ export const layer: Layer.Layer<
       if (current.id === ProjectV2.ID.global)
         return "Memory is unavailable until this repository has a real identity: commit once or add a remote, then run /init."
       if (current.vcs !== "git") return "Memory requires a git repository."
-      if (!current.time.initialized)
-        return "Memory is unavailable until the project is initialized — run /init first, then /memory on."
+      if (!current.time.initialized) {
+        // #415: the stamp is written by a Command.Event.Executed listener that
+        // can lose the race with /init itself. The artifact /init leaves behind
+        // (a non-empty AGENTS.md) is durable evidence the project WAS
+        // initialized, so heal the row instead of sending the user to re-run
+        // /init into the same race.
+        const agentsMd = path.join(current.worktree, "AGENTS.md")
+        // Non-empty AGENTS.md is the durable artifact /init leaves behind.
+        // FSUtil rides MemoryConfig's layer (optional access keeps this layer
+        // lightweight — a missing wire degrades to no-heal, not a crash).
+        const healed = yield* Effect
+          .serviceOption(FSUtil.Service)
+          .pipe(
+            Effect.flatMap((option) =>
+              Option.isSome(option)
+                ? option.value.readFileStringSafe(agentsMd).pipe(Effect.map((content) => (content?.trim().length ?? 0) > 0))
+                : Effect.succeed(false),
+            ),
+            Effect.catch(() => Effect.succeed(false)),
+          )
+        if (healed) {
+          yield* project.setInitialized(current.id)
+        } else {
+          return `Memory is unavailable until the project is initialized — run /init first, then /memory on. (db: time_initialized=NULL, worktree=${current.worktree}, sandboxes=${current.sandboxes.join(", ") || "none"})`
+        }
+      }
       // An unreadable config/store answers "cannot determine" rather than
       // failing the status surface.
       const optioned = yield* Effect.option(configuration())

--- a/packages/opencode/test/memory/memory-init-stamp-selfheal.test.ts
+++ b/packages/opencode/test/memory/memory-init-stamp-selfheal.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect } from "bun:test"
+import { describe, expect, afterAll, beforeAll } from "bun:test"
 import { Effect, Layer } from "effect"
 import fs from "node:fs"
+import os from "node:os"
 import path from "node:path"
 import { Config } from "@/config/config"
 import { Project } from "@/project/project"
@@ -21,6 +22,23 @@ import { MemoryModel } from "@/memory/model"
 import { ProviderTest } from "../fake/provider"
 import { provideInstance, testInstanceStoreLayer, tmpdirScoped } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
+
+// bun test runs all files in one process, sequentially, sharing one
+// XDG_CONFIG_HOME — a test file that runs before this one can leave an
+// enabled global memory.jsonc whose model this file's fake provider does not
+// know, turning the post-heal statusReason into a model-unavailable blocker.
+// Pin a private config dir per file so the global file can never be
+// contaminated by earlier files.
+const pinnedConfigDir = path.join(os.tmpdir(), `opencode-memory-selfheal-${process.pid}`)
+const previousConfigDir = process.env.OPENCODE_CONFIG_DIR
+beforeAll(() => {
+  fs.mkdirSync(pinnedConfigDir, { recursive: true })
+  process.env.OPENCODE_CONFIG_DIR = pinnedConfigDir
+})
+afterAll(() => {
+  if (previousConfigDir === undefined) delete process.env.OPENCODE_CONFIG_DIR
+  else process.env.OPENCODE_CONFIG_DIR = previousConfigDir
+})
 
 // #415: the /init stamp is written by a Command.Event.Executed listener that can
 // lose the race with the command itself, leaving time_initialized NULL forever.

--- a/packages/opencode/test/memory/memory-init-stamp-selfheal.test.ts
+++ b/packages/opencode/test/memory/memory-init-stamp-selfheal.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect } from "bun:test"
+import { Effect, Layer } from "effect"
+import fs from "node:fs"
+import path from "node:path"
+import { Config } from "@/config/config"
+import { Project } from "@/project/project"
+import { ProjectV2 } from "@opencode-ai/core/project"
+import { Database } from "@opencode-ai/core/database/database"
+import { FSUtil } from "@opencode-ai/core/fs-util"
+import { Git } from "@/git"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { EffectFlock } from "@opencode-ai/core/util/effect-flock"
+import { Memory } from "@/memory/memory"
+import { MemoryAdmission } from "@/memory/admission"
+import { MemoryConfig } from "@/memory/config"
+import { MemoryHome } from "@/memory/home"
+import { MemoryIdentityFence } from "@/memory/identity-fence"
+import { MemoryLock } from "@/memory/lock"
+import { MemoryStore } from "@/memory/store"
+import { MemoryModel } from "@/memory/model"
+import { ProviderTest } from "../fake/provider"
+import { provideInstance, testInstanceStoreLayer, tmpdirScoped } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+
+// #415: the /init stamp is written by a Command.Event.Executed listener that can
+// lose the race with the command itself, leaving time_initialized NULL forever.
+// The activation gate must self-heal: a project that already has the /init
+// artifact (non-empty AGENTS.md) passes without re-running /init, and a project
+// without it still reports the blocker — now with the DB row state attached.
+
+const emptyConfigLayer = Layer.mock(Config.Service, {
+  get: () => Effect.succeed({}),
+})
+
+const base = Layer.mergeAll(
+  emptyConfigLayer,
+  ProviderTest.fake().layer,
+  Project.defaultLayer,
+  Database.defaultLayer,
+  Git.defaultLayer,
+  FSUtil.defaultLayer,
+  EffectFlock.defaultLayer,
+  MemoryAdmission.defaultLayer,
+  MemoryConfig.defaultLayer,
+  MemoryHome.defaultLayer,
+  MemoryIdentityFence.defaultLayer,
+  MemoryLock.defaultLayer,
+  MemoryStore.defaultLayer,
+  Layer.mock(MemoryModel.Service, {
+    generate: () => Effect.die(new Error("model calls are not expected in self-heal tests")),
+  }),
+)
+
+// provideMerge builds `base` once, provides it to Memory.layer AND re-exposes its
+// services (Project/MemoryConfig/MemoryStore/...) to the test body.
+const layer = Layer.mergeAll(Memory.layer.pipe(Layer.provideMerge(base)), CrossSpawnSpawner.defaultLayer)
+
+const it = testEffect(layer)
+
+describe("memory /init stamp self-heal", () => {
+  it.live(
+    "statusReason stamps the project when AGENTS.md already exists",
+    () =>
+      Effect.gen(function* () {
+        const dir = yield* tmpdirScoped({ git: true })
+        yield* provideInstance(dir)(
+          Effect.gen(function* () {
+            const project = yield* Project.Service
+            const memory = yield* Memory.Service
+
+            const { project: info } = yield* project.fromDirectory(dir)
+            expect(info.id).not.toBe(ProjectV2.ID.global)
+            // The artifact /init produces: a non-empty AGENTS.md in the worktree.
+            fs.writeFileSync(path.join(info.worktree, "AGENTS.md"), "# project guide\n")
+
+            // Gate self-heals instead of reporting the blocker...
+            expect(yield* memory.statusReason()).toBeUndefined()
+            // ...and the stamp actually landed in the DB row.
+            const stamped = yield* project.get(info.id)
+            expect(stamped?.time.initialized).toBeDefined()
+          }),
+        ).pipe(Effect.provide(testInstanceStoreLayer))
+      }),
+    { timeout: 30_000 },
+  )
+
+  it.live(
+    "statusReason keeps blocking without AGENTS.md and reports the DB state",
+    () =>
+      Effect.gen(function* () {
+        const dir = yield* tmpdirScoped({ git: true })
+        yield* provideInstance(dir)(
+          Effect.gen(function* () {
+            const project = yield* Project.Service
+            const memory = yield* Memory.Service
+
+            const { project: info } = yield* project.fromDirectory(dir)
+            expect(info.id).not.toBe(ProjectV2.ID.global)
+
+            const reason = yield* memory.statusReason()
+            expect(reason).toContain("/init")
+            // #415 diagnostics: the blocker carries the actual row state so a
+            // stale identity (worktree pointing at a deleted clone) is visible.
+            expect(reason).toContain("time_initialized")
+            expect(reason).toContain(info.worktree)
+          }),
+        ).pipe(Effect.provide(testInstanceStoreLayer))
+      }),
+    { timeout: 30_000 },
+  )
+})

--- a/packages/opencode/test/tool/__snapshots__/parameters.test.ts.snap
+++ b/packages/opencode/test/tool/__snapshots__/parameters.test.ts.snap
@@ -485,7 +485,7 @@ exports[`tool parameters JSON Schema (wire shape) workflow 1`] = `
             },
             "workflow_id": {
               "description": "Target workflow ID",
-              "pattern": "^dag",
+              "pattern": "^dag.*$",
               "type": "string",
             },
           },
@@ -518,7 +518,7 @@ exports[`tool parameters JSON Schema (wire shape) workflow 1`] = `
             },
             "workflow_id": {
               "description": "Target workflow ID",
-              "pattern": "^dag",
+              "pattern": "^dag.*$",
               "type": "string",
             },
           },
@@ -552,7 +552,7 @@ exports[`tool parameters JSON Schema (wire shape) workflow 1`] = `
             },
             "workflow_id": {
               "description": "Target workflow ID",
-              "pattern": "^dag",
+              "pattern": "^dag.*$",
               "type": "string",
             },
           },
@@ -574,7 +574,7 @@ exports[`tool parameters JSON Schema (wire shape) workflow 1`] = `
             },
             "workflow_id": {
               "description": "Target workflow ID",
-              "pattern": "^dag",
+              "pattern": "^dag.*$",
               "type": "string",
             },
           },
@@ -609,7 +609,7 @@ exports[`tool parameters JSON Schema (wire shape) workflow 1`] = `
             },
             "workflow_id": {
               "description": "Target workflow ID",
-              "pattern": "^dag",
+              "pattern": "^dag.*$",
               "type": "string",
             },
           },

--- a/packages/schema/src/dag-event.ts
+++ b/packages/schema/src/dag-event.ts
@@ -17,7 +17,10 @@ import { Model } from "./model"
 // Branded IDs
 // ============================================================================
 
-export const DagID = Schema.String.check(Schema.isStartsWith("dag")).pipe(
+// Fully anchored pattern: llama.cpp's tool-schema conversion rejects any
+// `pattern` that doesn't start with '^' and end with '$'. `^dag.*$` keeps the
+// exact starts-with("dag") semantics of the previous isStartsWith filter.
+export const DagID = Schema.String.check(Schema.isPattern(/^dag.*$/)).pipe(
   Schema.brand("DagID"),
   withStatics((schema) => {
     const create = () => schema.make("dag_" + descending())

--- a/packages/schema/test/dag-id-pattern.test.ts
+++ b/packages/schema/test/dag-id-pattern.test.ts
@@ -1,0 +1,31 @@
+import { test, expect } from "bun:test"
+import { Schema } from "effect"
+import { DagEvent } from "../src/dag-event"
+
+// llama.cpp's OpenAI-compatible server rejects tool JSON Schemas whose `pattern`
+// is not anchored at both ends ("Pattern must start with '^' and end with '$'").
+// DagID flows into the workflow tool's workflow_id parameters, so every pattern
+// it serializes must carry both anchors while keeping starts-with("dag") semantics.
+const BOTH_ANCHORS = /^\^.*\$$/
+
+function patternsOf(node: unknown): string[] {
+  if (Array.isArray(node)) return node.flatMap(patternsOf)
+  if (typeof node !== "object" || node === null) return []
+  const record = node as Record<string, unknown>
+  const own = typeof record.pattern === "string" ? [record.pattern] : []
+  return [...own, ...Object.values(record).flatMap(patternsOf)]
+}
+
+test("DagID serializes to fully anchored JSON Schema patterns", () => {
+  const patterns = patternsOf(Schema.toJsonSchemaDocument(DagEvent.DagID))
+  expect(patterns.length).toBeGreaterThan(0)
+  for (const pattern of patterns) expect(pattern).toMatch(BOTH_ANCHORS)
+})
+
+test("DagID keeps starts-with validation semantics", () => {
+  const isDagID = Schema.is(DagEvent.DagID)
+  expect(isDagID("dag_000ffffffffffffff0000")).toBe(true)
+  expect(isDagID("dag_anything")).toBe(true)
+  expect(isDagID("ses_abc123")).toBe(false)
+  expect(isDagID("")).toBe(false)
+})


### PR DESCRIPTION
Closes #415

## Why
The `/init` stamp (`project.time_initialized`) is written only by a `Command.Event.Executed` listener (`packages/opencode/src/project/project.ts:418-424`). If the event is missed (subscription not yet established when `/init` runs), the stamp is never written and `/memory on` blocks with "run /init first" — re-running `/init` can lose the same race again. Real case: a project carried `time_initialized = NULL` forever; recovery required manual sqlite surgery.

## What changed
- `packages/opencode/src/memory/memory.ts` (`statusReason`): when the stamp is NULL but the worktree has a non-empty `AGENTS.md` (the durable artifact `/init` produces), heal the row via `setInitialized` instead of reporting the blocker. FSUtil is accessed through `Effect.serviceOption` so a missing wire degrades to no-heal, not a crash.
- The no-artifact blocker now carries the DB row state (`time_initialized=NULL, worktree=..., sandboxes=...`) so a stale identity (worktree pointing at a deleted clone) is visible at a glance.
- `packages/opencode/test/memory/memory-init-stamp-selfheal.test.ts`: both behaviors pinned (heal-on-artifact; blocker-with-diagnostics without artifact).

## Evidence
- New tests red before the fix, green after.
- `bun test test/memory/`: 104 pass (existing #350 statusReason tests unchanged — they use no AGENTS.md, still blocked with diagnostics).
- `bun typecheck` clean; `bun run test:dag-core` gate passed.

## Checklist
- [x] Root cause identified (listener race) and real-world case reproduced
- [x] Self-heal + diagnostics implemented with regression tests
- [x] Typecheck + memory suite + DAG core gate green locally
- [ ] CI gates green