### PR TITLE
docs: release notes v1.0.35

### DIFF
--- a/.github/releases/v1.0.35.md
+++ b/.github/releases/v1.0.35.md
@@ -1,0 +1,42 @@
+## opencode {VERSION}
+
+{Prerelease/Stable} release from `{branch}` branch. Giant `summary.diffs` snapshots (37.8MB measured in the wild) can no longer starve the event loop into an unkillable state: message summaries are capped at 256KB at every write path, and oversized legacy rows are stripped on read - the session that triggered the original kill -9 now reopens cleanly.
+
+---
+
+### 🐛 Bug Fixes
+
+- **ESC could not cancel a session fed a giant upstream diff, #458 (PR #459)**: `SessionSummary.summarize` wrote the full `snapshot.diffFull` output into the user message's `summary.diffs` with no size limit, so one upstream-sync turn injected a 37.8MB payload; every `message.updated` then re-serialized it into the event table (single events measured at 37.87MB, the shared DB grew to 10GB) and SSE broadcast, driving the in-process TUI into an allocation storm that starved the event loop - the abort HTTP request never got scheduled and only `kill -9` recovered it. Three guards now share `MAX_SUMMARY_DIFF_BYTES = 256KB`: source truncation in `summarize`, a write guard in `toRow`, and a read guard in `fromRow` that strips oversized legacy `summary_diffs` while keeping the additions/deletions/files stats (diffs are display-only metadata; the LLM context itself was only 695KB). Byte accounting matches the JSON serialization exactly, and round-trips are idempotent.
+
+---
+
+### ⚙️ CI / Engineering
+
+- **specgit-accept re-aligned with the main-line harness (PR #459)**: a `specgit init --force` version refresh had reverted the workflow to the template's workspace-local CLI install (`npm install --no-save`), which dies on this bun workspace's `catalog:` protocol (EUNSUPPORTEDPROTOCOL, #434 redux), and to a `yaml`-importing wait step the global install cannot resolve. Restored the verified shape: `npm install -g specgit@^0.5.0`, regex-based policy parsing, main-only trigger, and the deviation is now recorded in AGENTS.md's local-specializations list so the next re-init re-applies it.
+
+---
+
+### 🧪 Test Summary
+
+```
+CI gates on main at the delivery merge (PR #459):
+Typecheck:           pass
+Unit Tests (linux):  pass
+E2E Tests (linux):   pass
+E2E Tests (windows): pass
+SpecGit Acceptance:  pass
+dag-core gate:       52 pass / 0 fail
+new guard tests:     7/7 pass (summary-diff-guard.test.ts)
+```
+
+---
+
+### 🔍 Verification
+
+- Delivery carried an accepted SpecGit verdict (`specgit finish` exit 0) on the final head after anchor-fresh CI, via a DAG workflow (map -> coding -> verify -> review -> synthesize) with a PASS review verdict (0 blocking; 3 INFO suggestions all absorbed into the final commit: shared helper, byte-accounting comment, pinned boundary tests).
+- `test/session/summary-diff-guard.test.ts` runs the real service graph (`Session.node` + real `Database.node`, only `Snapshot.diffFull` stubbed): source truncation keeps the leading files within budget, the read guard strips legacy oversized rows while preserving stats, in-budget round-trips are lossless, and empty/single-oversized/exact-capacity boundaries are pinned.
+- Deliberately deferred (tracked in #458): abort-path resilience against a starved event loop, and an event-loop lag watchdog.
+
+---
+
+**Full changelog:** [`{previous_tag}`...`{current_tag}`](https://github.com/LeXwDeX/OpenCode-GraphAgent/compare/{previous_tag}...{current_tag})

--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -8,3 +8,4 @@ issues:
 issueKinds:
   - issue: 460
     kind: kind::docs
+pr: 461

--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -1,8 +1,10 @@
 version: 1
-delivery: giant-summary-guard
+delivery: release-notes-v1-0-35
 context:
   kind: branch
-  branch: feat/458-giant-summary-guard
+  branch: docs/460-release-notes-v1-0-35
 issues:
-  - 458
-pr: 459
+  - 460
+issueKinds:
+  - issue: 460
+    kind: kind::docs


### PR DESCRIPTION
Closes #460

## Why

v1.0.35 正式发布需要系列文件 `.github/releases/v1.0.35.md`（release-version.ts 从 `graphagent-v1.0.34` 推导下一版本 1.0.35；文件名必须等于推导版本，缺失即 release fail-closed）。

## What changed

- 新增 `.github/releases/v1.0.35.md`：记录 #458 巨型 summary.diffs 修复（PR #459）与 specgit-accept harness 对齐；结构与占位符遵循 RELEASE_NOTES_TEMPLATE.md 与 release-notes.ts 的 ASCII 校验。

## Evidence

- 本地渲染演练通过：
  `bun run ./packages/opencode/script/release-notes.ts --notes-dir .github/releases --version 1.0.35 --channel main --branch main --tag graphagent-v1.0.35 --previous-tag graphagent-v1.0.34 --repo LeXwDeX/OpenCode-GraphAgent --out /tmp/notes-1.0.35.md`
  （渲染输出已核对：版本/通道/branch/compare 链接占位符全部正确替换）
- Test Summary 数据取自 PR #459 的实际 CI 门禁（10/10 checks pass 含 SpecGit Acceptance）。

## Checklist

- [x] 文件名 = 推导版本（1.0.35）
- [x] 渲染演练（release-notes.ts）零报错
- [x] 正文 ASCII 校验通过（canonical emoji 标题除外）
