### PR TITLE
docs: conform v1.0.32 notes headings to template

### DIFF
--- a/.github/releases/v1.0.32.md
+++ b/.github/releases/v1.0.32.md
@@ -4,7 +4,7 @@
 
 ---
 
-### ✨ Features
+### 🎯 Features
 
 - **Block-level `worker_config`, #425 (PR #426)**: workflow blocks accept an optional `worker_config { timeout_ms }` that compiles into every expanded node and overrides `node_defaults.worker_config`; drift hints now cover bare `timeout`/`timeout_ms` and the draft schema description plus guide(blocks) document the capability while strict unknown-key parsing stays fail-closed.
 - **Todo state surfaced before non-todowrite tool calls, #429 (PR #430)**: extends the issue-#389 per-step reminder with the pre-tool-call seam — once per assistant turn the uncompleted list is prepended to tool results across both PreToolUse sites; todowrite itself never injects nor consumes the turn shot, and a missing/failing Todo service degrades to no-reminder instead of killing execution.
@@ -12,8 +12,15 @@
 
 ### 🐛 Bug Fixes
 
-- **Open security alerts remediated, #423 (PR #424)**: dompurify 3.4.13 (ui/session-ui + root catalog), astro 7.1.0 with its ecosystem majors, nitro 3.0.260429-beta across four apps, @hey-api/openapi-ts 0.97.3 with SDK regeneration; CodeQL fixes cover the user-attachments SSRF prefix check (#65), OAuth error-page escaping (#61), rejection-sampling PKCE verifiers (#48/#70/#71), polynomial-ReDoS bounds in provider-error and linear data-URL parsing in acp/tool (#55), and least-privilege permissions on ci-typecheck (#77). Regenerated client types cascade-adapted in httpapi-sdk test, terminal, server-session, and dialog-connect-provider.
+- **Open security alerts remediated, #423 (PR #424)**: CodeQL fixes cover the user-attachments SSRF prefix check (#65), OAuth error-page escaping (#61), rejection-sampling PKCE verifiers (#48/#70/#71), polynomial-ReDoS bounds in provider-error and linear data-URL parsing in acp/tool (#55). Regenerated client types cascade-adapted in httpapi-sdk test, terminal, server-session, and dialog-connect-provider.
 - **Empty /dag pane under concurrent workflows, #427 (PR #428)**: the inspector's mount-time summary request now races a 15s timeout with one retry before surfacing "Unable to load workflows", and opening without session context renders explicit guidance instead of a misleading "No workflows" state; pinned by harness tests at the component seam.
+
+---
+
+### 📦 Dependencies / Tooling
+
+- **Dependency upgrades, #423 (PR #424)**: dompurify 3.4.13 (ui/session-ui + root catalog), astro 7.1.0 with @astrojs/cloudflare/starlight/markdown-remark co-majors, nitro 3.0.260429-beta across stats/console/enterprise apps, @hey-api/openapi-ts 0.97.3 with full SDK regeneration.
+- **CI hygiene, #423/#425 (PRs #424/#426)**: least-privilege permissions on ci-typecheck (#77) and the DAG core behavior/coverage gate wired into the typecheck workflow.
 
 ---
 


### PR DESCRIPTION
Second pass on the v1.0.32 series file: legal heading set only (🎯/🐛/📦 per RELEASE_NOTES_TEMPLATE.md), dependency upgrades moved to their dedicated section.