### PR TITLE
docs: fix v1.0.32 notes block separators and ASCII-only body

### DIFF
--- a/.github/releases/v1.0.32.md
+++ b/.github/releases/v1.0.32.md
@@ -6,9 +6,11 @@
 
 ### 🎯 Features
 
-- **Block-level `worker_config`, #425 (PR #426)**: workflow blocks accept an optional `worker_config { timeout_ms }` that compiles into every expanded node and overrides `node_defaults.worker_config`; drift hints now cover bare `timeout`/`timeout_ms` and the draft schema description plus guide(blocks) document the capability while strict unknown-key parsing stays fail-closed.
-- **Todo state surfaced before non-todowrite tool calls, #429 (PR #430)**: extends the issue-#389 per-step reminder with the pre-tool-call seam — once per assistant turn the uncompleted list is prepended to tool results across both PreToolUse sites; todowrite itself never injects nor consumes the turn shot, and a missing/failing Todo service degrades to no-reminder instead of killing execution.
+- **Block-level `worker_config`, #425 (PR #426)**: workflow blocks accept an optional `worker_config` with a `timeout_ms` field that compiles into every expanded node and overrides `node_defaults.worker_config`; drift hints now cover bare `timeout`/`timeout_ms` and the draft schema description plus guide(blocks) document the capability while strict unknown-key parsing stays fail-closed.
+- **Todo state surfaced before non-todowrite tool calls, #429 (PR #430)**: extends the issue-#389 per-step reminder with the pre-tool-call seam  -  once per assistant turn the uncompleted list is prepended to tool results across both PreToolUse sites; todowrite itself never injects nor consumes the turn shot, and a missing/failing Todo service degrades to no-reminder instead of killing execution.
 - **Shell discipline in DAG block contracts, #431 (PR #432)**: a shared `SHELL_DISCIPLINE` sentence is appended to the explore/debug/coding/verify contracts from one source of truth, so curated templates and ad-hoc drafts alike bound long commands with `timeout <seconds>` and stream progress instead of piping into silent buffers; shell abort metadata now names both interrupt origins rather than blaming the user.
+
+---
 
 ### 🐛 Bug Fixes
 
@@ -39,7 +41,7 @@ SpecGit Acceptance:  pass
 
 ### 🔍 Verification
 
-- Each delivery carried its own accepted SpecGit verdict: PR #424 (frozen-lockfile, dag-core floors, acceptance tests, lint ratchet 4839≤4850, SDK freshness zero-diff), PR #426 (block compilation precedence tests, authoring-contract snapshot updated), PR #428 (component-seam tests: retry spy reaches second attempt, guidance copy renders with zero network calls), PR #430 (14/14 todo-reminders suite; the snapshot-race gate caught the missing-Todo.Service kill-path, fixed by degrading to no-reminder), PR #432 (contract wording assertions updated, cancel-timing suites green solo and combined).
+- Each delivery carried its own accepted SpecGit verdict: PR #424 (frozen-lockfile, dag-core floors, acceptance tests, lint ratchet 4839<=4850, SDK freshness zero-diff), PR #426 (block compilation precedence tests, authoring-contract snapshot updated), PR #428 (component-seam tests: retry spy reaches second attempt, guidance copy renders with zero network calls), PR #430 (14/14 todo-reminders suite; the snapshot-race gate caught the missing-Todo.Service kill-path, fixed by degrading to no-reminder), PR #432 (contract wording assertions updated, cancel-timing suites green solo and combined).
 
 ---
 


### PR DESCRIPTION
Third pass: block separator between Features and Bug Fixes, placeholder-free braces, ASCII-only body per release-notes invariants; verified by a local dry-run render with release-notes.ts.