### PR TITLE
Release train: llama.cpp tool-schema fix + memory /init self-heal + v1.0.31 series notes

### DIFF
--- a/.github/releases/v1.0.31.md
+++ b/.github/releases/v1.0.31.md
@@ -1,12 +1,13 @@
 ## opencode {VERSION}
 
-{Prerelease/Stable} release from `{branch}` branch. Tool JSON Schemas now use fully anchored patterns, so OpenAI-compatible backends with strict schema validation (llama.cpp server) accept tool-carrying requests instead of rejecting them.
+{Prerelease/Stable} release from `{branch}` branch. Tool JSON Schemas now use fully anchored patterns (llama.cpp-compatible) and the MEMORY `/init` gate self-heals from the AGENTS.md artifact instead of losing an event-listener race.
 
 ---
 
 ### 🐛 Bug Fixes
 
 - **DagID pattern only start-anchored, broke llama.cpp tool schema validation, #412 (PR #413)**: `DagID`'s `Schema.isStartsWith("dag")` filter serialized to `pattern: "^dag"` with only a start anchor. Backends that convert tool JSON Schemas to grammars (llama.cpp's OpenAI-compatible server) require `^...$` anchoring and rejected every request carrying the workflow tool with `JSON schema conversion failed: Pattern must start with '^' and end with '$'`. The filter is now `Schema.isPattern(/^dag.*$/)` with identical starts-with validation semantics.
+- **`/init` stamp lost to an event-listener race left MEMORY fail-closed, #415 (PR #416)**: `time_initialized` was written only by a `Command.Event.Executed` listener that can lose the race with `/init` itself; re-running `/init` hits the same race. The activation gate now self-heals: a NULL stamp plus a non-empty AGENTS.md (the durable `/init` artifact) stamps the row directly, and the no-artifact blocker carries the DB row state (`time_initialized=NULL, worktree=..., sandboxes=...`) so stale identities are visible at a glance.
 
 ---
 
@@ -28,6 +29,7 @@ SpecGit Acceptance:  pass
 - Regression pinned by `packages/schema/test/dag-id-pattern.test.ts`: every serialized pattern must match `^.*$` both-anchored form, and DagID still accepts any `dag`-prefixed string while rejecting others.
 - Workflow tool wire-shape snapshots updated (`^dag` to `^dag.*$`, 5 occurrences).
 - End-to-end: streaming chat completion against a real llama.cpp server (192.168.33.110:8081) with a `^dag.*$` tool pattern accepted (previously 400); delivered through the specgit harness with an accepted verdict on PR #413.
+- Self-heal pinned by `packages/opencode/test/memory/memory-init-stamp-selfheal.test.ts`: heal-on-artifact and blocker-with-diagnostics arms, red before the fix; delivered through the specgit harness with an accepted verdict on PR #416.
 
 ---
 


### PR DESCRIPTION
Closes #412
Closes #415

## Why
Promote the v1.0.31 stable train to main: fully anchored DagID tool-schema pattern (llama.cpp compatibility, #412 / PR #413), MEMORY /init-stamp self-heal with gate diagnostics (#415 / PR #416), and the v1.0.31 series notes.

## Checklist
- [x] dev synced with main (PR #417 back-merge after #416 landed on main directly)
- [x] Series notes updated for both fixes (PR #414, PR #418)
- [ ] 5 gates green, then release-fork from main