### PR TITLE
fix(core): stabilize dirty worktree removal on macOS

### DIFF
--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -6,3 +6,4 @@ context:
   branch: feat/474-stabilize-dirty-worktree
 issues:
   - 474
+pr: 481

--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -1,9 +1,8 @@
 version: 1
-delivery: sdk-openapi-race
+delivery: stabilize-dirty-worktree
 context:
   kind: worktree
-  label: fix-475
-  branch: fix/475-sdk-openapi-race
+  label: fix-474
+  branch: feat/474-stabilize-dirty-worktree
 issues:
-  - 475
-pr: 485
+  - 474

--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -3,7 +3,7 @@ delivery: stabilize-dirty-worktree
 context:
   kind: worktree
   label: fix-474
-  branch: feat/474-stabilize-dirty-worktree
+  branch: fix/474-stabilize-dirty-worktree
 issues:
   - 474
-pr: 481
+pr: 482

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -852,6 +852,13 @@ export const layer = Layer.effect(
       })
     })
 
+    // forceRequired must be derived from locale-stable porcelain state only:
+    // git's refusal prose is translated (e.g. zh_CN catalogs) and never matches reliably.
+    const worktreeDirty = Effect.fnUntraced(function* (directory: AbsolutePath) {
+      const status = yield* execute(directory, proc)(["status", "--porcelain"]).pipe(Effect.result)
+      return status._tag === "Success" && status.success.exitCode === 0 && status.success.text.trim() !== ""
+    })
+
     const worktreeRun = Effect.fnUntraced(function* (
       operation: "create" | "remove" | "list",
       repository: Repository,
@@ -872,7 +879,11 @@ export const layer = Layer.effect(
         operation,
         directory: worktreeDirectory,
         message,
-        forceRequired: operation === "remove" && /contains modified or untracked files|is dirty/i.test(message),
+        forceRequired:
+          operation === "remove" &&
+          result.exitCode === 128 &&
+          worktreeDirectory !== undefined &&
+          (yield* worktreeDirty(worktreeDirectory)),
       })
     })
 

--- a/packages/core/test/project-copy.test.ts
+++ b/packages/core/test/project-copy.test.ts
@@ -192,6 +192,44 @@ describe("ProjectCopy", () => {
     }),
   )
 
+  it.live("requires force to remove a git worktree with tracked modifications", () =>
+    Effect.gen(function* () {
+      const input = yield* setup()
+      const copy = yield* ProjectCopy.Service
+      const temp = yield* Effect.promise(() => fs.realpath(path.dirname(input.root.path)))
+      const parent = abs(path.join(temp, path.basename(input.root.path) + "-copy-tracked"))
+      yield* Effect.addFinalizer(() =>
+        Effect.promise(() => fs.rm(parent, { recursive: true, force: true })).pipe(Effect.ignore),
+      )
+      yield* Effect.promise(() => Bun.write(path.join(input.sourceDirectory, "tracked.txt"), "base"))
+      yield* Effect.promise(() => $`git add tracked.txt`.cwd(input.sourceDirectory).quiet())
+      yield* Effect.promise(() => $`git commit -m tracked`.cwd(input.sourceDirectory).quiet())
+      const created = yield* copy.create({
+        projectID: input.projectID,
+        strategy: gitWorktree,
+        sourceDirectory: input.sourceDirectory,
+        directory: parent,
+        name: "copy",
+      })
+      yield* Effect.promise(() => Bun.write(path.join(created.directory, "tracked.txt"), "modified"))
+
+      const error = yield* copy
+        .remove({ projectID: input.projectID, directory: created.directory, force: false })
+        .pipe(Effect.flip)
+
+      expect(error).toBeInstanceOf(Git.WorktreeError)
+      if (error instanceof Git.WorktreeError) {
+        expect(error.operation).toBe("remove")
+        expect(error.forceRequired).toBe(true)
+      }
+      expect(yield* stored(input.projectID)).toContainEqual({ directory: created.directory, strategy: "git_worktree" })
+      expect(yield* Effect.promise(() => Bun.file(path.join(created.directory, "tracked.txt")).exists())).toBe(true)
+
+      yield* copy.remove({ projectID: input.projectID, directory: created.directory, force: true })
+      expect(yield* Effect.promise(() => Bun.file(created.directory).exists())).toBe(false)
+    }),
+  )
+
   it.live("preserves copies whose stored strategy is unavailable", () =>
     Effect.gen(function* () {
       const input = yield* setup()


### PR DESCRIPTION
Closes #474

## Why

`packages/core/src/git.ts` classifies a failed `git worktree remove` by regex-matching hardcoded English prose (`contains modified or untracked files|is dirty`) against git's localized human-readable stderr. On macOS with a Homebrew git that ships a translation catalog and an inherited `zh_CN.UTF-8` locale, git refuses with `致命错误：'…' 包含修改或未跟踪的文件，使用 --force 删除`; the regex misses, so `forceRequired` is reported as `false` to clients. The refusal metadata is wrong whenever git's message language is not English — a translation-catalog × inherited-locale composition, not a macOS or git-version semantic. `ProjectCopy > requires force to remove a dirty git worktree` reproduced the failure locally on this machine.

## What changed

- `packages/core/src/git.ts`: recompute `forceRequired` in `worktreeRun` from locale-stable signals only — `operation === "remove"` + refusal exit code `128` + dirtiness of the target worktree confirmed via `git status --porcelain` (reusing the existing `execute` wrapper). The localized stderr prose is no longer an input to classification.
- `packages/core/test/project-copy.test.ts`: new regression `requires force to remove a git worktree with tracked modifications` — independently proves **tracked** dirtiness (committed file modified inside the copy) triggers `forceRequired: true`; the existing regression proves **untracked** dirtiness. Both pin the refusal's damage-correlation properties (entry preserved in storage, dirty content not destroyed) and the `force: true` removal path, so the `forceRequired: true` contract is strengthened, not weakened.

## Evidence

- **Red (pre-fix, ambient `zh_CN.UTF-8`, Homebrew git 2.55.0):** both regressions fail — `Expected: true / Received: false` at `forceRequired` (`bun test test/project-copy.test.ts -t "requires force"` → 0 pass / 2 fail).
- **Green (post-fix, ambient `zh_CN.UTF-8`):** both pass (2 pass / 0 fail).
- **Green (`LC_ALL=C`):** both pass — classification is locale-independent in both directions (porcelain is byte-identical across locales; stderr never consulted).
- **Full Core suite (macOS):** `bun test` in `packages/core` → 1206 pass / 1 fail; the single failure (`Watcher > publishes .git/HEAD events`) was reproduced on a pristine `origin/main` control worktree with zero modifications — pre-existing, owned by #473, untouched by this diff.
- **Typecheck:** `bun run typecheck` in `packages/core` (`tsgo --noEmit`) clean; pre-commit turbo typecheck across all 35 packages green.
- **Lint:** `bun run lint` → 4840 warnings / 0 errors, under the 4850 ratchet; every `git.ts` warning is at pre-existing lines (< 855, before the insertion point); zero warnings in changed code.
- Commit `8ff266d1ce`: 2 files changed, +50 / −1.

## Checklist

- [x] Root cause proven by reproduction matrix (binary × locale), fixture porcelain state captured
- [x] No gate weakened; `forceRequired: true` contract preserved and now covered for both dirtiness dimensions
- [x] Focused test, full Core suite, typecheck, lint green
