### PR TITLE
docs(release): add v1.0.37 notes

### DIFF
--- a/.github/releases/v1.0.37.md
+++ b/.github/releases/v1.0.37.md
@@ -1,0 +1,44 @@
+## opencode {VERSION}
+
+{Prerelease/Stable} release from `{branch}` branch. DAG replan topology refresh: equal-count replans now surface a `graphRev` revision that makes the TUI re-fetch superseded node graphs exactly once instead of rendering stale topology.
+
+---
+
+### 🎯 Features
+
+- **DAG replan topology refresh, #469**: an equal-count replan (node count and status distribution unchanged) previously never triggered a TUI node re-fetch, so the inspector and an expanded sidebar kept rendering superseded topology until the next unrelated state change. The existing `workflow.graph_rev` counter is now exposed end to end as `graphRev` (core summary, schema contract, HttpAPI response, regenerated SDK types) and folded into the inspector and sidebar refresh signatures, so a revision-only change triggers exactly one authoritative node re-fetch while no-op summaries stay refetch-free and no polling is added.
+
+---
+
+### ⚙️ CI / Engineering
+
+- `spec_git/policy.yaml` required checks realigned, 29e876ac2c: SpecGit acceptance for dev deliveries now requires the `Typecheck` and `Unit Tests (linux)` checks instead of the `unit-tests`/`e2e-tests` ids, matching the dev gates where E2E does not block.
+- JS SDK regenerated: the generated `DagWorkflowSummary` types carry the new `graphRev` field, and the CI `Check generated SDK` freshness gate passes.
+
+---
+
+### 🧪 Test Summary
+
+- New `packages/tui/test/feature-plugins/dag-panel.test.tsx` regression suite: equal-count replan bumps `graphRev` alone and refetches exactly once; a no-op summary replacement with the same `graphRev` and counts does not refetch.
+- Companion coverage: inspector refetch-once (`dag-inspector.test.tsx`), equal-count replan summary emission (`dag-summary-publisher-behavior.test.ts`), core summary store revision (`dag-store-summaries.test.ts`), and the HttpAPI contract exercise asserting `summary.graphRev`.
+
+```
+typecheck: root 29/29 tasks green
+test:dag-core: pass
+test:httpapi:ci: 230 pass / 0 fail
+focused suites: inspector 29 pass, sidebar/sync 7 pass
+CI @ 29e876ac2c: Typecheck / Unit Tests (linux) / E2E linux+windows / CodeQL all pass
+lint: 4836 warnings (ratchet 4850)
+```
+
+---
+
+### 🔍 Verification
+
+- DAG development workflow `dag_fe5fa90eeff6BrTFcV9rWDOSyK`: final review ACCEPT after R1 fixes, and `specgit finish --json` exited 0 with the PR #469 checklist complete.
+- All 8 GitHub checks on PR #469 green at 29e876ac2c, including E2E on linux (2m38s) and windows (7m19s).
+- Scope honesty: the only feature surface in this range is the DAG summary and TUI refresh signature; no upstream sync content, no dependency changes, and no standalone architecture or refactor entries.
+
+---
+
+**Full changelog:** [`{previous_tag}`...`{current_tag}`](https://github.com/LeXwDeX/OpenCode-GraphAgent/compare/{previous_tag}...{current_tag})

--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -8,3 +8,4 @@ issues:
 issueKinds:
   - issue: 470
     kind: kind::docs
+pr: 471

--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -1,8 +1,10 @@
 version: 1
-delivery: replan-topology-refresh
+delivery: release-v1-0-37-notes
 context:
   kind: branch
-  branch: feat/468-replan-topology-refresh
+  branch: docs/470-release-v1-0-37-notes
 issues:
-  - 468
-pr: 469
+  - 470
+issueKinds:
+  - issue: 470
+    kind: kind::docs


### PR DESCRIPTION
Closes #470

## Why
The dev prerelease gate correctly failed closed because `.github/releases/v1.0.37.md` was absent. The mechanically derived `1.0.37-dev.1` release cannot render or publish without that series file.

## What changed
- Added `.github/releases/v1.0.37.md` for changes landed since `graphagent-v1.0.36`.
- Documented DAG replan topology refresh, SDK generation, SpecGit check-name alignment, and verified test evidence.
- Preserved release placeholders and the required changelog comparison link.

## Evidence
- Independent DAG review: ACCEPT.
- File SHA-256: `9e6e646f83d92311c910bd189528b586cc6ad12d4da0f67d45fdc89c2a2920f0`.
- `release-notes.ts` rendered `1.0.37-dev.1` for channel `dev` with exit 0 and no unresolved placeholders.
- Commit hook: root typecheck 29/29 tasks passed.

## Checklist
- [x] Why, What changed, and Evidence are filled in.
- [x] `specgit finish` exits 0.
