### PR TITLE
fix(tui): re-exec with package tsconfig when cwd cannot compile solid jsx

### DIFF
--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -8,3 +8,4 @@ issues:
 issueKinds:
   - issue: 465
     kind: kind::fix
+pr: 466

--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -1,0 +1,10 @@
+version: 1
+delivery: tui-crashes-on
+context:
+  kind: branch
+  branch: fix/465-tui-crashes-on
+issues:
+  - 465
+issueKinds:
+  - issue: 465
+    kind: kind::fix

--- a/packages/opencode/src/cli/cmd/tui.ts
+++ b/packages/opencode/src/cli/cmd/tui.ts
@@ -68,6 +68,19 @@ export function resolveThreadDirectory(project?: string, envPWD = process.env.PW
   return Filesystem.resolve(cwd)
 }
 
+async function needsTranspileReexec() {
+  // The compiled binary embeds its sources; the candidate tsconfig only
+  // exists for source-mode runs, which are the only ones Bun re-transpiles.
+  const candidate = fileURLToPath(new URL("../../../tsconfig.json", import.meta.url))
+  if (!(await Filesystem.exists(candidate))) return false
+  const local = path.join(process.cwd(), "tsconfig.json")
+  if (!(await Filesystem.exists(local))) return true
+  const raw = await Bun.file(local)
+    .text()
+    .catch(() => "")
+  return !raw.includes("@opentui/solid")
+}
+
 export const TuiThreadCommand = cmd({
   command: "$0 [project]",
   describe: "start opencode tui",
@@ -168,6 +181,24 @@ export const TuiThreadCommand = cmd({
       UI.error(`${unsupported} requires --mini`)
       process.exitCode = 1
       return
+    }
+
+    // Bun snapshots the JSX transpiler config from $cwd/tsconfig.json at
+    // startup. Booting the source CLI from a directory without an
+    // @opentui/solid jsxImportSource compiles the TUI's solid JSX against the
+    // react runtime and dies on the first component. Re-exec from the package
+    // directory, which owns a compatible tsconfig; the original directory
+    // still reaches the thread/worker via [project] resolution, so project
+    // keys stay on the user's directory.
+    if (await needsTranspileReexec()) {
+      const pkg = fileURLToPath(new URL("../../../", import.meta.url))
+      const child = Bun.spawn([process.execPath, ...process.execArgv, Bun.main, ...process.argv.slice(2)], {
+        cwd: pkg,
+        stdin: "inherit",
+        stdout: "inherit",
+        stderr: "inherit",
+      })
+      process.exit(await child.exited)
     }
 
     const unguard = win32InstallCtrlCGuard()


### PR DESCRIPTION
Closes #465

## Why

Source-mode boots of the CLI (e.g. `bun --conditions=browser packages/opencode/src/index.ts`) crash from any directory without a compatible `tsconfig.json`:

```
Unexpected error
Cannot find package 'react' imported from packages/tui/src/config/index.tsx
```

Root cause: Bun snapshots JSX transpiler settings from `$cwd/tsconfig.json` at startup. When the cwd has none (or one without `@opentui/solid` as jsxImportSource), every TUI `.tsx` file is compiled against the **react** runtime, and resolution of `react/jsx-dev-runtime` fails — react is not installed anywhere in this monorepo. The whole TUI graph is affected (`app.tsx`, `config/index.tsx`, …), not a single file. Reproduced identically on `main`; not introduced by the upstream sync.

## What changed

- `packages/opencode/src/cli/cmd/tui.ts`: before entering the TUI flow, detect the hostile-transpile condition (source mode + cwd tsconfig missing or lacking `@opentui/solid`) and re-exec the same entry from the package directory, which owns a compatible tsconfig. `process.execArgv` is preserved (`--conditions=browser` etc. survive), and the original directory keeps reaching thread/worker resolution through the existing `[project]` positional + `process.chdir` path — project keys stay on the user's directory.
- Compiled binaries are unaffected and skip the guard (the candidate tsconfig only exists in a source checkout; binaries embed pre-compiled code).
- The re-exec is loop-proof: the child boots with the package tsconfig in cwd, so the guard no-ops.

## Evidence

- Hostile cwd (fixture project, no tsconfig) + pty: before = crash in ~2s with react resolution error; after = TUI alive at 20s with real render output (ANSI frames, provider labels), zero errors.
- Normal path untouched: `bun run dev -- --version` from `packages/opencode` does not re-exec (tsconfig present).
- `bun typecheck` PASS; `test/cli/cmd/tui/` 18 pass / 0 fail.
- Non-TUI commands (`serve`, `models`) never load the TUI graph and never hit the guard.
