### PR TITLE
chore(specgit): refresh delivery harness

### DIFF
--- a/.opencode/command/specgit-issue.md
+++ b/.opencode/command/specgit-issue.md
@@ -13,17 +13,18 @@ AGENTS.md SpecGit block; this command only launches it.
 
 1. Collect the argument: `$ARGUMENTS` is either an issue title (create) or a
    pure number (reuse). Multiple arguments = N issues in one delivery.
-2. Run from the repo root:
+2. Run from the repo root — keep `$ARGUMENTS` UNQUOTED so each quoted title
+   arrives as its own argument:
 
    ```bash
-   specgit issue "$ARGUMENTS" --json
+   specgit issue $ARGUMENTS --json
    ```
 
 3. On success report the brief: issue URL(s), PR URL (draft), branch name —
    then fill each issue body it created (Why / Scope / Approach /
    Acceptance) from the discussion with `gh issue edit <n>`, then
    implement. Fill in the draft PR's scaffold (Why / What changed /
-   Evidence) as you deliver; its placeholders are advisory, never gates,
-   and the closing references stay intact.
+   Evidence / Checklist) as you deliver; its placeholders are advisory,
+   never gates, and the closing references stay intact.
 4. Switch to the delivery branch and begin the TDD loop.
 5. On error, read `errors[].fix` and follow it — never bypass the record.

--- a/.opencode/hooks/specgit-merge-guard.sh
+++ b/.opencode/hooks/specgit-merge-guard.sh
@@ -26,7 +26,7 @@ esac
 command=$(printf '%s' "$payload" | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{try{const j=JSON.parse(s);process.stdout.write((j.tool_input&&j.tool_input.command)||'')}catch{process.stdout.write('')}})")
 
 case "$command" in
-  gh\ pr\ merge*)
+  gh\ pr\ merge*|glab\ mr\ merge*)
     exec node -e '
       const { spawn } = require("child_process");
       const fs = require("fs");

--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -1,11 +1,11 @@
 version: 1
-delivery: tui-crashes-on
+delivery: refresh-specgit-harness
 context:
   kind: branch
-  branch: fix/465-tui-crashes-on
+  branch: chore/refresh-specgit-harness
 issues:
-  - 465
+  - 488
 issueKinds:
-  - issue: 465
-    kind: kind::fix
-pr: 466
+  - issue: 488
+    kind: kind::chore
+pr: 489


### PR DESCRIPTION
Closes #488

## Why

The checked-in generated SpecGit harness conflicts with the installed `specgit` 1.10.1, so `specgit issue` is blocked on fresh feature worktrees — preventing independent deliveries for #433 and #435. This refreshes the harness against 1.10.1 while preserving every repository-specific acceptance-workflow specialization documented in AGENTS.md.

## What changed

- `specgit init --force` re-run with 1.10.1 in a clean worktree on this branch.
- `spec_git/policy.yaml`, the AGENTS.md/CLAUDE.md managed blocks, and `.opencode/hooks.json`: 1.10.1 output is byte-identical — no commit needed. The curated `required_checks` (`Typecheck`, `Unit Tests (linux)`) are preserved by design (#310: a no-argument `init --force` never replaces a working policy). The canonical ids (`unit-tests`/`e2e-tests`) stay out of the policy: they are not observable check-run names on the main-line CI matrix, so the acceptance waiter could never see them (b6473cc2c8, re-affirmed by 29e876ac2c).
- `.github/workflows/specgit-accept.yml`: kept the repository-specialized workflow verbatim —
  - no `workflow_dispatch` trigger (main-only `pull_request`),
  - head-ref checkout retained with `persist-credentials: false`,
  - global `npm install -g specgit@^0.5.0` (the template's `npm install --no-save specgit@1.10.1` reads this bun workspace's `package.json` and dies on the `catalog:` protocol — #434/#459),
  - yaml-free wait step with the proven 40min inline deadline / 45min job timeout. The 1.10.1 template variant `import`s `yaml` with no dependency installed in CI and waits only 13min — shorter than the ~28min Unit Tests sibling (6a3f3b22be, 8d5bb3dca9, 43d6915647).
- `.opencode/hooks/specgit-merge-guard.sh`: the only committed change — takes the 1.10.1 improvement, the merge guard now also blocks `glab mr merge`, not only `gh pr merge`.
- `.husky/_/pre-push`: untracked local pre-push guard (untracked model, ignored by husky on next install) — not committed.

## Evidence

- `specgit doctor --json` → `status: ok`, `exit: 0` (git / repo / origin / gh_authenticated / policy "2 required check(s)" all green).
- `specgit init --force` output confirms: "Preserved the required checks from the existing policy … this run is a version upgrade of the generated assets, not a policy re-birth."
- Post-init `git diff` reduced to the single merge-guard line; the acceptance workflow was restored byte-for-byte to the pre-init baseline carrying all four documented deviations.
- Guard hook passes `sh -n`.

## Checklist

- [x] No product source changed.
- [x] No unrelated CI touched.
- [x] Policy checks preserved, gate not weakened.
- [x] `specgit doctor --json` exits 0.
