### PR TITLE
fix: ad-hoc sign macOS binaries in build script so smoke test passes

### DIFF
--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -1,9 +1,7 @@
 version: 1
-delivery: upgrade-mcp-client
+delivery: ad-hoc-sign
 context:
   kind: branch
-  branch: refactor/447-upgrade-mcp-client
+  branch: fix/454-ad-hoc-sign
 issues:
-  - 447
-  - 448
-pr: 449
+  - 454

--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -5,3 +5,4 @@ context:
   branch: fix/454-ad-hoc-sign
 issues:
   - 454
+pr: 455

--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -209,6 +209,11 @@ for (const item of targets) {
     },
   })
 
+  // macOS kills freshly compiled unsigned darwin binaries (SIGKILL 137) before they can run
+  if (process.platform === "darwin" && item.os === "darwin" && fs.existsSync("/usr/bin/codesign")) {
+    await $`codesign --force --sign - dist/${name}/bin/opencode`
+  }
+
   // Smoke test: only run if binary is for current platform
   if (item.os === process.platform && item.arch === process.arch && !item.abi) {
     const binaryPath = `dist/${name}/bin/opencode`


### PR DESCRIPTION
Closes #454

## Why
macOS 本地 bun run build 产出的 darwin 二进制未签名，被内核 SIGKILL(137)，构建脚本自带 smoke test 必挂，产物无法自证。

## What changed
- script/build.ts：darwin 目标在 smoke test 前 codesign --force --sign - ad-hoc 签名；三重门卫（宿主 darwin + 目标 darwin + codesign 存在），其他平台零行为变化

## Evidence
超流评审 PASS（0 P0/P1）：build 13/13 目标 exit 0 含 darwin-arm64 Smoke test passed；产物 --version 直跑 Signature=adhoc。DAG workflow dag_fe5fc4380363FiaRrn7FiF0zed。