### PR TITLE
docs: add v1.0.34 release notes

### DIFF
--- a/.github/releases/v1.0.34.md
+++ b/.github/releases/v1.0.34.md
@@ -1,0 +1,51 @@
+## opencode {VERSION}
+
+Stable release from `main` branch. The MCP stack moves to SDK v2 with per-server protocol era negotiation (`auto`/`legacy`/`modern`), the negotiated era becomes visible in `mcp list` and the HTTP API, dual-era interop is locked in by real-server regression tests, and local macOS builds sign their darwin binaries so `bun run build` self-validates again.
+
+---
+
+### 🎯 Features
+
+- **MCP SDK v2 + 2026-07-28 protocol era negotiation, #447/#448 (PR #449)**: the client migrates from `@modelcontextprotocol/sdk@1.29.0` to `@modelcontextprotocol/client@2.0.0`, adding `protocol: auto | legacy | modern` per MCP server in config. `auto` probes `server/discover` with conservative fallback to the 2025 initialize handshake; `legacy` skips the probe; `modern` pins 2026-07-28 with no fallback. Known boundaries: SSE-only remote servers are no longer connectable, and transparent 404 session recovery is gone per spec.
+- **Negotiated era visible in status, #450 (PR #451)**: connected MCP statuses now carry optional `era` ("modern"/"legacy") and `protocolVersion` fields, populated from the v2 client's negotiated version (omitted when unreported). `opencode mcp list` renders `connected: modern (2026-07-28)`, the HTTP API schema composes the same fields, and the JS SDK is regenerated to match.
+
+---
+
+### 🐛 Bug Fixes
+
+- **macOS local builds died in their own smoke test, #454 (PR #455)**: freshly compiled unsigned darwin binaries were killed by the kernel (SIGKILL 137) before `--version` could run, failing `bun run build`; darwin targets are now ad-hoc signed (`codesign --force --sign -`) before the smoke step, triple-gated on host platform, target platform, and codesign availability. Linux hosts and cross-builds are unchanged.
+
+---
+
+### 🏗️ Architecture / Refactor
+
+- **dev-lineage re-sync with main (PR #456)**: the three v2 follow-up deliveries entered main directly (SpecGit bootstrap defaulted the PR base), so a chore sync PR re-established that dev contains all of main, keeping dev the integration layer for subsequent work.
+
+---
+
+### 🧪 Test Summary
+
+```
+CI gates on main at each delivery merge (#451/#453/#455):
+Typecheck:           pass (3/3 runs)
+Unit Tests (linux):  pass (3/3 runs)
+E2E Tests (linux):   pass (3/3 runs)
+E2E Tests (windows): pass (3/3 runs)
+SpecGit Acceptance:  pass (3/3 runs)
+mcp suite:           95 pass (92 + interop 3)
+lint ratchet:        4814-4825 <= 4850
+dev sync (#456):     all gates pass (1 prompt-loop flake, rerun green)
+```
+
+---
+
+### 🔍 Verification
+
+- Each delivery carried an accepted SpecGit verdict (`specgit finish` exit 0) on its final head after anchor-fresh CI, plus a DAG workflow double review (standards + intent) with 8/8 load-bearing claims independently verified and zero P0/P1 findings.
+- New dual-era interop tests drive the real v2 client in fresh subprocesses against in-repo fixture servers: stdio auto negotiates 2026-07-28, stdio legacy pin negotiates 2025-11-25 against the same fixture, streamable HTTP auto negotiates 2026-07-28, each with a tool-call round trip.
+- Live end-to-end check against dual-era fixtures: a v1 (legacy SDK) client connects via legacy fallback; a v2 binary negotiates modern and round-trips echo tools through the TUI.
+- Deliberately deferred: darwin cross-builds from Linux CI remain unsigned (ad-hoc signing requires macOS codesign); SSE-only server support is intentionally dropped with v2.
+
+---
+
+**Full changelog:** [`{previous_tag}`...`{current_tag}`](https://github.com/LeXwDeX/OpenCode-GraphAgent/compare/{previous_tag}...{current_tag})


### PR DESCRIPTION
Series notes for the next stable release (graphagent-v1.0.34): MCP SDK v2 + era negotiation, era observability, dual-era interop tests, darwin build signing. Rendered and validated locally via release-notes.ts; placeholders verified.