### PR TITLE
docs: add v1.0.33 release notes

### DIFF
--- a/.github/releases/v1.0.33.md
+++ b/.github/releases/v1.0.33.md
@@ -1,0 +1,46 @@
+## opencode {VERSION}
+
+Stable release from `main` branch. Batch closure of every remaining open security and CI issue: SSRF-hardened attachment downloads, library-modeled HTML escaping across all OAuth error pages, a submit_result reliability nudge for review-aggregate workflow nodes, and the dev lineage re-synced with main so SpecGit Acceptance runs green end to end.
+
+---
+
+### 🐛 Bug Fixes
+
+- **submit_result reliability for review-aggregate nodes, #436 (PR #444)**: children that produced their whole review in prose but never called submit_result killed the node and its work; the output contract now states up front that message text does not count as submitting and that a missing submission fails the node, and spawn grants exactly one same-session nudge turn to hand back the already-completed result before settling - captured-but-invalid payloads stay non-retried since that is a deterministic contract violation.
+- **Attachment download fetched the raw markdown URL, #442 (PR #444)**: the token-bearing request now targets only the validated URL object, with the https/github.com/user-attachments guard extracted into a unit-tested `isAllowedAttachmentUrl` predicate; closes CodeQL js/request-forgery alert #65 at the next default-branch scan.
+- **OAuth error pages escaped through an unmodeled sanitizer, #443 (PR #444)**: the hand-rolled replaceAll chain in `util/html` was correct but invisible to CodeQL, keeping js/reflected-xss alerts #60/#61/#62 open after the real fix landed; escapeHtml now delegates to the escape-html package (identical output, modeled sanitizer), covering xai, codex, snowflake cortex, and mcp/oauth-callback pages.
+
+---
+
+### ⚙️ CI / Engineering
+
+- **dev-lineage SpecGit Acceptance unblocked, #434 (PRs #444/#445)**: dev carried the old local `npm install --no-save` acceptance step that dies on bun catalog protocol deps; syncing main's global-install template through the promotion PR let the first binding-free dev-to-main verdict pass (11m23s), re-opening the standard promotion path.
+- **Secret-scanning fixture assembled, not literal, #440 (PR #444)**: the http-recorder redaction test now builds its Google-key-shaped sample from concatenated literals so the repo never contains a plausible live-format key blob.
+
+---
+
+### 🧪 Test Summary
+
+```
+CI gates on main at promotion merge (#445):
+Typecheck:           pass
+Unit Tests (linux):  pass
+E2E Tests (linux):   pass
+E2E Tests (windows): pass
+SpecGit Acceptance:  pass
+dag-core gate:       52 pass
+dag suite:           622 pass / 53 files
+lint ratchet:        4811 <= 4850
+```
+
+---
+
+### 🔍 Verification
+
+- PR #444 carried its own accepted SpecGit verdict into dev (8/8 checks including two anchor-race reruns of the required jobs), then PR #445 re-ran the full main gate on the merged tree.
+- CodeQL alerts #60/#61/#62/#65 are expected to auto-close on the post-promotion default-branch analysis; secret-scanning alert #1 resolves as used_in_tests pending owner confirmation that no such key exists in Google Cloud.
+- Remaining open issues are the two deliberate deferrals: #433 engine-level shell guardrail exploration and #435 /dag project-wide discovery fallback.
+
+---
+
+**Full changelog:** [`{previous_tag}`...`{current_tag}`](https://github.com/LeXwDeX/OpenCode-GraphAgent/compare/{previous_tag}...{current_tag})


### PR DESCRIPTION
Adds the fail-closed series file required by release-fork: .github/releases/v1.0.33.md (rendered and invariant-checked locally via release-notes.ts dry run). Required before dispatching the v1.0.33 stable release.