### PR TITLE
test: add MCP dual-era interop regression tests

### DIFF
--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -5,3 +5,4 @@ context:
   branch: test/452-add-mcp-dual
 issues:
   - 452
+pr: 453

--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -1,9 +1,7 @@
 version: 1
-delivery: upgrade-mcp-client
+delivery: add-mcp-dual
 context:
   kind: branch
-  branch: refactor/447-upgrade-mcp-client
+  branch: test/452-add-mcp-dual
 issues:
-  - 447
-  - 448
-pr: 449
+  - 452

--- a/packages/opencode/test/mcp/fixtures/interop-probe.ts
+++ b/packages/opencode/test/mcp/fixtures/interop-probe.ts
@@ -1,0 +1,89 @@
+// Runs the real v2 client against the fixture servers in a fresh process.
+// Sibling test files mock.module("@modelcontextprotocol/client") in the shared
+// bun test process, so real-transport coverage must not import the SDK there.
+import path from "node:path"
+import { Client, StreamableHTTPClientTransport } from "@modelcontextprotocol/client"
+import { StdioClientTransport } from "@modelcontextprotocol/client/stdio"
+
+const mode = process.argv[2] ?? "stdio-auto"
+const TIMEOUT_MS = 10_000
+let httpServer: Bun.Subprocess<"ignore", "pipe", "inherit"> | undefined
+
+process.on("SIGTERM", () => {
+  httpServer?.kill()
+  process.exit(1)
+})
+
+function withTimeout<T>(promise: Promise<T>, message: string): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(message)), TIMEOUT_MS)
+    promise.then(
+      (value) => {
+        clearTimeout(timer)
+        resolve(value)
+      },
+      (error) => {
+        clearTimeout(timer)
+        reject(error)
+      },
+    )
+  })
+}
+
+function firstText(result: { content: Array<{ type: string; text?: string }> }) {
+  return result.content[0]?.text
+}
+
+async function runStdio(legacy: boolean) {
+  const client = new Client({ name: "interop-probe", version: "0.0.0" }, { versionNegotiation: { mode: legacy ? "legacy" : "auto" } })
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: [path.join(import.meta.dir, "server-stdio.ts")],
+  })
+  await withTimeout(client.connect(transport), "stdio connect timed out")
+  try {
+    const result = await client.callTool({ name: "echo", arguments: { text: legacy ? "legacy" : "hello" } })
+    return { era: client.getProtocolEra(), version: client.getNegotiatedProtocolVersion(), echo: firstText(result as { content: Array<{ type: string; text?: string }> }) }
+  } finally {
+    await client.close()
+  }
+}
+
+async function readListeningPort(stream: ReadableStream<Uint8Array>): Promise<number> {
+  const reader = stream.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ""
+  while (true) {
+    const { done, value } = await reader.read()
+    if (value) buffer += decoder.decode(value)
+    const port = Number(buffer.match(/listening (\d+)/)?.[1])
+    if (port) {
+      reader.releaseLock()
+      return port
+    }
+    if (done) throw new Error(`http fixture exited before reporting a port: ${buffer}`)
+  }
+}
+
+async function runHttp() {
+  httpServer = Bun.spawn([process.execPath, path.join(import.meta.dir, "server-http.ts")], {
+    cwd: path.join(import.meta.dir, "../../.."),
+    stdout: "pipe",
+    stderr: "inherit",
+  })
+  const port = await withTimeout(readListeningPort(httpServer.stdout), "http fixture did not report a port in time")
+  const client = new Client({ name: "interop-probe", version: "0.0.0" }, { versionNegotiation: { mode: "auto" } })
+  await withTimeout(client.connect(new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${port}/mcp`))), "http connect timed out")
+  try {
+    const result = await client.callTool({ name: "echo", arguments: { text: "http" } })
+    return { era: client.getProtocolEra(), version: client.getNegotiatedProtocolVersion(), echo: firstText(result as { content: Array<{ type: string; text?: string }> }) }
+  } finally {
+    await client.close()
+    httpServer.kill()
+    await httpServer.exited
+  }
+}
+
+const outcome = mode === "http-auto" ? await runHttp() : await runStdio(mode === "stdio-legacy")
+console.log(JSON.stringify({ mode, ...outcome }))
+process.exit(0)

--- a/packages/opencode/test/mcp/fixtures/server-http.ts
+++ b/packages/opencode/test/mcp/fixtures/server-http.ts
@@ -1,0 +1,29 @@
+import { z } from "zod"
+import { McpServer, createMcpHandler } from "@modelcontextprotocol/server"
+
+const factory = () => {
+  const server = new McpServer({ name: "v2-fixture-http", version: "1.0.0" }, { capabilities: { tools: {} } })
+  server.registerTool(
+    "echo",
+    {
+      description: "echo the input back",
+      inputSchema: { text: z.string() },
+    },
+    async ({ text }) => ({ content: [{ type: "text" as const, text: `echo-http:${text}` }] }),
+  )
+  return server
+}
+
+const handler = createMcpHandler(factory)
+const server = Bun.serve({
+  port: 0,
+  fetch: async (req) => {
+    try {
+      return await handler.fetch(req)
+    } catch (e) {
+      console.error("[fixture]", e)
+      return new Response(JSON.stringify({ error: String(e) }), { status: 500 })
+    }
+  },
+})
+console.log(`listening ${server.port}`)

--- a/packages/opencode/test/mcp/fixtures/server-stdio.ts
+++ b/packages/opencode/test/mcp/fixtures/server-stdio.ts
@@ -1,0 +1,23 @@
+// Dual-era fixture: the SAME factory serves 2026-07-28 (server/discover) and
+// legacy (initialize) clients — serveStdio owns the era decision per connection.
+import { z } from "zod"
+import { McpServer } from "@modelcontextprotocol/server"
+import { serveStdio } from "@modelcontextprotocol/server/stdio"
+
+serveStdio(
+  () => {
+    const server = new McpServer({ name: "v2-fixture", version: "1.0.0" }, { capabilities: { tools: {} } })
+    server.registerTool(
+      "echo",
+      {
+        description: "echo the input back",
+        inputSchema: { text: z.string() },
+      },
+      async ({ text }) => ({ content: [{ type: "text", text: `echo:${text}` }] }),
+    )
+    return server
+  },
+  {
+    onerror: (e) => console.error("[fixture]", e.message),
+  },
+)

--- a/packages/opencode/test/mcp/interop.test.ts
+++ b/packages/opencode/test/mcp/interop.test.ts
@@ -1,0 +1,71 @@
+import path from "node:path"
+import { afterEach, describe, expect, test } from "bun:test"
+
+// Local to this branch: the era helper from #450 is not available here.
+const MODERN_VERSION = "2026-07-28"
+const LEGACY_VERSION = "2025-11-25"
+const PROBE_TIMEOUT_MS = 10_000
+
+const children: Array<Bun.Subprocess<"ignore", "pipe", "inherit">> = []
+
+afterEach(() => {
+  for (const child of children.splice(0)) child.kill()
+})
+
+function withTimeout<T>(promise: Promise<T>, message: string, ms = PROBE_TIMEOUT_MS): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(message)), ms)
+    promise.then(
+      (value) => {
+        clearTimeout(timer)
+        resolve(value)
+      },
+      (error) => {
+        clearTimeout(timer)
+        reject(error)
+      },
+    )
+  })
+}
+
+// The probe drives the real v2 client in a fresh process: sibling files in
+// test/mcp mock.module the client SDK in the shared bun test process.
+async function runProbe(mode: "stdio-auto" | "stdio-legacy" | "http-auto") {
+  const child = Bun.spawn([process.execPath, path.join(import.meta.dir, "fixtures", "interop-probe.ts"), mode], {
+    cwd: path.join(import.meta.dir, "../.."),
+    stdout: "pipe",
+    stderr: "inherit",
+  })
+  children.push(child)
+  const [code, stdout] = await withTimeout(
+    Promise.all([child.exited, Bun.readableStreamToText(child.stdout)]),
+    `interop probe ${mode} timed out`,
+  )
+  return { code, result: JSON.parse(stdout) as { era?: string; version?: string; echo?: string } }
+}
+
+describe("mcp dual-era interop", () => {
+  test("stdio auto negotiates 2026-07-28 and round-trips a tool call", async () => {
+    const { code, result } = await runProbe("stdio-auto")
+    expect(code, JSON.stringify(result)).toBe(0)
+    expect(result.era).toBe("modern")
+    expect(result.version).toBe(MODERN_VERSION)
+    expect(result.echo).toBe("echo:hello")
+  })
+
+  test("stdio legacy pin negotiates 2025-11-25 against the same fixture", async () => {
+    const { code, result } = await runProbe("stdio-legacy")
+    expect(code, JSON.stringify(result)).toBe(0)
+    expect(result.era).toBe("legacy")
+    expect(result.version).toBe(LEGACY_VERSION)
+    expect(result.echo).toBe("echo:legacy")
+  })
+
+  test("streamable http auto negotiates 2026-07-28 and round-trips a tool call", async () => {
+    const { code, result } = await runProbe("http-auto")
+    expect(code, JSON.stringify(result)).toBe(0)
+    expect(result.era).toBe("modern")
+    expect(result.version).toBe(MODERN_VERSION)
+    expect(result.echo).toBe("echo-http:http")
+  })
+})


### PR DESCRIPTION
Closes #452

## Why
SDK v2 迁移缺少对真实服务器的双 era 端到端回归测试，协商/回退坏了也发现不了。

## What changed
- test/mcp/fixtures/：双 era stdio server + Streamable HTTP server（移植自已验证的临时 fixtures）
- test/mcp/interop.test.ts：三行兼容矩阵全走真实 v2 客户端、零 transport mock——stdio auto→2026-07-28、stdio legacy pin→2025-11-25、http auto→2026-07-28，含工具往返调用与进程清理

## Evidence
超流评审 PASS（0 P0/P1）：interop 连跑两遍无 flaky；oxlint 4825/4850 0 err；typecheck 绿。DAG workflow dag_fe5fc4380363FiaRrn7FiF0zed。