### PR TITLE
fix(test): bound httpapi exerciser teardown and force process exit (#472)

### DIFF
--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -6,3 +6,4 @@ context:
   branch: feat/472-issue472
 issues:
   - 472
+pr: 487

--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -1,9 +1,8 @@
 version: 1
-delivery: git-head-watcher
+delivery: issue472
 context:
   kind: worktree
-  label: fix-473
-  branch: test/git-head-watcher
+  label: fix-472
+  branch: feat/472-issue472
 issues:
-  - 473
-pr: 486
+  - 472

--- a/packages/opencode/test/server/httpapi-exercise/backend.ts
+++ b/packages/opencode/test/server/httpapi-exercise/backend.ts
@@ -53,9 +53,9 @@ export function callAuthProbe(scenario: ActiveScenario, credentials: "missing" |
   })
 }
 
-type CachedApp = BackendApp & { readonly dispose: () => Promise<void> }
+export type CachedApp = BackendApp & { readonly dispose: () => Promise<void> }
 
-const appCache: Partial<Record<string, CachedApp>> = {}
+export const appCache: Partial<Record<string, CachedApp>> = {}
 
 export async function disposeApps(heartbeat?: (label: string) => void) {
   const apps = Object.values(appCache)

--- a/packages/opencode/test/server/httpapi-exercise/index.ts
+++ b/packages/opencode/test/server/httpapi-exercise/index.ts
@@ -24,7 +24,6 @@ import path from "path"
 import { array, boolean, check, isRecord, message, object, stable } from "./assertions"
 import { controlledPtyInput, http, route } from "./dsl"
 import {
-  cleanupExercisePaths,
   exerciseConfigDirectory,
   exerciseDataDirectory,
   exerciseDatabasePath,
@@ -33,8 +32,8 @@ import {
 import { color, printHeader, printResults } from "./report"
 import { coverageResult, parseOptions, routeKey, routeKeys, selectedScenarios } from "./routing"
 import { runScenario } from "./runner"
-import { disposeApps } from "./backend"
 import { runtime } from "./runtime"
+import { runMainWithHardExit, teardown } from "./teardown"
 import { type Options, type Scenario } from "./types"
 import { startProgressWatchdog } from "./watchdog"
 
@@ -2216,13 +2215,7 @@ const llmScenarios = new Set([
 ])
 
 const main = Effect.gen(function* () {
-  yield* Effect.addFinalizer(() =>
-    Effect.promise(() => disposeApps(options.heartbeat)).pipe(
-      Effect.andThen(Effect.sync(() => options.heartbeat?.("teardown: cleanupExercisePaths"))),
-      Effect.andThen(cleanupExercisePaths),
-      Effect.andThen(Effect.sync(() => options.heartbeat?.("teardown: complete"))),
-    ),
-  )
+  yield* Effect.addFinalizer(() => Effect.promise(() => teardown(options)))
   const parsed = parseOptions(Bun.argv.slice(2))
   const options: Options = parsed.progress ? { ...parsed, heartbeat: startProgressWatchdog() } : parsed
   const modules = yield* Effect.promise(() => runtime())
@@ -2266,10 +2259,7 @@ const main = Effect.gen(function* () {
   return undefined
 })
 
-Effect.runPromise(main.pipe(Effect.provide(TestLLMServer.layer), Effect.scoped)).then(
-  () => process.exit(0),
-  (error: unknown) => {
-    console.error(`${color.red}${message(error)}${color.reset}`)
-    process.exit(1)
-  },
+runMainWithHardExit(
+  Effect.runPromise(main.pipe(Effect.provide(TestLLMServer.layer), Effect.scoped)),
+  (code) => process.exit(code),
 )

--- a/packages/opencode/test/server/httpapi-exercise/runner.ts
+++ b/packages/opencode/test/server/httpapi-exercise/runner.ts
@@ -290,7 +290,7 @@ const resetState = Effect.promise(async () => {
  */
 const CLEANUP_STEP_TIMEOUT_MS = 10_000
 
-async function bounded(label: string, work: () => Promise<unknown>, ms = CLEANUP_STEP_TIMEOUT_MS) {
+export async function bounded(label: string, work: () => Promise<unknown>, ms = CLEANUP_STEP_TIMEOUT_MS) {
   let timer: ReturnType<typeof setTimeout> | undefined
   const timeout = new Promise<"timeout">((resolve) => {
     timer = setTimeout(() => resolve("timeout"), ms)

--- a/packages/opencode/test/server/httpapi-exercise/teardown.test.ts
+++ b/packages/opencode/test/server/httpapi-exercise/teardown.test.ts
@@ -1,0 +1,103 @@
+import { afterAll, describe, expect, test } from "bun:test"
+import { Flag } from "@opencode-ai/core/flag/flag"
+import path from "path"
+import type { CachedApp } from "./backend"
+
+// The exercise harness re-points the process env at its isolated DB/XDG roots
+// at import time. Import it lazily under dedicated preserved paths, then
+// restore everything so this file never leaks those overrides into the rest of
+// the bun test process (single shared process).
+const exerciseDb = path.join(process.env.TMPDIR ?? "/tmp", `opencode-teardown-regression-${process.pid}.db`)
+const exerciseGlobal = path.join(process.env.TMPDIR ?? "/tmp", `opencode-teardown-regression-${process.pid}`)
+const envKeys = [
+  "OPENCODE_DB",
+  "OPENCODE_HTTPAPI_EXERCISE_DB",
+  "OPENCODE_HTTPAPI_EXERCISE_GLOBAL",
+  "OPENCODE_DISABLE_SHARE",
+  "XDG_DATA_HOME",
+  "XDG_CONFIG_HOME",
+  "XDG_STATE_HOME",
+  "XDG_CACHE_HOME",
+] as const
+const savedEnv: Record<string, string | undefined> = {}
+const savedFlagDb = Flag.OPENCODE_DB
+
+for (const key of envKeys) {
+  savedEnv[key] = process.env[key]
+}
+
+process.env.OPENCODE_HTTPAPI_EXERCISE_DB = exerciseDb
+process.env.OPENCODE_HTTPAPI_EXERCISE_GLOBAL = exerciseGlobal
+
+const { createExitBackstop, exitBackstop, runMainWithHardExit, teardown } = await import("./teardown")
+const { appCache } = await import("./backend")
+
+Flag.OPENCODE_DB = savedFlagDb
+for (const key of envKeys) {
+  const value = savedEnv[key]
+  if (value === undefined) delete process.env[key]
+  else process.env[key] = value
+}
+
+afterAll(async () => {
+  exitBackstop.disarm()
+  const fs = await import("fs/promises")
+  await fs.rm(exerciseDb, { force: true }).catch(() => undefined)
+  await fs.rm(exerciseGlobal, { recursive: true, force: true }).catch(() => undefined)
+})
+
+describe("httpapi-exercise main teardown (#472 regression)", () => {
+  test(
+    "teardown completes when an app dispose never settles",
+    async () => {
+      const poison = {
+        dispose: () => new Promise<void>(() => {}),
+        request: () => {
+          throw new Error("poison app must never serve a request")
+        },
+      } satisfies CachedApp
+      appCache["poison:poison"] = poison
+      try {
+        const outcome = await Promise.race([
+          teardown({}).then(() => "done" as const),
+          Bun.sleep(15_000).then(() => "hung" as const),
+        ])
+        expect(outcome).toBe("done")
+      } finally {
+        delete appCache["poison:poison"]
+      }
+    },
+    { timeout: 20_000 },
+  )
+
+  test("armed backstop forces exit when settlement stalls", async () => {
+    const exits: number[] = []
+    const backstop = createExitBackstop((code) => exits.push(code), 100)
+    backstop.arm()
+    await Bun.sleep(300)
+    expect(exits).toEqual([1])
+  })
+
+  test("disarm cancels the forced exit", async () => {
+    const exits: number[] = []
+    const backstop = createExitBackstop((code) => exits.push(code), 100)
+    backstop.arm()
+    backstop.disarm()
+    await Bun.sleep(200)
+    expect(exits).toEqual([])
+  })
+
+  test("runMainWithHardExit exits 0 when the main fiber settles", async () => {
+    const exits: number[] = []
+    runMainWithHardExit(Promise.resolve("settled"), (code) => exits.push(code))
+    await Bun.sleep(50)
+    expect(exits).toEqual([0])
+  })
+
+  test("runMainWithHardExit exits 1 when the main fiber rejects", async () => {
+    const exits: number[] = []
+    runMainWithHardExit(Promise.reject(new Error("boom")), (code) => exits.push(code))
+    await Bun.sleep(50)
+    expect(exits).toEqual([1])
+  })
+})

--- a/packages/opencode/test/server/httpapi-exercise/teardown.ts
+++ b/packages/opencode/test/server/httpapi-exercise/teardown.ts
@@ -1,0 +1,56 @@
+import { Effect } from "effect"
+import { message } from "./assertions"
+import { disposeApps } from "./backend"
+import { cleanupExercisePaths } from "./environment"
+import { color } from "./report"
+import { bounded } from "./runner"
+import { type Options } from "./types"
+
+export async function teardown(options: Pick<Options, "heartbeat">) {
+  // Main-scope twin of resetState's bounded cleanup: a dispose stalled on a
+  // ref'd outbound socket must degrade into a loud warning, not hang the whole
+  // composite `&&` chain (issue #472). Arming the backstop here — not at
+  // startup — because the scenario run itself may legitimately take minutes.
+  exitBackstop.arm()
+  await bounded("disposeApps", () => disposeApps(options.heartbeat))
+  options.heartbeat?.("teardown: cleanupExercisePaths")
+  await bounded("cleanupExercisePaths", () => Effect.runPromise(cleanupExercisePaths))
+  options.heartbeat?.("teardown: complete")
+}
+
+export const HARD_EXIT_TIMEOUT_MS = 30_000
+
+// process.exit must not depend on the main fiber settling: even with bounded
+// teardown, a ref'd socket can keep the event loop alive past settlement. The
+// wall-clock backstop guarantees the process always reaches an exit.
+export function createExitBackstop(exit: (code: number) => void, ms = HARD_EXIT_TIMEOUT_MS) {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  return {
+    arm() {
+      timer ??= setTimeout(() => {
+        console.error(`[cleanup] main scope settlement exceeded ${ms}ms — forcing exit`)
+        exit(1)
+      }, ms)
+    },
+    disarm() {
+      clearTimeout(timer)
+      timer = undefined
+    },
+  }
+}
+
+export const exitBackstop = createExitBackstop((code) => process.exit(code))
+
+export function runMainWithHardExit(main: Promise<unknown>, exit: (code: number) => void) {
+  main.then(
+    () => {
+      exitBackstop.disarm()
+      exit(0)
+    },
+    (error: unknown) => {
+      exitBackstop.disarm()
+      console.error(`${color.red}${message(error)}${color.reset}`)
+      exit(1)
+    },
+  )
+}


### PR DESCRIPTION
Closes #472

## Why

`bun run test:httpapi:ci` hangs indefinitely on macOS. Root cause (proven in the debug artifact): the harness main-scope finalizer ran `disposeApps` **unbounded**, and `process.exit` was only reachable after `runPromise` settled. When the auth leg's shared layer build leaves stalled/ref'd outbound TLS sockets (models.dev, registry.npmjs.org), `web.dispose()` never settles → `runPromise` never settles → `process.exit` never runs → Bun stays alive on the ref'd sockets → the composite `&&` chain blocks forever. The repo already bounded `resetState`'s cleanup after the 2026-07-27 CI incident (`runner.ts`), but the main finalizer never received the same treatment.

## What changed

- `teardown.ts` (new): main-scope teardown extracted and made bounded — `disposeApps` and `cleanupExercisePaths` wrapped in the existing `bounded()` pattern (10s cap, loud `[cleanup] ... exceeded` warning on timeout), mirroring `resetState`.
- `teardown.ts`: wall-clock exit backstop (`createExitBackstop`, 30s) armed **when teardown starts** — not at startup, because the scenario run may legitimately take minutes — so `process.exit` no longer depends on `runPromise` settlement. `runMainWithHardExit` disarms it on settle and preserves the 0/1 exit-code contract.
- `index.ts`: finalizer now calls `teardown(options)`; tail wires `runMainWithHardExit`. Scenarios, fail-on flags, watchdog and heartbeat sequence unchanged.
- `backend.ts`/`runner.ts`: export `appCache`/`CachedApp`/`bounded` (same-directory harness seams for the regression test).
- `teardown.test.ts` (new): regression coverage.

## Evidence

- **RED (sensitive)**: with the raw (unbounded) teardown, `bun test test/server/httpapi-exercise/teardown.test.ts` fails — poison dispose hangs teardown (timeout) and exit is never called (expected `[1]`, got `[]`). Timeout/forced-exit counted as failure, never success.
- **GREEN**: same test — poison teardown completes at ~10.0s after `[cleanup] disposeApps exceeded 10000ms — forcing continuation (resource may leak)`; backstop forces exit on stalled settlement; disarm cancels; 0/1 paths verified. 5/5 pass.
- **Composite ×2 (post-fix)**: `bun run test:httpapi:ci` exit 0 twice; all three legs `pass=230 fail=0 skip=0 missing=0 extra=0`. Composite #3 live-fired the exact reported trigger: the auth leg hit a real dispose stall → bounded warning → clean exit → `&&` chain continued (previously the hang point).
- **Standalone controls**: coverage and auth legs pass individually with `--fail-on-missing --fail-on-skip`; effect leg verified in both composites (`--progress --trace`).
- **Gates**: `bun typecheck` (packages/opencode) exit 0; root `bun run lint` exit 0 (4840 < 4850 budget, 0 errors, no new warnings); pre-commit ran full-workspace typecheck 29/29.

## Checklist

- [x] Root cause proven, fix limited to the harness-owned defect
- [x] Regression check fails without the repair (timeout = failure)
- [x] Scenarios and fail-on flags preserved (`--fail-on-missing --fail-on-skip` untouched)
- [x] No product `src/` changes; harness-only (`test/server/httpapi-exercise/`)
