### PR TITLE
feat(tui): project-level discovery fallback for /dag inspector

### DIFF
--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -6,3 +6,4 @@ context:
   branch: feat/435-dag-project-discovery
 issues:
   - 435
+pr: 490

--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -1,11 +1,8 @@
 version: 1
-delivery: refresh-specgit-harness
+delivery: dag-project-discovery
 context:
-  kind: branch
-  branch: chore/refresh-specgit-harness
+  kind: worktree
+  label: issue-435-delivery
+  branch: feat/435-dag-project-discovery
 issues:
-  - 488
-issueKinds:
-  - issue: 488
-    kind: kind::chore
-pr: 489
+  - 435

--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -1,8 +1,7 @@
 version: 1
 delivery: dag-project-discovery
 context:
-  kind: worktree
-  label: issue-435-delivery
+  kind: branch
   branch: feat/435-dag-project-discovery
 issues:
   - 435

--- a/packages/tui/src/feature-plugins/system/dag-inspector-utils.ts
+++ b/packages/tui/src/feature-plugins/system/dag-inspector-utils.ts
@@ -4,7 +4,7 @@
 /** Pure topology helpers for the DAG inspector. Extracted for unit testing,
  * mirroring the diff-viewer-file-tree-utils pattern in this directory. */
 
-import type { DagNode } from "@opencode-ai/sdk/v2"
+import type { DagNode, DagWorkflowSummary } from "@opencode-ai/sdk/v2"
 
 export type { DagNode }
 
@@ -199,4 +199,42 @@ export function dagControlProgressMessage(operation: DagControlOperation) {
   if (operation === "resume") return "Resuming workflow..."
   if (operation === "step") return "Stepping workflow..."
   return "Cancelling workflow..."
+}
+
+/**
+ * Unique owning sessions of a project-level workflow list, preserving the
+ * list's order. The summary endpoint is session-scoped, so discovery groups
+ * the flat `GET /dag` rows by `session_id` before fetching summaries.
+ */
+export function dagWorkflowSessions(workflows: ReadonlyArray<{ session_id: string }>): string[] {
+  const seen = new Set<string>()
+  const sessions: string[] = []
+  for (const workflow of workflows) {
+    if (seen.has(workflow.session_id)) continue
+    seen.add(workflow.session_id)
+    sessions.push(workflow.session_id)
+  }
+  return sessions
+}
+
+/**
+ * Merge per-session summary lists into one row set ordered by the project
+ * list, dropping summaries for workflows the list no longer reports. Rows
+ * keep the list's identity as the source of truth — a session-scoped summary
+ * can legitimately lag a concurrent cancel.
+ */
+export function mergeDagWorkflowSummaries(
+  list: ReadonlyArray<{ id: string }>,
+  summaries: ReadonlyArray<ReadonlyArray<DagWorkflowSummary>>,
+): DagWorkflowSummary[] {
+  const byID = new Map<string, DagWorkflowSummary>()
+  for (const rows of summaries) {
+    for (const row of rows) byID.set(row.id, row)
+  }
+  const merged: DagWorkflowSummary[] = []
+  for (const workflow of list) {
+    const row = byID.get(workflow.id)
+    if (row) merged.push(row)
+  }
+  return merged
 }

--- a/packages/tui/src/feature-plugins/system/dag-inspector.tsx
+++ b/packages/tui/src/feature-plugins/system/dag-inspector.tsx
@@ -18,11 +18,13 @@ import {
   dagNodeGlyph,
   dagNodeHistoryLabel,
   dagStatusColor,
+  dagWorkflowSessions,
   formatDagDeadline,
   formatDagDuration,
   formatDagError,
   formatDagOutputPreview,
   formatDagProgress,
+  mergeDagWorkflowSummaries,
   dagEscalationLabel,
   type DagControlOperation,
   type DagNode,
@@ -111,6 +113,33 @@ function cancelActiveWorkflow(api: TuiPluginApi) {
     })
 }
 
+// Project-level discovery: the inspector's workflow list must not depend on
+// the route's sessionID chain, so a missing or stale link can never produce
+// a zero-request empty state. The flat project list groups by owning session
+// for the session-scoped summary endpoint; one dead session must not kill
+// the whole discovery.
+async function discoverProjectWorkflows(
+  api: TuiPluginApi,
+  timeoutMs: number,
+): Promise<{ summaries: DagWorkflowSummary[]; sessionByWorkflow: Map<string, string> }> {
+  const response = await withTimeout(api.client.dag.list(), timeoutMs)
+  const workflows = response.data ?? []
+  const grouped = await Promise.all(
+    dagWorkflowSessions(workflows).map(async (sessionID) => {
+      try {
+        const summaries = await withTimeout(api.client.dag.summary({ sessionID }), timeoutMs)
+        return summaries.data ?? []
+      } catch {
+        return []
+      }
+    }),
+  )
+  return {
+    summaries: mergeDagWorkflowSummaries(workflows, grouped),
+    sessionByWorkflow: new Map(workflows.map((workflow) => [workflow.id, workflow.session_id])),
+  }
+}
+
 function DagInspector(props: { api: TuiPluginApi }) {
   const theme = () => props.api.theme.current
   // The plugin-facing theme omits the resolver flags selectedForeground needs,
@@ -131,56 +160,94 @@ function DagInspector(props: { api: TuiPluginApi }) {
   const [selectedNode, setSelectedNode] = createSignal<string | undefined>(undefined)
   const [nodes, setNodes] = createSignal<DagNode[]>([])
   const [fetchedWorkflows, setFetchedWorkflows] = createSignal<ReadonlyArray<DagWorkflowSummary> | undefined>()
+  const [projectWorkflows, setProjectWorkflows] = createSignal<ReadonlyArray<DagWorkflowSummary>>([])
   const [workflowLoad, setWorkflowLoad] = createSignal<"loading" | "loaded" | "error">("loading")
   const [actionMessage, setActionMessage] = createSignal<string | undefined>()
+  // Owning session per discovered workflow — plain lookup for the summary
+  // event gate, which is scoped to the selected workflow's session, not the
+  // route's. Rebuilt on every discovery run.
+  const sessionByWorkflow = new Map<string, string>()
   let workflowScroll: ScrollBoxRenderable | undefined
   let nodeScroll: ScrollBoxRenderable | undefined
 
   const workflows = createMemo(() => {
+    // Session-scoped live data wins when the route names a session; the
+    // project-level discovery is the floor that keeps the list populated
+    // when that chain is broken, stale, or absent.
     const sid = params()?.sessionID
-    if (!sid) return []
-    const synced = props.api.state.session.dag(sid)
-    return synced.length > 0 ? synced : (fetchedWorkflows() ?? [])
+    if (sid) {
+      const synced = props.api.state.session.dag(sid)
+      if (synced.length > 0) return synced
+      const fetched = fetchedWorkflows()
+      if (fetched && fetched.length > 0) return fetched
+    }
+    return projectWorkflows()
   })
 
   // Refresh authoritative state when the inspector opens. Summary events are
   // ephemeral, so the shared sync slice can legitimately be empty after a
-  // missed event even though the workflow exists on the server.
+  // missed event even though the workflow exists on the server. Project
+  // discovery runs on every mount — it is the one source that does not
+  // depend on the route's sessionID.
   createEffect(() => {
     const sessionID = params()?.sessionID
     setFetchedWorkflows([])
+    setProjectWorkflows([])
+    sessionByWorkflow.clear()
     setSelectedWorkflow(undefined)
     setSelectedNode(undefined)
     setNodes([])
     setActionMessage(undefined)
-    if (!sessionID) {
-      setWorkflowLoad("loaded")
-      return
-    }
     let disposed = false
-    let attemptsLeft = 1
+    let pendingSources = sessionID ? 2 : 1
+    let anySourceLoaded = false
     onCleanup(() => {
       disposed = true
     })
-    const attempt = () => {
-      void withTimeout(props.api.client.dag.summary({ sessionID }), fetchTimeoutMs(props.api))
-        .then((response) => {
-          if (disposed || params()?.sessionID !== sessionID) return
-          setFetchedWorkflows(response.data ?? [])
-          setWorkflowLoad("loaded")
+    const settle = (loaded: boolean) => {
+      if (disposed) return
+      pendingSources -= 1
+      anySourceLoaded = anySourceLoaded || loaded
+      if (pendingSources === 0) setWorkflowLoad(anySourceLoaded ? "loaded" : "error")
+    }
+    const attemptDiscovery = (attemptsLeft: number) => {
+      void withTimeout(discoverProjectWorkflows(props.api, fetchTimeoutMs(props.api)), fetchTimeoutMs(props.api))
+        .then((discovered) => {
+          if (disposed) return
+          setProjectWorkflows(discovered.summaries)
+          for (const [workflowID, owner] of discovered.sessionByWorkflow) {
+            sessionByWorkflow.set(workflowID, owner)
+          }
+          settle(true)
         })
         .catch(() => {
-          if (disposed || params()?.sessionID !== sessionID) return
+          if (disposed) return
           if (attemptsLeft > 0) {
-            attemptsLeft -= 1
-            setTimeout(attempt, RETRY_DELAY_MS)
+            setTimeout(() => attemptDiscovery(attemptsLeft - 1), RETRY_DELAY_MS)
             return
           }
-          setWorkflowLoad("error")
+          settle(false)
+        })
+    }
+    const attemptSession = (session: string, attemptsLeft: number) => {
+      void withTimeout(props.api.client.dag.summary({ sessionID: session }), fetchTimeoutMs(props.api))
+        .then((response) => {
+          if (disposed || params()?.sessionID !== session) return
+          setFetchedWorkflows(response.data ?? [])
+          settle(true)
+        })
+        .catch(() => {
+          if (disposed || params()?.sessionID !== session) return
+          if (attemptsLeft > 0) {
+            setTimeout(() => attemptSession(session, attemptsLeft - 1), RETRY_DELAY_MS)
+            return
+          }
+          settle(false)
         })
     }
     setWorkflowLoad("loading")
-    attempt()
+    attemptDiscovery(1)
+    if (sessionID) attemptSession(sessionID, 1)
   })
 
   // Keep a valid workflow selected: adopt the first workflow when nothing is
@@ -211,10 +278,11 @@ function DagInspector(props: { api: TuiPluginApi }) {
   let lastSignature = ""
 
   const signatureFor = (wfId: string): string => {
+    // The sync slice is read directly — event handlers fire outside any
+    // reactive scope, so a memoized read could serve a stale signature.
     const sid = params()?.sessionID
-    if (!sid) return ""
-    const wfs = props.api.state.session.dag(sid)
-    const wf = wfs.find((w) => w.id === wfId)
+    const wf = (sid ? props.api.state.session.dag(sid) : []).find((w) => w.id === wfId) ??
+      workflows().find((w) => w.id === wfId)
     if (!wf) return ""
     return `${wf.nodeCount}:${wf.completedNodes}:${wf.runningNodes}:${wf.failedNodes}`
   }
@@ -230,12 +298,13 @@ function DagInspector(props: { api: TuiPluginApi }) {
     // open has something to compare against.
     lastSignature = signatureFor(wf)
     void fetchNodes(wf)
-    // Re-fetch nodes only when a summary event for THIS session indicates the
-    // selected workflow's node-level state changed. Summary events for other
-    // sessions and unchanged summaries do not trigger a fetch.
-    const sid = params()?.sessionID
+    // Re-fetch nodes only when a summary event for the selected workflow's
+    // owning session indicates the workflow's node-level state changed.
+    // Project discovery supplies the owning session when the route carries
+    // no sessionID; events for other sessions never trigger a fetch.
+    const owner = sessionByWorkflow.get(wf) ?? params()?.sessionID
     const off = props.api.event.on("dag.workflow.summary.updated", (event) => {
-      if (!sid || event.properties.sessionID !== sid) return
+      if (!owner || event.properties.sessionID !== owner) return
       const sig = signatureFor(wf)
       if (sig === lastSignature) return
       lastSignature = sig
@@ -547,7 +616,7 @@ function DagInspector(props: { api: TuiPluginApi }) {
               <Match when={!params()?.sessionID && workflows().length === 0}>
                 <box marginTop={1}>
                   <text fg={theme().textMuted}>
-                    {"No session context — reopen /dag from within a conversation."}
+                    {"No DAG workflows in this project — run /dag-auto <task> to start an orchestration."}
                   </text>
                 </box>
               </Match>

--- a/packages/tui/test/feature-plugins/dag-inspector-utils.test.ts
+++ b/packages/tui/test/feature-plugins/dag-inspector-utils.test.ts
@@ -8,11 +8,13 @@ import {
   dagNodeGlyph,
   dagNodeHistoryLabel,
   dagStatusColor,
+  dagWorkflowSessions,
   formatDagDeadline,
   formatDagDuration,
   formatDagError,
   formatDagOutputPreview,
   formatDagProgress,
+  mergeDagWorkflowSummaries,
   type DagNode,
 } from "../../src/feature-plugins/system/dag-inspector-utils"
 
@@ -175,5 +177,46 @@ describe("node detail formatting", () => {
   test("progress counts completed+skipped as settled (P2-9)", () => {
     expect(formatDagProgress({ nodeCount: 9, completedNodes: 3, skippedNodes: 4 })).toBe("7/9")
     expect(formatDagProgress({ nodeCount: 2, completedNodes: 0, skippedNodes: 0 })).toBe("0/2")
+  })
+})
+
+describe("dagWorkflowSessions", () => {
+  test("keeps first-seen order and drops duplicate owners", () => {
+    expect(
+      dagWorkflowSessions([{ session_id: "b" }, { session_id: "a" }, { session_id: "b" }]),
+    ).toEqual(["b", "a"])
+  })
+
+  test("empty list yields no sessions", () => {
+    expect(dagWorkflowSessions([])).toEqual([])
+  })
+})
+
+describe("mergeDagWorkflowSummaries", () => {
+  const summary = (id: string) => ({
+    id,
+    title: id,
+    status: "running",
+    nodeCount: 1,
+    completedNodes: 0,
+    runningNodes: 1,
+    failedNodes: 0,
+    skippedNodes: 0,
+    queuedNodes: 0,
+    escalatedNodes: 0,
+  })
+
+  test("orders merged rows by the project list and keeps the list as source of truth", () => {
+    const merged = mergeDagWorkflowSummaries([{ id: "b" }, { id: "a" }], [[summary("b")], [summary("a")]])
+    expect(merged.map((row) => row.id)).toEqual(["b", "a"])
+  })
+
+  test("drops summaries for workflows the list no longer reports", () => {
+    const merged = mergeDagWorkflowSummaries([{ id: "a" }], [[summary("a"), summary("ghost")]])
+    expect(merged.map((row) => row.id)).toEqual(["a"])
+  })
+
+  test("empty discovery inputs merge to nothing", () => {
+    expect(mergeDagWorkflowSummaries([], [])).toEqual([])
   })
 })

--- a/packages/tui/test/feature-plugins/dag-inspector.test.tsx
+++ b/packages/tui/test/feature-plugins/dag-inspector.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, test } from "bun:test"
 import { createDefaultOpenTuiKeymap } from "@opentui/keymap/opentui"
 import { testRender, useRenderer } from "@opentui/solid"
 import type { TuiPluginApi, TuiRouteCurrent, TuiRouteDefinition } from "@opencode-ai/plugin/tui"
-import type { DagNode, DagWorkflowSummary } from "@opencode-ai/sdk/v2"
+import type { DagNode, DagWorkflow, DagWorkflowSummary } from "@opencode-ai/sdk/v2"
 import { KVProvider } from "../../src/context/kv"
 import { ThemeProvider } from "../../src/context/theme"
 import { TuiConfigProvider } from "../../src/config"
@@ -33,12 +33,24 @@ const wfSummary = (overrides: Partial<DagWorkflowSummary> = {}): DagWorkflowSumm
 type RenderOpts = {
   workflows?: DagWorkflowSummary[]
   serverWorkflows?: DagWorkflowSummary[]
+  projectWorkflows?: DagWorkflow[]
   nodes?: DagNode[]
   initialRoute?: TuiRouteCurrent
   summary?: (sessionID: string) => Promise<{ data: DagWorkflowSummary[] }>
   fetchTimeoutMs?: number
   width?: number
 }
+
+const projectWorkflow = (overrides: Partial<DagWorkflow> & { id: string; session_id: string }): DagWorkflow => ({
+  project_id: "proj_1",
+  title: `Workflow ${overrides.id}`,
+  status: "running",
+  config: "{}",
+  seq: 1,
+  time_created: 0,
+  time_updated: 0,
+  ...overrides,
+})
 
 function dagNode(overrides: Partial<DagNode> & { id: string }): DagNode {
   return {
@@ -69,6 +81,7 @@ async function renderDagInspector(opts: RenderOpts = {}) {
   // Trackable spies
   const nodesCalls: string[] = []
   const summaryCalls: string[] = []
+  let listCalls = 0
   const controlCalls: { dagID: string; operation: string }[] = []
   const commandCalls: unknown[] = []
   const navigations: { name: string; params?: Record<string, unknown> }[] = []
@@ -89,6 +102,10 @@ async function renderDagInspector(opts: RenderOpts = {}) {
       keymap,
       client: {
         dag: {
+          list: async () => {
+            listCalls += 1
+            return { data: opts.projectWorkflows ?? [] }
+          },
           summary: async (input: { sessionID: string }) => {
             summaryCalls.push(input.sessionID)
             return opts.summary?.(input.sessionID) ?? { data: opts.serverWorkflows ?? workflowsState }
@@ -181,6 +198,7 @@ async function renderDagInspector(opts: RenderOpts = {}) {
     toasts: () => toasts,
     nodesCalls: () => nodesCalls,
     summaryCalls: () => summaryCalls,
+    listCalls: () => listCalls,
     controlCalls: () => controlCalls,
     setWorkflows: (wfs: DagWorkflowSummary[]) => {
       workflowsState = wfs
@@ -693,11 +711,59 @@ describe("DagInspector", () => {
     }
   })
 
-  test("explains missing session context instead of pretending there are no workflows", async () => {
+  test("lists project workflows when the route has no session context", async () => {
+    const viewer = await renderDagInspector({
+      initialRoute: { name: "dag" },
+      projectWorkflows: [
+        projectWorkflow({ id: "wf-p1", session_id: "ses_a", title: "Orphan discovery", status: "running" }),
+        projectWorkflow({ id: "wf-p2", session_id: "ses_b", title: "Other session", status: "completed" }),
+      ],
+      summary: (sessionID) =>
+        Promise.resolve({
+          data:
+            sessionID === "ses_a"
+              ? [wfSummary({ id: "wf-p1", title: "Orphan discovery", status: "running" })]
+              : [],
+        }),
+    })
+    try {
+      // Discovery renders workflows from any session when the route carries
+      // no sessionID — the zero-request empty state is gone.
+      await viewer.app.waitForFrame((frame) => frame.includes("Orphan discovery"))
+      // Workflows group by owning session for the session-scoped summary; a
+      // dead session resolves empty without failing the whole discovery.
+      expect(viewer.summaryCalls()).toEqual(["ses_a", "ses_b"])
+    } finally {
+      viewer.app.renderer.destroy()
+    }
+  })
+
+  test("falls back to project discovery when the routed session has no workflows", async () => {
+    const viewer = await renderDagInspector({
+      projectWorkflows: [projectWorkflow({ id: "wf-p1", session_id: "ses_other" })],
+      summary: (sessionID) =>
+        Promise.resolve({
+          data:
+            sessionID === SESSION_ID
+              ? []
+              : [wfSummary({ id: "wf-p1", title: "Discovered elsewhere", status: "running" })],
+        }),
+    })
+    try {
+      await viewer.app.waitForFrame((frame) => frame.includes("Discovered elsewhere"))
+    } finally {
+      viewer.app.renderer.destroy()
+    }
+  })
+
+  test("without session context the empty state stays honest about what was consulted", async () => {
     const viewer = await renderDagInspector({ initialRoute: { name: "dag" } })
     try {
-      await viewer.app.waitForFrame((frame) => frame.includes("No session context"))
-      // The no-context branch is local-only; it must not touch the server.
+      await viewer.app.waitForFrame((frame) => frame.includes("No DAG workflows"))
+      // The project list is the discovery source that does not depend on the
+      // route's sessionID chain — it is consulted even without a session,
+      // while session summaries never run (an empty list has no sessions).
+      expect(viewer.listCalls()).toBe(1)
       expect(viewer.summaryCalls()).toEqual([])
     } finally {
       viewer.app.renderer.destroy()


### PR DESCRIPTION
Closes #435

## Why

/dag inspector data discovery depended entirely on the sessionID inherited through route params (`dag.open` reads `route.current.params`). Any missing link in that chain produced a zero-request silent empty state. #427 added the conservative fix (timeout + retry + honest copy), but the project-level `GET /dag` endpoint remained unused.

## What changed

- On mount the inspector runs project-level discovery via `client.dag.list`, independent of the route's sessionID: rows group by owning session (`dagWorkflowSessions`) for the session-scoped summary endpoint, then merge back ordered by the project list (`mergeDagWorkflowSummaries`) — both pure helpers in `dag-inspector-utils.ts` with unit tests.
- The routed sessionID demotes from a hard gate to a live-data preference: the session sync slice and session summary still win when they have data; project discovery is the floor, so running workflows stay listed without session context — and when the routed session legitimately has none.
- The summary-event gate resolves the selected workflow's owning session from discovery (`sessionByWorkflow`) when the route carries no sessionID; `signatureFor` reads the sync slice directly at event time (a memoized read served stale signatures outside reactive scopes).
- Honest empty states: no session context plus an empty project now reads "No DAG workflows in this project…" instead of claiming the inspector cannot work without a session; the session-scoped empty copy is unchanged.

## Evidence

- `bun test test/feature-plugins/dag-inspector-utils.test.ts test/feature-plugins/dag-inspector.test.tsx` (packages/tui): 54 pass, 0 fail — including new coverage: project listing without session context (grouped summary calls asserted, dead session tolerated), project fallback when the routed session has no workflows, and the honest empty state (list consulted exactly once, zero summary calls without sessions).
- `bun typecheck` (packages/tui) clean; full-repo `bun turbo typecheck` green via the pre-push hook (29/29 packages).
- oxlint on the four touched files: 6 warnings, exactly the pre-change baseline (lint-warning ratchet unmoved).

## Checklist

- [x] Why, What changed, and Evidence are filled in.
- [ ] `specgit finish` exits 0.
