### PR TITLE
docs: add v1.0.32 release series notes

### DIFF
--- a/.github/releases/v1.0.32.md
+++ b/.github/releases/v1.0.32.md
@@ -1,0 +1,39 @@
+## opencode {VERSION}
+
+{Prerelease/Stable} release from `{branch}` branch. Security remediation sweep (four dependency upgrades, seven CodeQL fixes), block-level `worker_config` for workflow composition, a /dag inspector resilience fix, heuristic todo reminders before non-todo tool calls, and shell discipline embedded into DAG block contracts.
+
+---
+
+### ✨ Features
+
+- **Block-level `worker_config`, #425 (PR #426)**: workflow blocks accept an optional `worker_config { timeout_ms }` that compiles into every expanded node and overrides `node_defaults.worker_config`; drift hints now cover bare `timeout`/`timeout_ms` and the draft schema description plus guide(blocks) document the capability while strict unknown-key parsing stays fail-closed.
+- **Todo state surfaced before non-todowrite tool calls, #429 (PR #430)**: extends the issue-#389 per-step reminder with the pre-tool-call seam — once per assistant turn the uncompleted list is prepended to tool results across both PreToolUse sites; todowrite itself never injects nor consumes the turn shot, and a missing/failing Todo service degrades to no-reminder instead of killing execution.
+- **Shell discipline in DAG block contracts, #431 (PR #432)**: a shared `SHELL_DISCIPLINE` sentence is appended to the explore/debug/coding/verify contracts from one source of truth, so curated templates and ad-hoc drafts alike bound long commands with `timeout <seconds>` and stream progress instead of piping into silent buffers; shell abort metadata now names both interrupt origins rather than blaming the user.
+
+### 🐛 Bug Fixes
+
+- **Open security alerts remediated, #423 (PR #424)**: dompurify 3.4.13 (ui/session-ui + root catalog), astro 7.1.0 with its ecosystem majors, nitro 3.0.260429-beta across four apps, @hey-api/openapi-ts 0.97.3 with SDK regeneration; CodeQL fixes cover the user-attachments SSRF prefix check (#65), OAuth error-page escaping (#61), rejection-sampling PKCE verifiers (#48/#70/#71), polynomial-ReDoS bounds in provider-error and linear data-URL parsing in acp/tool (#55), and least-privilege permissions on ci-typecheck (#77). Regenerated client types cascade-adapted in httpapi-sdk test, terminal, server-session, and dialog-connect-provider.
+- **Empty /dag pane under concurrent workflows, #427 (PR #428)**: the inspector's mount-time summary request now races a 15s timeout with one retry before surfacing "Unable to load workflows", and opening without session context renders explicit guidance instead of a misleading "No workflows" state; pinned by harness tests at the component seam.
+
+---
+
+### 🧪 Test Summary
+
+```
+CI gates on main at merge of all five deliveries:
+Typecheck:           pass
+Unit Tests (linux):  pass
+E2E Tests (linux):   pass
+E2E Tests (windows): pass
+SpecGit Acceptance:  pass
+```
+
+---
+
+### 🔍 Verification
+
+- Each delivery carried its own accepted SpecGit verdict: PR #424 (frozen-lockfile, dag-core floors, acceptance tests, lint ratchet 4839≤4850, SDK freshness zero-diff), PR #426 (block compilation precedence tests, authoring-contract snapshot updated), PR #428 (component-seam tests: retry spy reaches second attempt, guidance copy renders with zero network calls), PR #430 (14/14 todo-reminders suite; the snapshot-race gate caught the missing-Todo.Service kill-path, fixed by degrading to no-reminder), PR #432 (contract wording assertions updated, cancel-timing suites green solo and combined).
+
+---
+
+**Full changelog:** [`{previous_tag}`...`{current_tag}`](https://github.com/LeXwDeX/OpenCode-GraphAgent/compare/{previous_tag}...{current_tag})


### PR DESCRIPTION
Adds the fail-closed series file required by release-notes.ts for graphagent-v1.0.32. Content summarizes the five merged deliveries (#424 #426 #428 #430 #432). Required so the release job can render notes; no code changes.