### PR TITLE
fix: dedupe byte-identical durable event appends without consuming seq

### DIFF
--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -1,8 +1,8 @@
 version: 1
-delivery: summary-diff-continue
+delivery: event-idempotency-gate
 context:
   kind: branch
-  branch: fix/525-summary-diff-continue
+  branch: fix/523-event-idempotency-gate
 issues:
-  - 525
-pr: 526
+  - 523
+pr: 527

--- a/packages/core/schema.json
+++ b/packages/core/schema.json
@@ -1,9 +1,9 @@
 {
   "version": "7",
   "dialect": "sqlite",
-  "id": "abadf28b-1770-46c6-bbf6-b7800a9ca874",
+  "id": "7a2e2a70-584a-4604-bf73-4c6e116c20a3",
   "prevIds": [
-    "874d8e74-d354-4dcb-b98c-c893660c9371"
+    "abadf28b-1770-46c6-bbf6-b7800a9ca874"
   ],
   "ddl": [
     {
@@ -1049,6 +1049,16 @@
       "default": null,
       "generated": null,
       "name": "data",
+      "entityType": "columns",
+      "table": "event"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "data_hash",
       "entityType": "columns",
       "table": "event"
     },

--- a/packages/core/src/database/migration.gen.ts
+++ b/packages/core/src/database/migration.gen.ts
@@ -57,5 +57,6 @@ export const migrations = (
     import("./migration/20260815044858_dag_graph_rev_view"),
     import("./migration/20260815083000_workflow_directory_convergence"),
     import("./migration/20260903044702_drop_session_summary_diffs"),
+    import("./migration/20260903062324_add_event_data_hash"),
   ])
 ).map((module) => module.default) satisfies DatabaseMigration.Migration[]

--- a/packages/core/src/database/migration/20260903062324_add_event_data_hash.ts
+++ b/packages/core/src/database/migration/20260903062324_add_event_data_hash.ts
@@ -1,0 +1,11 @@
+import { Effect } from "effect"
+import type { DatabaseMigration } from "../migration"
+
+export default {
+  id: "20260903062324_add_event_data_hash",
+  up(tx) {
+    return Effect.gen(function* () {
+      yield* tx.run(`ALTER TABLE \`event\` ADD \`data_hash\` text;`)
+    })
+  },
+} satisfies DatabaseMigration.Migration

--- a/packages/core/src/database/schema.gen.ts
+++ b/packages/core/src/database/schema.gen.ts
@@ -149,6 +149,7 @@ export default {
           \`seq\` integer NOT NULL,
           \`type\` text NOT NULL,
           \`data\` text NOT NULL,
+          \`data_hash\` text,
           CONSTRAINT \`fk_event_aggregate_id_event_sequence_aggregate_id_fk\` FOREIGN KEY (\`aggregate_id\`) REFERENCES \`event_sequence\`(\`aggregate_id\`) ON DELETE CASCADE
         );
       `)

--- a/packages/core/src/event.ts
+++ b/packages/core/src/event.ts
@@ -3,13 +3,14 @@ export * as EventV2 from "./event"
 import { Cause, Context, Effect, FiberSet, Layer, Option, PubSub, Schema, Stream } from "effect"
 import { Event } from "@opencode-ai/schema/event"
 import type { Data, Definition, Payload } from "@opencode-ai/schema/event"
-import { and, asc, eq, gt } from "drizzle-orm"
+import { and, asc, desc, eq, gt } from "drizzle-orm"
 import { Database } from "./database/database"
 import { EventSequenceTable, EventTable } from "./event/sql"
 import { Location } from "./location"
 import { LayerNode } from "./effect/layer-node"
 import { isDeepStrictEqual } from "node:util"
 import { Durable } from "@opencode-ai/schema/durable-event-manifest"
+import { Hash } from "./util/hash"
 
 export const ID = Event.ID
 export type ID = import("@opencode-ai/schema/event").ID
@@ -227,6 +228,30 @@ export const layerWith = (options?: LayerOptions) =>
           if (input && row?.ownerID && row.ownerID !== input.ownerID) {
             return undefined
           }
+          const dataHash = Hash.sha256(JSON.stringify(encoded))
+          if (!input) {
+            // Idempotency gate (#523): a fresh append that byte-for-byte repeats
+            // this aggregate's latest same-type event carries zero information
+            // delta. Skip it entirely — no seq consumed, no projectors, no commit
+            // hook, no durable wake — so the persisted sequence stays dense and
+            // both the replayAll contiguity check and gt(seq, after) readers are
+            // unaffected. Replay appends (input) keep their exact-seq contract,
+            // and legacy rows carry a NULL hash so they never match.
+            const previous = yield* db
+              .select({ dataHash: EventTable.data_hash })
+              .from(EventTable)
+              .where(
+                and(
+                  eq(EventTable.aggregate_id, aggregateID),
+                  eq(EventTable.type, versionedType(definition.type, durable.version)),
+                ),
+              )
+              .orderBy(desc(EventTable.seq))
+              .limit(1)
+              .get()
+              .pipe(Effect.orDie)
+            if (previous && previous.dataHash === dataHash) return undefined
+          }
           const seq = input?.seq ?? latest + 1
           if (input && seq !== latest + 1) {
             yield* Effect.die(
@@ -278,6 +303,7 @@ export const layerWith = (options?: LayerOptions) =>
                 seq,
                 type: versionedType(definition.type, durable.version),
                 data: encoded,
+                data_hash: dataHash,
               },
             ])
             .run()
@@ -479,7 +505,9 @@ export const layerWith = (options?: LayerOptions) =>
                 .transaction(
                   () =>
                     Effect.gen(function* () {
-                      const results = new Array<{ aggregateID: string; seq: number }>()
+                      // Aligned with entries by index: a deduped entry yields
+                      // undefined so the payload pairing below stays positional.
+                      const results = new Array<{ aggregateID: string; seq: number } | undefined>()
                       for (const entry of entries) {
                         // No replay input: seq is allocated contiguously from the latest sequence inside the transaction.
                         const result = yield* commitDurableEventInner(
@@ -488,7 +516,7 @@ export const layerWith = (options?: LayerOptions) =>
                           undefined,
                           entry.commit,
                         )
-                        if (result) results.push(result)
+                        results.push(result)
                       }
                       return results
                     }),
@@ -499,19 +527,19 @@ export const layerWith = (options?: LayerOptions) =>
               return results
             }),
           )
-          const payloads = entries.flatMap((entry, index) => {
+          const payloads = entries.map((entry, index) => {
             const result = committed[index]
-            if (!result) return []
-            return [
-              {
-                ...entry.event,
-                durable: {
-                  aggregateID: result.aggregateID,
-                  seq: result.seq,
-                  version: entry.durable.version,
-                },
-              } as Payload,
-            ]
+            // A deduped entry is still notified (mirrors the single-publish
+            // path) but stays unstamped: it occupies no sequence position.
+            if (!result) return entry.event
+            return {
+              ...entry.event,
+              durable: {
+                aggregateID: result.aggregateID,
+                seq: result.seq,
+                version: entry.durable.version,
+              },
+            } as Payload
           })
           for (const payload of payloads) {
             yield* notify(payload)

--- a/packages/core/src/event/sql.ts
+++ b/packages/core/src/event/sql.ts
@@ -17,6 +17,11 @@ export const EventTable = sqliteTable(
     seq: integer().notNull(),
     type: text().notNull(),
     data: text({ mode: "json" }).$type<Record<string, unknown>>().notNull(),
+    // sha256 of the serialized payload, written once at append time. The
+    // idempotency gate compares against the latest same-type row via
+    // event_aggregate_type_seq_idx instead of re-hashing MiB-scale payloads.
+    // Nullable: legacy rows predate the column and never match the gate.
+    data_hash: text(),
   },
   (table) => [
     uniqueIndex("event_aggregate_seq_idx").on(table.aggregate_id, table.seq),

--- a/packages/core/test/event.test.ts
+++ b/packages/core/test/event.test.ts
@@ -10,7 +10,7 @@ import { EventSequenceTable, EventTable } from "@opencode-ai/core/event/sql"
 import { Location } from "@opencode-ai/core/location"
 import { AbsolutePath } from "@opencode-ai/core/schema"
 import { WorkspaceV2 } from "@opencode-ai/core/workspace"
-import { eq } from "drizzle-orm"
+import { asc, eq } from "drizzle-orm"
 import { location } from "./fixture/location"
 import { testEffect } from "./lib/effect"
 
@@ -379,6 +379,238 @@ describe("EventV2", () => {
         .pipe(Effect.orDie)
 
       expect(rows.map((row) => row.seq)).toEqual([0, 1])
+    }),
+  )
+
+  it.effect("skips a byte-identical duplicate of the latest same-type durable event", () =>
+    Effect.gen(function* () {
+      const events = yield* EventV2.Service
+      const { db } = yield* Database.Service
+      const aggregateID = EventV2.ID.create()
+
+      const first = yield* events.publish(SyncMessage, { id: aggregateID, text: "hello" })
+      const duplicate = yield* events.publish(SyncMessage, { id: aggregateID, text: "hello" })
+      const rows = yield* db
+        .select({ seq: EventTable.seq, dataHash: EventTable.data_hash })
+        .from(EventTable)
+        .where(eq(EventTable.aggregate_id, aggregateID))
+        .all()
+        .pipe(Effect.orDie)
+
+      expect(first.durable?.seq).toBe(0)
+      expect(duplicate.durable).toBeUndefined()
+      expect(rows).toHaveLength(1)
+      expect(rows[0]?.dataHash).toHaveLength(64)
+    }),
+  )
+
+  it.effect("keeps the persisted sequence dense when a duplicate is skipped", () =>
+    Effect.gen(function* () {
+      const events = yield* EventV2.Service
+      const { db } = yield* Database.Service
+      const aggregateID = EventV2.ID.create()
+
+      yield* events.publish(SyncMessage, { id: aggregateID, text: "hello" })
+      yield* events.publish(SyncMessage, { id: aggregateID, text: "hello" })
+      const third = yield* events.publish(SyncMessage, { id: aggregateID, text: "world" })
+      const rows = yield* db
+        .select({ seq: EventTable.seq, data: EventTable.data })
+        .from(EventTable)
+        .where(eq(EventTable.aggregate_id, aggregateID))
+        .orderBy(asc(EventTable.seq))
+        .all()
+        .pipe(Effect.orDie)
+
+      expect(third.durable?.seq).toBe(1)
+      expect(rows.map((row) => [row.seq, row.data["text"]])).toEqual([
+        [0, "hello"],
+        [1, "world"],
+      ])
+    }),
+  )
+
+  it.effect("appends when the payload differs from the latest same-type event", () =>
+    Effect.gen(function* () {
+      const events = yield* EventV2.Service
+      const { db } = yield* Database.Service
+      const aggregateID = EventV2.ID.create()
+
+      yield* events.publish(SyncMessage, { id: aggregateID, text: "a" })
+      yield* events.publish(SyncMessage, { id: aggregateID, text: "b" })
+      yield* events.publish(SyncMessage, { id: aggregateID, text: "a" })
+      const rows = yield* db
+        .select({ seq: EventTable.seq })
+        .from(EventTable)
+        .where(eq(EventTable.aggregate_id, aggregateID))
+        .all()
+        .pipe(Effect.orDie)
+
+      expect(rows).toHaveLength(3)
+    }),
+  )
+
+  it.effect("dedupes only against the same aggregate and event type", () =>
+    Effect.gen(function* () {
+      const events = yield* EventV2.Service
+      const { db } = yield* Database.Service
+      const aggregateID = EventV2.ID.create()
+      const otherAggregateID = EventV2.ID.create()
+
+      yield* events.publish(SyncMessage, { id: aggregateID, text: "same" })
+      yield* events.publish(SyncSent, { messageID: aggregateID, text: "same" })
+      yield* events.publish(SyncMessage, { id: otherAggregateID, text: "same" })
+      const own = yield* db
+        .select({ type: EventTable.type })
+        .from(EventTable)
+        .where(eq(EventTable.aggregate_id, aggregateID))
+        .all()
+        .pipe(Effect.orDie)
+      const other = yield* db
+        .select({ seq: EventTable.seq })
+        .from(EventTable)
+        .where(eq(EventTable.aggregate_id, otherAggregateID))
+        .all()
+        .pipe(Effect.orDie)
+
+      expect(new Set(own.map((row) => row.type))).toHaveLength(2)
+      expect(other).toHaveLength(1)
+    }),
+  )
+
+  it.effect("skips duplicates inside a publishMany batch and keeps payloads aligned", () =>
+    Effect.gen(function* () {
+      const events = yield* EventV2.Service
+      const { db } = yield* Database.Service
+      const aggregateID = EventV2.ID.create()
+
+      const payloads = yield* events.publishMany([
+        { definition: SyncMessage, data: { id: aggregateID, text: "a" } },
+        { definition: SyncMessage, data: { id: aggregateID, text: "a" } },
+        { definition: SyncMessage, data: { id: aggregateID, text: "b" } },
+      ])
+      const rows = yield* db
+        .select({ seq: EventTable.seq })
+        .from(EventTable)
+        .where(eq(EventTable.aggregate_id, aggregateID))
+        .all()
+        .pipe(Effect.orDie)
+
+      expect(rows).toHaveLength(2)
+      expect(payloads.map((event) => event.data)).toEqual([
+        { id: aggregateID, text: "a" },
+        { id: aggregateID, text: "a" },
+        { id: aggregateID, text: "b" },
+      ])
+      expect(payloads.map((event) => event.durable?.seq)).toEqual([0, undefined, 1])
+    }),
+  )
+
+  it.effect("runs projectors and commit hooks only for persisted appends", () =>
+    Effect.gen(function* () {
+      const events = yield* EventV2.Service
+      const projected = new Array<EventV2.Payload>()
+      yield* events.project(SyncMessage, (event) =>
+        Effect.sync(() => {
+          projected.push(event)
+        }),
+      )
+      const commits = new Array<number>()
+      const aggregateID = EventV2.ID.create()
+      const publishWithCommit = () =>
+        events.publish(
+          SyncMessage,
+          { id: aggregateID, text: "hello" },
+          { commit: (seq) => Effect.sync(() => commits.push(seq)) },
+        )
+
+      yield* publishWithCommit()
+      yield* publishWithCommit()
+
+      expect(projected.map((event) => event.durable?.seq)).toEqual([0])
+      expect(commits).toEqual([0])
+    }),
+  )
+
+  it.effect("never dedupes against legacy rows with a NULL hash", () =>
+    Effect.gen(function* () {
+      const events = yield* EventV2.Service
+      const { db } = yield* Database.Service
+      const aggregateID = EventV2.ID.create()
+
+      yield* db
+        .insert(EventSequenceTable)
+        .values([{ aggregate_id: aggregateID, seq: 0 }])
+        .run()
+        .pipe(Effect.orDie)
+      yield* db
+        .insert(EventTable)
+        .values([
+          {
+            id: EventV2.ID.create(),
+            aggregate_id: aggregateID,
+            seq: 0,
+            type: EventV2.versionedType(SyncMessage.type, 1),
+            data: { id: aggregateID, text: "legacy" },
+          },
+        ])
+        .run()
+        .pipe(Effect.orDie)
+
+      const published = yield* events.publish(SyncMessage, { id: aggregateID, text: "legacy" })
+      const rows = yield* db
+        .select({ seq: EventTable.seq })
+        .from(EventTable)
+        .where(eq(EventTable.aggregate_id, aggregateID))
+        .all()
+        .pipe(Effect.orDie)
+
+      expect(published.durable?.seq).toBe(1)
+      expect(rows).toHaveLength(2)
+    }),
+  )
+
+  it.effect("replay with an explicit seq is never deduped", () =>
+    Effect.gen(function* () {
+      const events = yield* EventV2.Service
+      const { db } = yield* Database.Service
+      const aggregateID = Session.ID.create()
+
+      yield* events.publish(DurableMessage, durableData(aggregateID, "same"))
+      yield* events.replay({
+        id: EventV2.ID.create(),
+        type: EventV2.versionedType(DurableMessage.type, 1),
+        seq: 1,
+        aggregateID,
+        data: durableData(aggregateID, "same"),
+      })
+      const rows = yield* db
+        .select({ seq: EventTable.seq })
+        .from(EventTable)
+        .where(eq(EventTable.aggregate_id, aggregateID))
+        .all()
+        .pipe(Effect.orDie)
+
+      expect(rows).toHaveLength(2)
+    }),
+  )
+
+  it.effect("durable readers observe only persisted events after a skipped duplicate", () =>
+    Effect.gen(function* () {
+      const events = yield* EventV2.Service
+      const aggregateID = Session.ID.create()
+      yield* events.publish(DurableMessage, durableData(aggregateID, "zero"))
+      const fiber = yield* events
+        .durable({ aggregateID })
+        .pipe(Stream.take(2), Stream.runCollect, Effect.forkScoped)
+      yield* Effect.yieldNow
+
+      yield* events.publish(DurableMessage, durableData(aggregateID, "zero"))
+      yield* events.publish(DurableMessage, durableData(aggregateID, "one"))
+
+      expect(Array.from(yield* Fiber.join(fiber)).map((event) => [event.durable?.seq, event.data])).toEqual([
+        [0, durableData(aggregateID, "zero")],
+        [1, durableData(aggregateID, "one")],
+      ])
     }),
   )
 

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/sync.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/sync.ts
@@ -72,7 +72,13 @@ export const syncHandlers = HttpApiBuilder.group(InstanceHttpApi, "sync", (handl
     const history = Effect.fn("SyncHttpApi.history")(function* (ctx: { payload: typeof HistoryPayload.Type }) {
       const exclude = Object.entries(ctx.payload)
       return yield* db
-        .select()
+        .select({
+          id: EventTable.id,
+          aggregate_id: EventTable.aggregate_id,
+          seq: EventTable.seq,
+          type: EventTable.type,
+          data: EventTable.data,
+        })
         .from(EventTable)
         .where(
           exclude.length > 0


### PR DESCRIPTION
Closes #523

## Why

`481e31e2b7` 闸住 summary.diffs 之后，事件持久化浪费的主因是**会话内逐字节重复写入**：`packages/core/src/event.ts` 的 `.insert(EventTable)`（全仓唯一事件写入点）零重复检测。修复后数据实测（issue #523）：`message.updated.1` 28,059 条 / 208.9 MiB 中 **64.3%（134.3 MiB）是逐字节重复**；`ses_fe5fecc1e45c` 平均每条消息被重发 3.9 次全量快照，信息增量为零。

## What changed

- **`EventTable` 新增 `data_hash` 列**（nullable text，sha256 of 序列化 payload，append 时算一次落列，比对不重算 MiB 级 payload）。Legacy 行 hash 为 NULL 永不匹配 → **零回填**：`ALTER TABLE event ADD data_hash text` 是 O(1) 元数据操作，对生产 8.2 GiB event 表无启动负担
- **幂等闸**（`commitDurableEventInner` fresh-append 路径）：经 `event_aggregate_type_seq_idx` 定位同 `aggregate_id`+`type` 的上一条事件，`data_hash` 相同 → `return undefined` = **完全静默（语义 B，已确认）**：不占 seq、不跑 projectors、不调 commit hook、不 wake durable 流。publisher 收到 unstamped payload —— 与单 publish 既有 unstamped 分支一致；`session/input.ts` admit 已有 `catchDefect → find(stored)` 恢复路径，行为闭环
- **seq 保持连续致密 = 已持久化事件数**。这正是必须选 B 的硬证据：`replayAll`（event.ts:574-585）断言重放序列连续（`start+index`），A 语义（占号留空洞）会让跨实例 sync 重放直接 die
- **replay（显式 input.seq）路径不受闸影响**：跨实例同步的精确 seq 契约、divergence 检测原样保留
- **`publishMany` 对齐修复**：results 改为与 entries 按位对齐（原 `if (result) push` + 按 index 配对在去重产生 undefined 时会给后续 payload 错标 seq）；被去重 entry 仍 notify（unstamped），与单 publish 路径镜像
- **`sync.ts` history 显式列选择**：`data_hash` 不出机器，`/sync/history` 响应形状不变 → 无 SDK 再生成、无 httpapi-exercise 变更
- Migration `20260903053128_add_event_data_hash` + `schema.gen.ts` / `migration.gen.ts` / `schema.json` 再生成（`--check` 干净）

## Evidence

新增 9 个单测（`packages/core/test/event.test.ts`）钉住验收与 B 语义：

- 同 aggregate 连续 publish 相同事件 → 只新增一行，第二次返回 unstamped
- **跳过不占 seq**：dup 后下一事件 seq = prev+1（致密）
- payload 不同 / 被不同事件隔开 → 正常追加；跨 type、跨 aggregate 不去重
- `publishMany` 批内重复 → payload 对齐钉住（`[a→0, a→unstamped, b→1]`）
- projectors / commit hook 只对落库 append 执行
- NULL-hash legacy 行永不匹配；显式 seq replay 永不去重
- durable 流读者只见持久化事件（`gt(seq, after)` 路径）

回归与门禁：

- core `event` + `event-batch` **67 pass**；core 回归 **159 pass**（control-plane/workspace、session-create/projector/prompt/runner/hotpath、database-migration、legacy-event-schema）
- opencode **492 pass**（httpapi-sync、workspace-proxy/routing、`test/session/` 全目录）
- `bun run test:dag-core` **60 pass** + 覆盖率地板全过（DAG 持久化骑在事件层上）
- `bun typecheck`（core + opencode）exit 0；root lint **4839 = dev 基线零新增**
- 三处读取路径核验：core `readAfter`、`sync.ts` replay、`workspace.ts` 均为显式字段映射，新列不外泄
- 实测口径（issue 验收第 5 条）由单测等价覆盖：新增会话中 `message.updated.1` distinct/total → 1（post-fix 基线 0.78）；生产库实测需已装 binary 更新后另行验证，不在本 PR 范围

## Checklist

- [x] Why, What changed, and Evidence are filled in.
- [ ] `specgit finish` exits 0.
