### PR TITLE
chore(specgit): automate bootstrap around required harness specializations

### DIFF
--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -5,3 +5,4 @@ context:
   branch: feat/521-specgit-bootstrap-wrapper
 issues:
   - 521
+pr: 532

--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -1,8 +1,7 @@
 version: 1
-delivery: event-idempotency-gate
+delivery: specgit-bootstrap-wrapper
 context:
   kind: branch
-  branch: fix/523-event-idempotency-gate
+  branch: feat/521-specgit-bootstrap-wrapper
 issues:
-  - 523
-pr: 527
+  - 521

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ feat/**, fix/** ──PR(Typecheck + Unit Tests 门禁)──▶ dev ──push 
 新功能开发、Debug 等一切交付范畴恒定走此循环；后续所有工作必须遵守该方案，不得另起流程：
 
 1. **确立条目**：明确条目的内容、范围、类型（`feat`/`fix`/…）。一个 issue = 一个可独立验证的 WHY，无法独立验证的先拆分再立项。
-2. **SpecGit 立项**：`specgit issue <title-or-number>` 创建/复用 issues 批次，确立交付分支与草稿 PR 脚手架（`.specgit.yaml` 绑定）；立项前先查重，避免同一 WHY 双开。
+2. **SpecGit 立项**：`script/specgit-bootstrap.sh <title-or-number>` 创建/复用 issues 批次，确立交付分支与草稿 PR 脚手架（`.specgit.yaml` 绑定）；立项前先查重，避免同一 WHY 双开。wrapper 是 canonical 入口（见 "SpecGit harness local specializations"）；直跑裸 `specgit issue` 预期被 harness currency gate 以 `harness_stale` (exit 2) 拒绝。
 3. **超流执行**：安排 DAG workflow（超流）承载实现——并行开发 + 多角度 Review + 复合（synthesize），其产出作为交付证据基线。
 4. **PR 过门禁**：SpecGit 发起/推进 PR，过 TDD 与 CI 门禁（Typecheck、Unit Tests、DAG gate；`specgit finish` exit 0 是唯一 "done"）。
 5. **修复门禁问题**：门禁失败在交付分支修代码/测试，永远不削弱门禁本身。
@@ -272,6 +272,15 @@ Kept OUTSIDE the managed block so `specgit init`/`--force` never rewrites them; 
 - `specgit-accept.yml` pins `node-version: '22'` for the wait script and the CLI.
 - The wait script hand-parses `spec_git/policy.yaml` (minimal line-based parse) instead of importing the `yaml` package: no root-reachable `yaml` exists under workspace catalog isolation, so `import { parse } from 'yaml'` would fail to resolve on the runner.
 - `spec_git/policy.yaml` `required_checks` uses the template's canonical check IDs (`unit-tests`, `e2e-tests`), not display names.
+
+#### specgit-bootstrap wrapper (canonical `specgit issue` entry, #521)
+
+`script/specgit-bootstrap.sh <specgit issue args...>` is THE canonical way to run `specgit issue` in this repository. Bare `specgit issue` is expected to fail with `harness_stale` (exit 2) whenever the pinned CLI's harness template moves — the wrapper satisfies that gate safely: it snapshots the full init write surface to a temp dir outside the repo, runs `specgit init --force --no-protect` (hardcoded, offline), then `specgit issue "$@"` with arguments, exit status, and diagnostics passed through verbatim, and restores the specialized bytes above on success and every failure path (EXIT/INT/TERM/HUP), verifying each file byte-for-byte via `git hash-object`.
+
+- Never run bare `specgit init --force` here: it overwrites the six specialized bytes; the wrapper exists to make that refresh transient.
+- Fail-closed rejections: dirty write-surface paths (tracked/staged/untracked) → exit 2 with the offending paths listed; no SpecGit binding (`.specgit.yaml` or `spec_git/policy.yaml` missing) → exit 3; restore hash mismatch → exit 3 with the snapshot kept for forensics. Rejection paths print plain `specgit-bootstrap:` stderr lines and NEVER produce a `--json` envelope.
+- The inner `.specgit.yaml` written by `specgit issue` is a legitimate binding artifact and is never rolled back.
+- Managed-block guidance referencing bare `specgit issue` commands is superseded by this section for this repository. Behavior tests: `bash script/specgit-bootstrap.test.sh` (stubbed CLI, zero network; not CI-wired).
 
 <!-- specgit:block:start -->
 ## SpecGit delivery harness

--- a/script/specgit-bootstrap.sh
+++ b/script/specgit-bootstrap.sh
@@ -1,0 +1,150 @@
+#!/bin/sh
+# specgit-bootstrap — repository-local fail-safe wrapper around `specgit issue` (#521).
+#
+# Why: `specgit issue` (1.10.1) runs an unconditional harness-currency gate that
+# exits 2 (`harness_stale`) unless the managed harness was refreshed by
+# `specgit init --force`. But `init --force` overwrites this repository's six
+# hand-applied specializations (see AGENTS.md, "SpecGit harness local
+# specializations"). This wrapper makes the refresh safe:
+#
+#   1. refuses to run when any init write-surface path has uncommitted changes
+#      (tracked, staged, or untracked), or when the repo has no SpecGit binding;
+#   2. snapshots every existing write-surface path to a temp directory OUTSIDE
+#      the repository, recording each file's `git hash-object` content hash;
+#   3. runs `specgit init --force --no-protect` (hardcoded, offline; init's
+#      stdout prose is routed to stderr so a wrapped `--json` call's stdout
+#      stays exactly one JSON document) then `specgit issue "$@"` with all
+#      arguments preserved verbatim and stdin/stdout/stderr inherited;
+#   4. restores the snapshots on every exit path (EXIT/INT/TERM/HUP) and
+#      verifies each restored file byte-for-byte against the recorded hash;
+#      any mismatch is reported loudly and exits 3.
+#
+# The `.specgit.yaml` binding written/updated by the inner `specgit issue` is a
+# legitimate delivery artifact and is never rolled back. Wrapper rejections
+# print plain stderr lines prefixed `specgit-bootstrap:` — never a `--json`
+# envelope; only the inner CLI receives the wrapped arguments.
+#
+# Usage: script/specgit-bootstrap.sh <specgit issue args...>
+#
+# Write surface below mirrors specgit 1.10.1 harness-placement; it is
+# version-coupled to the pinned CLI in .github/workflows/specgit-accept.yml.
+
+set -u
+
+SURFACE='
+.github/workflows/specgit-accept.yml
+AGENTS.md
+CLAUDE.md
+.opencode/hooks.json
+.opencode/hooks/specgit-merge-guard.sh
+.git/hooks/pre-push
+.husky/_/pre-push
+'
+
+say() {
+  printf 'specgit-bootstrap: %s\n' "$1" >&2
+}
+
+REPO=$(git rev-parse --show-toplevel 2>/dev/null) || {
+  say "not inside a git repository"
+  exit 3
+}
+cd "$REPO" || exit 3
+
+# Fail-closed: serve only bound delivery repositories; a fresh repo has no
+# specializations to protect, so bare `specgit issue` is fine there.
+if [ ! -f .specgit.yaml ] || [ ! -f spec_git/policy.yaml ]; then
+  say "no SpecGit binding (.specgit.yaml / spec_git/policy.yaml missing) - run bare 'specgit issue' instead"
+  exit 3
+fi
+
+# Fail-closed: ambiguous pre-existing changes on the write surface could be
+# clobbered by init and could not be told apart from init's own writes.
+# shellcheck disable=SC2086
+dirty=$(git status --porcelain -- $SURFACE)
+if [ -n "$dirty" ]; then
+  say "refusing to run - init write-surface paths have uncommitted changes (inner CLI NOT executed):"
+  printf '%s\n' "$dirty" | sed 's/^/  /' >&2
+  say "commit or stash those changes first, then retry"
+  exit 2
+fi
+
+SNAP=$(mktemp -d "${TMPDIR:-/tmp}/specgit-bootstrap.XXXXXX") || {
+  say "cannot create snapshot directory under \${TMPDIR:-/tmp}"
+  exit 3
+}
+mkdir "$SNAP/tree" "$SNAP/hashes" || {
+  rm -rf "$SNAP"
+  say "cannot prepare snapshot directory layout"
+  exit 3
+}
+
+# shellcheck disable=SC2086
+for rel in $SURFACE; do
+  [ -f "$rel" ] || continue
+  mkdir -p "$SNAP/tree/$(dirname "$rel")" "$SNAP/hashes/$(dirname "$rel")" || {
+    rm -rf "$SNAP"
+    say "cannot stage snapshot for $rel"
+    exit 3
+  }
+  cp "$rel" "$SNAP/tree/$rel" || {
+    rm -rf "$SNAP"
+    say "snapshot copy failed for $rel"
+    exit 3
+  }
+  git hash-object -- "$rel" > "$SNAP/hashes/$rel" || {
+    rm -rf "$SNAP"
+    say "content hash failed for $rel"
+    exit 3
+  }
+done
+
+RESTORED=0
+
+# Idempotent restore + byte verification. On mismatch the snapshot directory
+# is KEPT for forensics and the wrapper exits 3 (fail-closed, aligning with
+# the CLI's exit contract for "cannot proceed").
+restore_all() {
+  [ "$RESTORED" -eq 1 ] && return 0
+  RESTORED=1
+  mismatched=0
+  # shellcheck disable=SC2086
+  for rel in $SURFACE; do
+    [ -f "$SNAP/tree/$rel" ] || continue
+    cp "$SNAP/tree/$rel" "$rel"
+    now=$(git hash-object -- "$rel" 2>/dev/null)
+    want=$(cat "$SNAP/hashes/$rel" 2>/dev/null)
+    if [ "$now" != "$want" ]; then
+      printf 'specgit-bootstrap: RESTORE MISMATCH for %s (got %s, expected %s)\n' \
+        "$rel" "${now:-<none>}" "${want:-<none>}" >&2
+      mismatched=1
+    fi
+  done
+  if [ "$mismatched" -eq 1 ]; then
+    say "restored bytes differ from pre-run snapshots - specialized harness bytes may be corrupted."
+    say "snapshot kept for forensics at $SNAP; inspect 'git diff' before continuing."
+    trap - EXIT
+    exit 3
+  fi
+  rm -rf "$SNAP"
+}
+
+trap 'restore_all' EXIT
+trap 'restore_all; exit 129' HUP
+trap 'restore_all; exit 130' INT
+trap 'restore_all; exit 143' TERM
+
+# init's stdout prose must not pollute the wrapped --json parse surface.
+specgit init --force --no-protect >&2
+init_status=$?
+if [ "$init_status" -ne 0 ]; then
+  say "specgit init --force --no-protect failed (exit $init_status); restoring harness bytes"
+  restore_all
+  exit "$init_status"
+fi
+
+# All arguments pass through verbatim; exit status and diagnostics inherit.
+specgit issue "$@"
+issue_status=$?
+restore_all
+exit "$issue_status"

--- a/script/specgit-bootstrap.test.sh
+++ b/script/specgit-bootstrap.test.sh
@@ -1,0 +1,271 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2015,SC2329
+# ok/bad always return 0, so `cond && ok .. || bad ..` cannot mis-fire (SC2015);
+# cleanup() runs via the EXIT trap, which shellcheck does not count (SC2329).
+# Behavior tests for script/specgit-bootstrap.sh (#521).
+#
+# Zero network, zero forge: `specgit` is a stub placed first on PATH; every
+# fixture is a throwaway git repo under $TMPDIR. The real repository is never
+# touched: wrapper invocations run with cwd set to the fixture, and all stub
+# artifacts (log, captured output) live outside the fixture worktree.
+#
+# Not wired into CI (#521 scope): run manually from anywhere via
+#   bash script/specgit-bootstrap.test.sh
+set -u
+
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+WRAPPER="$ROOT/script/specgit-bootstrap.sh"
+WORK=$(mktemp -d "${TMPDIR:-/tmp}/specgit-bootstrap-test.XXXXXX")
+PASS=0
+FAIL=0
+
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT
+
+if command -v sha256sum >/dev/null 2>&1; then
+  digest() { sha256sum "$1" | cut -d' ' -f1; }
+else
+  digest() { shasum -a 256 "$1" | cut -d' ' -f1; }
+fi
+
+SURFACE_FILES=(
+  .github/workflows/specgit-accept.yml
+  AGENTS.md
+  .opencode/hooks.json
+  .opencode/hooks/specgit-merge-guard.sh
+  .git/hooks/pre-push
+)
+
+ok() { PASS=$((PASS + 1)); printf 'ok   - %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf 'FAIL - %s\n' "$1"; }
+
+surface_digests() { # <fixture-dir>
+  local fx="$1" f
+  for f in "${SURFACE_FILES[@]}"; do
+    printf '%s %s\n' "$(digest "$fx/$f")" "$f"
+  done
+}
+
+assert_surface_restored() { # <fixture-dir> <baseline-file>
+  diff <(surface_digests "$1") "$2" >/dev/null
+}
+
+assert_clean() { # <fixture-dir>
+  [ -z "$(git -C "$1" status --porcelain)" ]
+}
+
+assert_rc() { # <expected> <actual> <label>
+  [ "$1" = "$2" ]
+}
+
+new_fixture() { # <name> [no-binding]
+  local fx="$WORK/$1"
+  mkdir -p "$fx/.github/workflows" "$fx/.opencode/hooks" "$fx/spec_git" "$fx/.git/hooks"
+  git -C "$fx" -c init.defaultBranch=main init -q
+  git -C "$fx" config user.email test@example.invalid
+  git -C "$fx" config user.name test
+  printf 'version: 1\nkind: probe\n' > "$fx/spec_git/policy.yaml"
+  printf 'version: 1\nbranch: feat/probe\nissues: []\n' > "$fx/.specgit.yaml"
+  cat > "$fx/.github/workflows/specgit-accept.yml" <<'YAML'
+# fixture accept workflow
+spec-a: drop-dispatch
+spec-b: global-install
+YAML
+  printf '# fixture agents\n' > "$fx/AGENTS.md"
+  printf '{\n  "hooks": []\n}\n' > "$fx/.opencode/hooks.json"
+  printf '#!/bin/sh\nexit 0\n' > "$fx/.opencode/hooks/specgit-merge-guard.sh"
+  printf '#!/bin/sh\nexit 0\n' > "$fx/.git/hooks/pre-push"
+  git -C "$fx" add -A
+  git -C "$fx" commit -qm "fixture $1"
+  if [ "${2:-}" = "no-binding" ]; then
+    rm "$fx/.specgit.yaml"
+  fi
+}
+
+make_stub() { # <case-name>
+  local dir="$WORK/stubs/$1"
+  mkdir -p "$dir"
+  : > "$dir/log"
+  cat > "$dir/specgit" <<'EOF'
+#!/usr/bin/env bash
+# stub specgit: records argv to $STUB_LOG, simulates harness refresh plus the
+# scripted exit/mode contract. Never touches network or forge.
+set -u
+printf '%s\n' "$*" >> "${STUB_LOG:?STUB_LOG required}"
+cmd="${1:-}"
+[ $# -gt 0 ] && shift
+case "$cmd" in
+  init)
+    printf 'specgit init: refreshing harness files\n'
+    printf '\n# canonical harness refresh (stub init)\n' >> .github/workflows/specgit-accept.yml
+    exit "${STUB_INIT_EXIT:-0}"
+    ;;
+  issue)
+    grep -q 'canonical harness refresh' .github/workflows/specgit-accept.yml || {
+      printf 'stub: refreshed harness bytes were not visible to the inner CLI\n' >&2
+      exit 99
+    }
+    case "${STUB_ISSUE_MODE:-exit}" in
+      exit)
+        [ "${1:-}" = "--json" ] && printf '{"stub":"issue"}\n'
+        exit "${STUB_ISSUE_EXIT:-0}"
+        ;;
+      reject130)
+        printf 'Interrupted.' >&2
+        exit 130
+        ;;
+      sigint)
+        trap 'printf "Interrupted." >&2; exit 130' INT
+        # Deliver a real SIGINT to the wrapper (our foreground parent). A
+        # background wrapper would inherit SIG_IGN at exec (signals ignored
+        # upon entry cannot be trapped), so the stub is the delivery seam.
+        kill -INT "${STUB_SIGNAL_TARGET:-$PPID}"
+        sleep 1
+        exit 0
+        ;;
+      tamper_snapshot)
+        d=$(ls -dt "${TMPDIR:-/tmp}"/specgit-bootstrap.* 2>/dev/null | sed -n '1p')
+        if [ -n "$d" ] && [ -f "$d/tree/.github/workflows/specgit-accept.yml" ]; then
+          printf 'tampered-by-test\n' > "$d/tree/.github/workflows/specgit-accept.yml"
+        fi
+        exit "${STUB_ISSUE_EXIT:-0}"
+        ;;
+    esac
+    ;;
+  *)
+    printf 'stub: unknown subcommand: %s\n' "$cmd" >&2
+    exit 64
+    ;;
+esac
+EOF
+  chmod +x "$dir/specgit"
+}
+
+# run_wrapper <case> [args...]  — env knobs must already be exported.
+run_wrapper() {
+  local case="$1"
+  shift
+  local fx="$WORK/$case"
+  ( cd "$fx" && env PATH="$WORK/stubs/$case:$PATH" STUB_LOG="$WORK/stubs/$case/log" "$WRAPPER" "$@" > "$WORK/$case.out" 2> "$WORK/$case.err" )
+}
+
+report() {
+  printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+  [ "$FAIL" -eq 0 ]
+}
+
+[ -x "$WRAPPER" ] || {
+  bad "wrapper executable exists at script/specgit-bootstrap.sh"
+  report
+  exit 1
+}
+
+# ---- case 1: success — args passed through verbatim, bytes restored --------
+new_fixture c1
+make_stub c1
+surface_digests "$WORK/c1" > "$WORK/c1.baseline"
+run_wrapper c1 --json "feat: probe title"
+rc=$?
+assert_rc 0 "$rc" "case1: wrapper exits 0" && ok "case1: wrapper exits 0" || bad "case1: wrapper exits 0 (got $rc)"
+printf 'init --force --no-protect\nissue --json feat: probe title\n' > "$WORK/c1.wantlog"
+diff "$WORK/stubs/c1/log" "$WORK/c1.wantlog" >/dev/null && ok "case1: argv order + passthrough (init first, issue verbatim)" || bad "case1: stub log mismatch: $(cat "$WORK/stubs/c1/log" | tr '\n' '|')"
+assert_surface_restored "$WORK/c1" "$WORK/c1.baseline" && ok "case1: surface bytes restored" || bad "case1: surface bytes differ"
+assert_clean "$WORK/c1" && ok "case1: fixture git status clean" || bad "case1: fixture dirty: $(git -C "$WORK/c1" status --porcelain | tr '\n' '|')"
+printf '{"stub":"issue"}\n' > "$WORK/c1.wantout"
+diff "$WORK/c1.out" "$WORK/c1.wantout" >/dev/null && ok "case1: --json stdout is exactly one JSON document (no init prose)" || bad "case1: stdout not a single JSON doc: $(tr '\n' '|' < "$WORK/c1.out")"
+grep -q 'refreshing harness files' "$WORK/c1.err" && ok "case1: init stdout prose routed to stderr" || bad "case1: init prose missing from stderr"
+
+# ---- case 2: inner rejected (exit 1) — passthrough + restore ---------------
+new_fixture c2
+make_stub c2
+surface_digests "$WORK/c2" > "$WORK/c2.baseline"
+STUB_ISSUE_EXIT=1 run_wrapper c2 "fix: probe"
+rc=$?
+assert_rc 1 "$rc" && ok "case2: wrapper exits 1 (inner rejected)" || bad "case2: exit $rc, want 1"
+assert_surface_restored "$WORK/c2" "$WORK/c2.baseline" && ok "case2: surface bytes restored" || bad "case2: surface bytes differ"
+assert_clean "$WORK/c2" && ok "case2: fixture clean" || bad "case2: fixture dirty"
+
+# ---- case 3: harness_stale (exit 2) — passthrough + restore ----------------
+new_fixture c3
+make_stub c3
+surface_digests "$WORK/c3" > "$WORK/c3.baseline"
+STUB_ISSUE_EXIT=2 run_wrapper c3 "fix: probe"
+rc=$?
+assert_rc 2 "$rc" && ok "case3: wrapper exits 2 (harness_stale passthrough)" || bad "case3: exit $rc, want 2"
+assert_surface_restored "$WORK/c3" "$WORK/c3.baseline" && ok "case3: surface bytes restored" || bad "case3: surface bytes differ"
+assert_clean "$WORK/c3" && ok "case3: fixture clean" || bad "case3: fixture dirty"
+
+# ---- case 4a: inner catches SIGINT and exits 130 — passthrough + restore ---
+new_fixture c4a
+make_stub c4a
+surface_digests "$WORK/c4a" > "$WORK/c4a.baseline"
+STUB_ISSUE_MODE=reject130 run_wrapper c4a "fix: probe"
+rc=$?
+assert_rc 130 "$rc" && ok "case4a: wrapper exits 130 (inner SIGINT contract)" || bad "case4a: exit $rc, want 130"
+grep -q 'Interrupted.' "$WORK/c4a.err" && ok "case4a: inner stderr inherited (Interrupted.)" || bad "case4a: inner stderr not inherited"
+assert_surface_restored "$WORK/c4a" "$WORK/c4a.baseline" && ok "case4a: surface bytes restored" || bad "case4a: surface bytes differ"
+assert_clean "$WORK/c4a" && ok "case4a: fixture clean" || bad "case4a: fixture dirty"
+
+# ---- case 4b: real SIGINT to the wrapper while inner runs ------------------
+new_fixture c4b
+make_stub c4b
+surface_digests "$WORK/c4b" > "$WORK/c4b.baseline"
+STUB_ISSUE_MODE=sigint run_wrapper c4b "fix: probe"
+rc=$?
+assert_rc 130 "$rc" && ok "case4b: wrapper exits 130 on trapped SIGINT" || bad "case4b: exit $rc, want 130"
+assert_surface_restored "$WORK/c4b" "$WORK/c4b.baseline" && ok "case4b: surface bytes restored after signal" || bad "case4b: surface bytes differ"
+assert_clean "$WORK/c4b" && ok "case4b: fixture clean" || bad "case4b: fixture dirty"
+
+# ---- case 5: init fails — restore immediately, no issue call ---------------
+new_fixture c5
+make_stub c5
+surface_digests "$WORK/c5" > "$WORK/c5.baseline"
+STUB_INIT_EXIT=3 run_wrapper c5 "fix: probe"
+rc=$?
+assert_rc 3 "$rc" && ok "case5: wrapper exits 3 (init failure passthrough)" || bad "case5: exit $rc, want 3"
+printf 'init --force --no-protect\n' > "$WORK/c5.wantlog"
+diff "$WORK/stubs/c5/log" "$WORK/c5.wantlog" >/dev/null && ok "case5: issue never executed after init failure" || bad "case5: unexpected stub calls: $(tr '\n' '|' < "$WORK/stubs/c5/log")"
+assert_surface_restored "$WORK/c5" "$WORK/c5.baseline" && ok "case5: surface bytes restored" || bad "case5: surface bytes differ"
+assert_clean "$WORK/c5" && ok "case5: fixture clean" || bad "case5: fixture dirty"
+
+# ---- case 6: dirty write surface — fail-closed rejection, zero stub calls --
+new_fixture c6
+make_stub c6
+printf 'dirty work\n' >> "$WORK/c6/AGENTS.md"
+printf 'untracked\n' > "$WORK/c6/CLAUDE.md"
+run_wrapper c6 "fix: probe"
+rc=$?
+assert_rc 2 "$rc" && ok "case6: wrapper exits 2 on dirty write surface" || bad "case6: exit $rc, want 2"
+[ ! -s "$WORK/stubs/c6/log" ] && ok "case6: inner CLI never executed" || bad "case6: stub was called: $(tr '\n' '|' < "$WORK/stubs/c6/log")"
+grep -q 'AGENTS.md' "$WORK/c6.err" && ok "case6: stderr lists AGENTS.md" || bad "case6: stderr missing AGENTS.md"
+grep -q 'CLAUDE.md' "$WORK/c6.err" && ok "case6: stderr lists untracked CLAUDE.md" || bad "case6: stderr missing CLAUDE.md"
+grep -q '^specgit-bootstrap:' "$WORK/c6.err" && ok "case6: diagnostics use specgit-bootstrap: prefix" || bad "case6: missing prefix"
+grep -q '"verdict"' "$WORK/c6.err" && bad "case6: rejection emitted a JSON envelope" || ok "case6: rejection emits no JSON envelope"
+# deliberate dirty artifacts: assert bytes NOT touched by wrapper
+grep -q 'dirty work' "$WORK/c6/AGENTS.md" && ok "case6: dirty fixture left untouched" || bad "case6: dirty fixture mutated"
+
+# ---- case 7: snapshot tampering detected — loud mismatch, exit 3 -----------
+new_fixture c7
+make_stub c7
+surface_digests "$WORK/c7" > "$WORK/c7.baseline"
+STUB_ISSUE_MODE=tamper_snapshot run_wrapper c7 "fix: probe"
+rc=$?
+assert_rc 3 "$rc" && ok "case7: wrapper exits 3 on restore mismatch" || bad "case7: exit $rc, want 3"
+grep -q 'RESTORE MISMATCH' "$WORK/c7.err" && ok "case7: mismatch reported loudly on stderr" || bad "case7: no RESTORE MISMATCH diagnostic"
+grep -q 'tampered-by-test' "$WORK/c7/.github/workflows/specgit-accept.yml" && ok "case7: corrupted snapshot surfaced (deliberate artifact)" || bad "case7: workflow bytes unexpected: $(digest "$WORK/c7/.github/workflows/specgit-accept.yml")"
+# every non-tampered surface file must be back to its committed bytes: the
+# only porcelain entry may be the workflow the stub corrupted
+[ "$(git -C "$WORK/c7" status --porcelain | grep -cv 'specgit-accept.yml')" = "0" ] && ok "case7: non-tampered files restored correctly" || bad "case7: unexpected residual changes: $(git -C "$WORK/c7" status --porcelain | tr '\n' '|')"
+
+# ---- case 8: unbound repository — refuse service, zero execution -----------
+new_fixture c8 no-binding
+make_stub c8
+run_wrapper c8 "feat: probe"
+rc=$?
+assert_rc 3 "$rc" && ok "case8: wrapper exits 3 on unbound repository" || bad "case8: exit $rc, want 3"
+[ ! -s "$WORK/stubs/c8/log" ] && ok "case8: inner CLI never executed" || bad "case8: stub was called"
+grep -q 'spec_git/policy.yaml\|\.specgit\.yaml' "$WORK/c8.err" && ok "case8: stderr names the missing binding" || bad "case8: stderr lacks binding context"
+grep -q '^specgit-bootstrap:' "$WORK/c8.err" && ok "case8: diagnostics use specgit-bootstrap: prefix" || bad "case8: missing prefix"
+
+report
+exit $?


### PR DESCRIPTION
Closes #521

## Why

The pinned SpecGit 1.10.1 currency gate rejects every `specgit issue` run because this repository intentionally specializes the generated acceptance workflow. Refreshing the harness manually is unsafe because it overwrites those required bytes.

## What changed

- Added `script/specgit-bootstrap.sh` as the canonical repository-local entry point.
- Snapshot and restore the complete SpecGit init write surface on success, failure, and handled signals.
- Fail closed for dirty write-surface paths, missing binding state, and restore hash mismatches.
- Preserve wrapped arguments, diagnostics, exit status, and the single-JSON stdout contract.
- Added isolated fake-CLI behavior tests and updated repository instructions.

## Evidence

- `bash script/specgit-bootstrap.test.sh`: 38 passed, 0 failed.
- `sh -n script/specgit-bootstrap.sh`: passed.
- `bash -n script/specgit-bootstrap.test.sh`: passed.
- `shellcheck -s sh script/specgit-bootstrap.sh`: passed.
- `shellcheck -s bash script/specgit-bootstrap.test.sh`: passed.
- Commit hooks: root lint passed at 4840/4850 warnings; all 29 typecheck tasks passed.
- DAG verification: PASS; corrected diff review: PASS with 0 blocking findings.

## Checklist

- [x] Why, What changed, and Evidence are filled in.
- [ ] `specgit finish` exits 0.
