### PR TITLE
test(core): normalize .git/HEAD watcher events on macOS

### DIFF
--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -3,7 +3,7 @@ delivery: git-head-watcher
 context:
   kind: worktree
   label: fix-473
-  branch: feat/473-git-head-watcher
+  branch: test/git-head-watcher
 issues:
   - 473
-pr: 484
+pr: 486

--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -6,3 +6,4 @@ context:
   branch: feat/473-git-head-watcher
 issues:
   - 473
+pr: 484

--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -1,9 +1,8 @@
 version: 1
-delivery: stabilize-dirty-worktree
+delivery: git-head-watcher
 context:
   kind: worktree
-  label: fix-474
-  branch: fix/474-stabilize-dirty-worktree
+  label: fix-473
+  branch: feat/473-git-head-watcher
 issues:
-  - 474
-pr: 482
+  - 473

--- a/packages/core/test/filesystem/watcher.test.ts
+++ b/packages/core/test/filesystem/watcher.test.ts
@@ -225,11 +225,32 @@ describeWatcher("Watcher", () => {
           const branch = `watch-${Math.random().toString(36).slice(2)}`
           yield* ready(directory)
           yield* Effect.promise(() => $`git branch ${branch}`.cwd(directory).quiet())
+          // Contract for an existing HEAD: once the backend stream has seen HEAD, an
+          // update publishes "change" and removal publishes "unlink". The first write
+          // to a pre-existing but stream-unseen HEAD is backend vocabulary (fs-events
+          // may flag ItemCreated, surfacing as "add" on macOS), so it is consumed only
+          // to record HEAD in the stream — its classification is deliberately not
+          // asserted, while the asserted "change" and "unlink" must match exactly.
+          yield* eventuallyUpdate(
+            (event) => event.file === head,
+            () => fs.writeFileString(head, `ref: refs/heads/${branch}\n`),
+          )
+          const renamed = `watch-${Math.random().toString(36).slice(2)}`
+          yield* Effect.promise(() => $`git branch ${renamed}`.cwd(directory).quiet())
           expect(
-            yield* nextUpdate((event) => event.file === head, fs.writeFileString(head, `ref: refs/heads/${branch}\n`)),
+            yield* nextUpdate(
+              (event) => event.file === head && event.event === "change",
+              fs.writeFileString(head, `ref: refs/heads/${renamed}\n`),
+            ),
           ).toEqual({
             file: head,
             event: "change",
+          })
+          expect(
+            yield* nextUpdate((event) => event.file === head && event.event === "unlink", fs.remove(head)),
+          ).toEqual({
+            file: head,
+            event: "unlink",
           })
         }),
       { git: true },
@@ -247,14 +268,27 @@ describeWatcher("Watcher", () => {
             yield* Effect.addFinalizer(() => Effect.promise(() => fs.rm(actual, { recursive: true, force: true })))
             yield* ready(directory)
             const head = path.join(directory, ".git", "HEAD")
+            const resolved = path.join(actual, "HEAD")
             const branch = `watch-${Math.random().toString(36).slice(2)}`
             yield* Effect.promise(() => $`git branch ${branch}`.cwd(directory).quiet())
+            // Same contract as the direct .git/HEAD case, observed through the symlink:
+            // events carry the realpath of the store, so both the update and the
+            // removal are asserted against actual/HEAD exactly.
+            yield* eventuallyUpdate(
+              (event) => event.file === resolved,
+              () => afs.writeFileString(head, `ref: refs/heads/${branch}\n`),
+            )
+            const renamed = `watch-${Math.random().toString(36).slice(2)}`
+            yield* Effect.promise(() => $`git branch ${renamed}`.cwd(directory).quiet())
             expect(
               yield* nextUpdate(
-                (event) => event.file === path.join(actual, "HEAD"),
-                afs.writeFileString(head, `ref: refs/heads/${branch}\n`),
+                (event) => event.file === resolved && event.event === "change",
+                afs.writeFileString(head, `ref: refs/heads/${renamed}\n`),
               ),
-            ).toEqual({ file: path.join(actual, "HEAD"), event: "change" })
+            ).toEqual({ file: resolved, event: "change" })
+            expect(
+              yield* nextUpdate((event) => event.file === resolved && event.event === "unlink", afs.remove(head)),
+            ).toEqual({ file: resolved, event: "unlink" })
           }),
         {
           git: true,


### PR DESCRIPTION
Closes #473

## Why

On macOS, `Watcher > publishes .git/HEAD events` deterministically receives `add` for the first stream-seen write to a pre-existing `.git/HEAD` while the test asserts `change`. `@parcel/watcher` 2.5.1 (fs-events) classifies that first write as `create` (ItemCreated flag, empty subscribe-time DirTree, `since=0`), so the full local Core suite stays red on macOS and watcher regressions become hard to distinguish from backend event-vocabulary differences.

## What changed

Test-only repair in `packages/core/test/filesystem/watcher.test.ts` (both `.git/HEAD` tests); no runtime change — the `watcher.ts` passthrough (`create`→`add`, `update`→`change`, `delete`→`unlink`) is intentionally preserved.

The two tests now define and enforce the contract for an existing `.git/HEAD` without accepting ambiguous first-write classifications:

- The first write to a pre-existing but stream-unseen HEAD is backend vocabulary (fs-events may flag `ItemCreated`, surfacing as `add` on macOS). It is consumed via `eventuallyUpdate` only to record HEAD in the stream — deliberately not type-asserted (no `add|change` union assertion), and it also hardens against the subscription-readiness flake.
- The second write (branch retarget of an already-seen HEAD) must publish exactly `change`.
- Removing HEAD must publish exactly `unlink` (new coverage — create and delete behavior stay distinguishable).
- The symlinked-`.git` variant asserts the same exact `change`/`unlink` contract against the realpath (`actual/HEAD`), preserving the events-carry-realpath guarantee.

## Evidence

- Root cause re-proven in this worktree (macOS, arm64, bun 1.4.0): RED run of `bun test test/filesystem/watcher.test.ts` → `Watcher > publishes .git/HEAD events` failed with `expect(received).toEqual(expected)` (`change` expected, `add` received); the symlink variant passed this session (FSEvents flag-dependent: Modified-only delivery), matching the diagnosis evidence.
- GREEN: 5 consecutive focused runs, all exit 0, zero failures (`/tmp/opencode-repair-wave-472-477/fix-473-green-all.log`).
- Full Core suite from `packages/core`: 1206 tests across 151 files — the only failure is `ProjectCopy > requires force to remove a dirty git worktree`, proven pre-existing on pristine `origin/main` (re-run with this change stashed: same failure; owned by the #474 lane).
- `bun typecheck` in `packages/core`: exit 0. Pre-commit hook additionally ran full-workspace `turbo typecheck`: 29/29 successful.
- Root `bun run lint`: exit 0 (4840 warnings, 0 errors — within the ratchet budget).
- Logs: `/tmp/opencode-repair-wave-472-477/fix-473-{red,green-all,full-core,typecheck,lint}.log`.

## Checklist

- [x] Focused watcher tests pass repeatedly on macOS (5×)
- [x] Full Core suite green except the pre-existing, independently owned #474 failure
- [x] `bun typecheck` (packages/core + full workspace via hook) clean
- [x] Root lint clean (ratchet intact)
