### PR TITLE
fix: worker config on workflow blocks

### DIFF
--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -1,8 +1,7 @@
 version: 1
 delivery: worker-config-on
 context:
-  kind: worktree
-  label: opencode-dag-dx
+  kind: branch
   branch: fix/425-worker-config-on
 issues:
   - 425

--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -6,3 +6,4 @@ context:
   branch: fix/425-worker-config-on
 issues:
   - 425
+pr: 426

--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -1,8 +1,8 @@
 version: 1
-delivery: init-stamp-is
+delivery: worker-config-on
 context:
-  kind: branch
-  branch: fix/415-init-stamp-is
+  kind: worktree
+  label: opencode-dag-dx
+  branch: fix/425-worker-config-on
 issues:
-  - 415
-pr: 416
+  - 425

--- a/packages/core/src/plugin/command/workflow-blocks.md
+++ b/packages/core/src/plugin/command/workflow-blocks.md
@@ -84,10 +84,13 @@ fragment:
 ```
 
 Every block accepts only `id`, `kind`, `depends_on`, `instruction`,
-`worker_type`, `required`, and `report_to_parent`. `id` and `kind` are required.
-Allowed `kind` values are `explore`, `plan`, `prototype`, `debug`, `coding`,
-`verify`, `review`, and `synthesize`. Omit `worker_type` unless the exact
-configured agent name is already known; never invent one.
+`worker_type`, `worker_config`, `required`, and `report_to_parent`. `id` and
+`kind` are required. Allowed `kind` values are `explore`, `plan`, `prototype`,
+`debug`, `coding`, `verify`, `review`, and `synthesize`. Omit `worker_type`
+unless the exact configured agent name is already known; never invent one. An
+optional block-level `worker_config` accepts only `timeout_ms` and applies to
+every node the block expands into; it overrides `node_defaults.worker_config`
+for that block.
 
 For optional `node_defaults`, the only fields are `required`,
 `report_to_parent`, and `worker_config`; `worker_config` accepts only

--- a/packages/core/src/plugin/command/workflow-routing.md
+++ b/packages/core/src/plugin/command/workflow-routing.md
@@ -105,8 +105,8 @@ config:
 
 Top level is `title`/`mode`/`admission` (optional) and `config` (required);
 `objective` lives INSIDE `config`; every block field is one of `id` (required),
-`kind` (required), `depends_on`, `instruction`, `worker_type`, `required`,
-`report_to_parent` — never `worker`, `prompt`, or `agent`.
+`kind` (required), `depends_on`, `instruction`, `worker_type`, `worker_config`,
+`required`, `report_to_parent` — never `worker`, `prompt`, or `agent`.
 
 A `report_to_parent` node with dependents is a reporting checkpoint: gate each
 dependent on its output via `condition`, keep it a reporting leaf, or drop

--- a/packages/core/test/plugin/command.test.ts
+++ b/packages/core/test/plugin/command.test.ts
@@ -203,7 +203,10 @@ describe("CommandPlugin.Plugin", () => {
       expect(CommandPlugin.WorkflowBlocksContent).toContain("### Extend file")
       expect(CommandPlugin.WorkflowBlocksContent).toContain("### Replan file")
       expect(CommandPlugin.WorkflowBlocksContent).toMatch(
-        /`id`, `kind`, `depends_on`, `instruction`,\s+`worker_type`, `required`, and `report_to_parent`/,
+        /`id`, `kind`, `depends_on`, `instruction`,\s+`worker_type`, `worker_config`, `required`, and `report_to_parent`/,
+      )
+      expect(CommandPlugin.WorkflowBlocksContent).toContain(
+        "overrides `node_defaults.worker_config`",
       )
       expect(CommandPlugin.WorkflowBlocksContent).toMatch(
         /`action`, `workflow_id`, `operation`, and `spec_path` are tool-call fields/,

--- a/packages/opencode/src/dag/blocks.ts
+++ b/packages/opencode/src/dag/blocks.ts
@@ -31,6 +31,13 @@ export class WorkflowBlock extends Schema.Class<WorkflowBlock>("WorkflowBlock")(
   worker_type: Schema.optional(Schema.String).annotate({
     description: "Optional configured agent override; defaults from the block kind",
   }),
+  worker_config: Schema.optional(
+    Schema.Struct({
+      timeout_ms: Schema.Number,
+    }),
+  ).annotate({
+    description: "{ timeout_ms } — bounds node execution; overrides config.node_defaults.worker_config",
+  }),
   required: Schema.optional(Schema.Boolean).annotate({
     description:
       "Whether failure is terminal. Decision and verification blocks default to true; volume blocks to false",
@@ -160,6 +167,7 @@ function compileBlock(
           "Reproduce or characterize the failure read-only where possible. Capture exact symptoms, commands, logs, boundaries, and the smallest falsifiable observations. Do not patch the code.",
         required: false,
         reportToParent: false,
+        workerConfig: block.worker_config,
         condition,
       }),
       node({
@@ -172,6 +180,7 @@ function compileBlock(
         contract: BLOCK_CONTRACTS.debug,
         required: block.required ?? true,
         reportToParent: block.report_to_parent ?? false,
+        workerConfig: block.worker_config,
       }),
     ]
   }
@@ -201,6 +210,7 @@ function compileBlock(
         contract: `${BLOCK_CONTRACTS.review} Focus on documented repository standards, architecture constraints, correctness, and verification evidence.`,
         required: false,
         reportToParent: false,
+        workerConfig: block.worker_config,
         condition: reviewCondition,
         inputMapping: reviewEvidence,
       }),
@@ -214,6 +224,7 @@ function compileBlock(
         contract: `${BLOCK_CONTRACTS.review} Focus on the confirmed goal, scope, acceptance criteria, and user-visible behavior.`,
         required: false,
         reportToParent: false,
+        workerConfig: block.worker_config,
         condition: reviewCondition,
         inputMapping: reviewEvidence,
       }),
@@ -233,6 +244,7 @@ function compileBlock(
         ].join(" "),
         required: block.required ?? true,
         reportToParent: block.report_to_parent ?? true,
+        workerConfig: block.worker_config,
         condition: reviewCondition,
         inputMapping: route
           ? {
@@ -262,6 +274,7 @@ function compileBlock(
         contract: AGGREGATOR_CONTRACT,
         required: true,
         reportToParent: false,
+        workerConfig: block.worker_config,
         inputMapping: aggregatorEvidenceMapping(aggregation.writerIDs),
         outputSchema: IMPLEMENTATION_SCHEMA,
       }),
@@ -301,6 +314,7 @@ function compileBlock(
       contract: BLOCK_CONTRACTS[block.kind],
       required,
       reportToParent: block.report_to_parent ?? block.kind === "synthesize",
+      workerConfig: block.worker_config,
       condition,
       inputMapping: verifyAggregator
         ? {
@@ -327,6 +341,7 @@ function node(input: {
   contract: string
   required: boolean
   reportToParent: boolean
+  workerConfig?: { timeout_ms: number }
   condition?: string
   inputMapping?: Record<string, string>
   review?: NodeConfig["review"]
@@ -371,6 +386,7 @@ function node(input: {
         ...(hasInstruction ? { instruction: instructionText } : {}),
       },
     },
+    ...(input.workerConfig ? { worker_config: input.workerConfig } : {}),
     ...(input.condition ? { condition: input.condition } : {}),
     ...(input.inputMapping ? { input_mapping: input.inputMapping } : {}),
     ...(input.review ? { review: input.review } : {}),
@@ -499,6 +515,7 @@ function aggregateParallelWriters(blocks: WorkflowBlock[]) {
       depends_on: replaced,
       instruction: block.instruction,
       worker_type: block.worker_type,
+      worker_config: block.worker_config,
       required: block.required,
       report_to_parent: block.report_to_parent,
     })

--- a/packages/opencode/src/dag/validation.ts
+++ b/packages/opencode/src/dag/validation.ts
@@ -354,6 +354,9 @@ const FIELD_DRIFT_HINTS: Record<string, string> = {
   worker: "worker_type",
   workers: "worker_type",
   agent: "worker_type",
+  timeout: "worker_config: { timeout_ms }",
+  timeouts: "worker_config: { timeout_ms }",
+  timeout_ms: "worker_config: { timeout_ms }",
   prompt: "instruction",
   task: "instruction",
   objective: "config.objective",
@@ -366,7 +369,7 @@ const FIELD_DRIFT_HINTS: Record<string, string> = {
 function driftHint(path: string, message: string) {
   for (const [wrong, right] of Object.entries(FIELD_DRIFT_HINTS)) {
     if (message.includes(`"${wrong}"`) || path.includes(`["${wrong}"]`)) {
-      return `Did you mean "${right}"? Every block field is one of id, kind, depends_on, instruction, worker_type, required, report_to_parent; objective lives inside config`
+      return `Did you mean "${right}"? Every block field is one of id, kind, depends_on, instruction, worker_type, worker_config, required, report_to_parent; objective lives inside config`
     }
   }
   return "Fix the field shape; blocks graphs need name+objective+blocks, nodes graphs need name+nodes"

--- a/packages/opencode/src/tool/workflow.ts
+++ b/packages/opencode/src/tool/workflow.ts
@@ -120,7 +120,7 @@ const Draft = Schema.Struct({
   title: Schema.optional(Schema.String).annotate({ description: "Optional workflow title" }),
   config: DagValidation.WorkflowGraphSchema.annotate({
     description:
-      'Exactly one graph shape: { name, objective, blocks: [{ id, kind, depends_on?, instruction?, worker_type?, required?, report_to_parent? }], node_defaults?, max_concurrency?, max_node_replan_attempts?, max_total_nodes? } or the low-level { name, nodes: [...] } form. Fields are exhaustive — no others exist',
+      'Exactly one graph shape: { name, objective, blocks: [{ id, kind, depends_on?, instruction?, worker_type?, worker_config?, required?, report_to_parent? }], node_defaults?, max_concurrency?, max_node_replan_attempts?, max_total_nodes? } or the low-level { name, nodes: [...] } form. A block-level worker_config { timeout_ms } overrides node_defaults.worker_config for that block. Fields are exhaustive — no others exist',
   }),
 })
 const ValidationProfile = Schema.optional(Schema.Literals(["portable", "environment"])).annotate({

--- a/packages/opencode/test/dag/blocks.test.ts
+++ b/packages/opencode/test/dag/blocks.test.ts
@@ -285,6 +285,45 @@ describe("workflow blocks", () => {
     expect(runtime.isComplete()).toBe(true)
   })
 
+  // issue #425: block-level worker_config must reach every node the block
+  // expands into — including the injected aggregator and the verify block
+  // rebuilt by parallel-writer rewiring — while blocks that omit it stay
+  // untouched for node_defaults to fill in.
+  it("threads block-level worker_config onto every expanded node", () => {
+    const nodes = DagBlocks.compileWorkflowBlocks({
+      objective: "Bound each block individually",
+      blocks: [
+        { id: "impl-a", kind: "coding" },
+        { id: "impl-b", kind: "prototype" },
+        {
+          id: "impl-verify",
+          kind: "verify",
+          depends_on: ["impl-a", "impl-b"],
+          worker_config: { timeout_ms: 4321 },
+        },
+        { id: "gate", kind: "review", depends_on: ["impl-verify"], worker_config: { timeout_ms: 4321 } },
+        { id: "diag", kind: "debug", depends_on: ["gate"], worker_config: { timeout_ms: 4321 } },
+        { id: "map", kind: "explore", depends_on: ["gate"], worker_config: { timeout_ms: 4321 } },
+      ],
+    })
+
+    expect(Object.fromEntries(nodes.map((node) => [node.id, node.worker_config]))).toEqual({
+      "impl-a": undefined,
+      "impl-b": undefined,
+      "impl-verify": { timeout_ms: 4321 },
+      "gate--aggregate": { timeout_ms: 4321 },
+      "gate--standards": { timeout_ms: 4321 },
+      "gate--intent": { timeout_ms: 4321 },
+      gate: { timeout_ms: 4321 },
+      "diag--evidence": { timeout_ms: 4321 },
+      diag: { timeout_ms: 4321 },
+      map: { timeout_ms: 4321 },
+    })
+    // The rewired verify block keeps its own timeout while its dependencies
+    // move onto the injected aggregator.
+    expect(nodes.find((node) => node.id === "impl-verify")?.depends_on).toEqual(["gate--aggregate"])
+  })
+
   it("rejects an implementation review without one verification gate", () => {
     expect(() =>
       DagBlocks.compileWorkflowBlocks({

--- a/packages/opencode/test/dag/workflow-authoring.test.ts
+++ b/packages/opencode/test/dag/workflow-authoring.test.ts
@@ -49,6 +49,53 @@ describe("WorkflowAuthoring source-to-graph seam", () => {
     }),
   )
 
+  // issue #425: bare timeout vocabulary at block level must point at the
+  // worker_config wrapper instead of the generic fallback.
+  it.effect("hints bare block-level timeout fields toward worker_config", () =>
+    Effect.gen(function* () {
+      const authoring = WorkflowAuthoring.make()
+      for (const wrong of ["timeout: 100", "timeout_ms: 100"]) {
+        const result = yield* authoring.prepare({
+          action: "start",
+          source: {
+            kind: "yaml",
+            source: "drift.yaml",
+            content: ["config:", "  name: drift", "  objective: Timeout drift probe.", "  blocks:", "    - id: a", "      kind: coding", `      ${wrong}`].join("\n"),
+          },
+          profile: "portable",
+        })
+        expect(result.valid).toBe(false)
+        expect(result.errors.some((e) => e.hint.includes('Did you mean "worker_config: { timeout_ms }"?'))).toBe(true)
+      }
+    }),
+  )
+
+  it.effect("keeps block worker_config strict — unknown nested keys stay rejected", () =>
+    Effect.gen(function* () {
+      const authoring = WorkflowAuthoring.make()
+      const result = yield* authoring.prepare({
+        action: "start",
+        source: {
+          kind: "yaml",
+          source: "strict.yaml",
+          content: [
+            "config:",
+            "  name: strict",
+            "  objective: Strictness probe.",
+            "  blocks:",
+            "    - id: a",
+            "      kind: coding",
+            "      worker_config:",
+            "        foo: 1",
+          ].join("\n"),
+        },
+        profile: "portable",
+      })
+      expect(result.valid).toBe(false)
+      expect(result.errors.some((e) => e.code === DagValidation.DIAGNOSTIC_CODES.schemaInvalid)).toBe(true)
+    }),
+  )
+
   it.effect("keeps every block-guide YAML envelope executable", () =>
     Effect.gen(function* () {
       const guide = CommandPlugin.WorkflowBlocksContent

--- a/packages/opencode/test/dag/workflow-tool.test.ts
+++ b/packages/opencode/test/dag/workflow-tool.test.ts
@@ -652,7 +652,7 @@ describe("workflow tool schema (negative tests)", () => {
         name: "structured-draft",
         objective: "Validate the draft rendering path.",
         blocks: [
-          { id: "map", kind: "explore", instruction: "Map the seams." },
+          { id: "map", kind: "explore", instruction: "Map the seams.", worker_config: { timeout_ms: 4321 } },
           { id: "review", kind: "review", depends_on: ["map"] },
         ],
       },
@@ -661,6 +661,12 @@ describe("workflow tool schema (negative tests)", () => {
     // The high-frequency drift shapes die at the schema boundary.
     expect(() =>
       decode({ params: { action: "draft", config: { ...draft.config, blocks: [{ id: "x", kind: "coding", worker: "general" }] } } }),
+    ).toThrow()
+    expect(() =>
+      decode({ params: { action: "draft", config: { ...draft.config, blocks: [{ id: "x", kind: "coding", worker_timeout: 5000 }] } } }),
+    ).toThrow()
+    expect(() =>
+      decode({ params: { action: "draft", config: { ...draft.config, blocks: [{ id: "x", kind: "coding", worker_config: { foo: 1 } }] } } }),
     ).toThrow()
     expect(() => decode({ params: { action: "draft", objective: "top level" } })).toThrow()
     expect(() => decode({ params: { action: "draft" } })).toThrow()
@@ -2009,6 +2015,59 @@ config:
           worker_config: { timeout_ms: 4321 },
         }),
       )
+    }),
+  )
+
+  // issue #425: block-level worker_config rides through compilation onto the
+  // expanded nodes and beats node_defaults; omitted blocks still inherit.
+  runtime.effect("start resolves block worker_config over node_defaults", () =>
+    Effect.gen(function* () {
+      published.length = 0
+      const info = yield* WorkflowTool
+      const workflow = yield* info.init()
+      const specPath = yield* writeWorkflowSpec("block-worker-config", {
+        config: {
+          name: "block-worker-config",
+          objective: "Bound each block individually.",
+          node_defaults: {
+            worker_config: { timeout_ms: 1234 },
+          },
+          blocks: [
+            { id: "override", kind: "coding", worker_config: { timeout_ms: 4321 } },
+            { id: "inherit", kind: "verify", depends_on: ["override"] },
+            { id: "diag", kind: "debug", depends_on: ["inherit"], worker_config: { timeout_ms: 4321 } },
+          ],
+        },
+      })
+
+      yield* workflow.execute(
+        { params: {
+          action: "start",
+          spec_path: specPath,
+        }},
+        {
+          sessionID: SessionID.make("ses_workflow_parent"),
+          messageID: MessageID.ascending(),
+          agent: "build",
+          abort: new AbortController().signal,
+          messages: [],
+          metadata: () => Effect.void,
+          ask: () => Effect.void,
+        } satisfies Tool.Context,
+      )
+
+      const created = published.find((event) => event.type === DagEvent.WorkflowCreated.type)?.data
+      const configJSON =
+        typeof created === "object" && created !== null && "config" in created && typeof created.config === "string"
+          ? created.config
+          : "{}"
+      const nodes: Array<{ id: string; worker_config?: { timeout_ms?: number } }> = JSON.parse(configJSON).nodes ?? []
+      expect(Object.fromEntries(nodes.map((node) => [node.id, node.worker_config?.timeout_ms]))).toEqual({
+        override: 4321,
+        inherit: 1234,
+        "diag--evidence": 4321,
+        diag: 4321,
+      })
     }),
   )
 

--- a/packages/opencode/test/tool/__snapshots__/parameters.test.ts.snap
+++ b/packages/opencode/test/tool/__snapshots__/parameters.test.ts.snap
@@ -734,6 +734,18 @@ exports[`tool parameters JSON Schema (wire shape) workflow 1`] = `
                             "description": "Whether failure is terminal. Decision and verification blocks default to true; volume blocks to false",
                             "type": "boolean",
                           },
+                          "worker_config": {
+                            "description": "{ timeout_ms } — bounds node execution; overrides config.node_defaults.worker_config",
+                            "properties": {
+                              "timeout_ms": {
+                                "type": "number",
+                              },
+                            },
+                            "required": [
+                              "timeout_ms",
+                            ],
+                            "type": "object",
+                          },
                           "worker_type": {
                             "description": "Optional configured agent override; defaults from the block kind",
                             "type": "string",
@@ -973,7 +985,7 @@ exports[`tool parameters JSON Schema (wire shape) workflow 1`] = `
                   "type": "object",
                 },
               ],
-              "description": "Exactly one graph shape: { name, objective, blocks: [{ id, kind, depends_on?, instruction?, worker_type?, required?, report_to_parent? }], node_defaults?, max_concurrency?, max_node_replan_attempts?, max_total_nodes? } or the low-level { name, nodes: [...] } form. Fields are exhaustive — no others exist",
+              "description": "Exactly one graph shape: { name, objective, blocks: [{ id, kind, depends_on?, instruction?, worker_type?, worker_config?, required?, report_to_parent? }], node_defaults?, max_concurrency?, max_node_replan_attempts?, max_total_nodes? } or the low-level { name, nodes: [...] } form. A block-level worker_config { timeout_ms } overrides node_defaults.worker_config for that block. Fields are exhaustive — no others exist",
             },
             "title": {
               "description": "Optional workflow title",


### PR DESCRIPTION
Closes #425

## Why
模型在用 workflow 工具组合 blocks 图时因 schema 词汇不对称误传块级 `worker_config` 被 fail-closed 拒绝。按用户决策显式接受该字段（B）并补齐诊断与文档（A'）。

## What changed
- WorkflowBlock 可选 `worker_config { timeout_ms }`，编译映射进节点且覆盖 node_defaults
- FIELD_DRIFT_HINTS 覆盖裸 timeout/timeouts/timeout_ms；字段清单文案更新
- draft 描述与 guide(blocks) 文档同步；严格未知键拒绝保持不变

## Evidence
- dx-verify 门禁 PASS @ fix/425-worker-config-on @ 9854ec3c74（typecheck / 定向 dag 测试 / dag-core / lint 棘轮 / 文案一致性 grep）
- 提交时 pre-commit 全仓 turbo typecheck 29/29

## Checklist
- [x] Why, What changed, and Evidence are filled in.
- [ ] `specgit finish` exits 0.