### PR TITLE
fix(session): settle native tools before compaction

### DIFF
--- a/.github/releases/v1.0.40.md
+++ b/.github/releases/v1.0.40.md
@@ -1,0 +1,37 @@
+## opencode {VERSION}
+
+{Prerelease/Stable} release from `{branch}` branch. Native LLM requests now settle local tools before automatic compaction can close the stream. This release also includes the reviewed event-storage, summary-diff, delivery, and macOS installer fixes already integrated into dev.
+
+---
+
+### 🐛 Bug Fixes
+
+- **Tools survive automatic compaction, #539**: a high-usage `step-finish` could abort a slow local tool before its result reached the session processor. Native LLM now delivers all local tool results before terminal events. Parallel tools settle completely; explicit user cancellation still interrupts execution.
+- **Summary diffs retain later small entries, #526**: skip an oversized diff individually instead of dropping every following entry. Remove the unused legacy `session.summary_diffs` column through a tested database migration.
+- **Identical durable events no longer consume storage or sequence numbers, #527**: suppress byte-identical fresh appends within the same aggregate/type while preserving explicit-sequence replay. Batch results retain input alignment; legacy rows require no hash backfill.
+
+---
+
+### ⚙️ CI / Engineering
+
+- **Delivery tracking, #520 and #532 through #535**: close linked issues after dev merges, preserve repository-specific SpecGit harness files, restore failed bootstrap state, reject unsupported branch types before remote writes, and verify that delivery PRs target dev.
+- **macOS installation verification, #536**: verify release archive checksums before extraction and validate the installed binary's signature after quarantine clearing and re-signing. Added a negative checksum control and a real macOS installation acceptance test.
+
+---
+
+### 🧪 Test Summary
+
+```
+LLM / native runtime / processor targeted suites: 66 pass, 1 existing skip, 0 fail
+opencode typecheck: passed
+```
+
+---
+
+### 🔍 Verification
+
+The slow-tool regression was observed failing before the fix and passing afterward through the real session processor and a local HTTP model endpoint. Additional cases cover parallel local tools and explicit cancellation. Formal publication requires independent review, SpecGit acceptance, and the main-branch Typecheck, Linux unit, and Linux/Windows E2E gates. Reported model usage in the regression is deterministic test input; no live model context limit is inferred from it.
+
+---
+
+**Full changelog:** [`{previous_tag}`...`{current_tag}`](https://github.com/LeXwDeX/OpenCode-GraphAgent/compare/{previous_tag}...{current_tag})

--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -8,3 +8,4 @@ issues:
 issueKinds:
   - issue: 538
     kind: kind::fix
+pr: 539

--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -1,11 +1,10 @@
 version: 1
-delivery: sync-v1-0-39
+delivery: native-tool-settlement
 context:
   kind: branch
-  branch: chore/517-sync-v1-0-39
+  branch: fix/538-native-tool-settlement
 issues:
-  - 517
+  - 538
 issueKinds:
-  - issue: 517
-    kind: kind::chore
-pr: 518
+  - issue: 538
+    kind: kind::fix

--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -5,6 +5,7 @@ context:
   branch: fix/538-native-tool-settlement
 issues:
   - 538
+  - 540
 issueKinds:
   - issue: 538
     kind: kind::fix

--- a/packages/core/test/npm.test.ts
+++ b/packages/core/test/npm.test.ts
@@ -54,7 +54,9 @@ describe("Npm.add", () => {
     await Bun.write(path.join(tmp.path, "fixture-provider", "index.js"), "export const fixture = true\n")
 
     const spec = `fixture-provider@file:${path.join(tmp.path, "fixture-provider")}`
-    await fs.mkdir(path.join(tmp.path, "cache", "packages", Npm.sanitize(spec)), { recursive: true })
+    const cache = path.join(tmp.path, "cache", "packages", Npm.sanitize(spec))
+    await fs.mkdir(cache, { recursive: true })
+    await Bun.write(path.join(cache, ".npmrc"), "audit=false\n")
 
     const entry = await Effect.gen(function* () {
       const npm = yield* Npm.Service
@@ -78,7 +80,7 @@ describe("Npm.install", () => {
         "dev-pkg": "file:./dev-pkg",
       },
     })
-    await Bun.write(path.join(tmp.path, ".npmrc"), "omit=dev\n")
+    await Bun.write(path.join(tmp.path, ".npmrc"), "omit=dev\naudit=false\n")
     await fs.mkdir(path.join(tmp.path, "prod-pkg"))
     await fs.mkdir(path.join(tmp.path, "dev-pkg"))
     await writePackage(path.join(tmp.path, "prod-pkg"), { name: "prod-pkg" })
@@ -108,7 +110,10 @@ describe("Npm.install", () => {
     const bundled = path.join(tmp.path, "bundled-plugin-sdk")
     process.env.OPENCODE_PLUGIN_SDK_PATH = bundled
     await fs.mkdir(path.join(bundled, "src"), { recursive: true })
-    await writePackage(bundled, { name: "@opencode-ai/plugin", exports: { ".": "./src/index.ts", "./tui": "./src/tui.ts" } })
+    await writePackage(bundled, {
+      name: "@opencode-ai/plugin",
+      exports: { ".": "./src/index.ts", "./tui": "./src/tui.ts" },
+    })
     await Bun.write(path.join(bundled, "src", "index.ts"), "export const plugin = true\n")
     await Bun.write(path.join(bundled, "src", "tui.ts"), "export const tui = true\n")
 
@@ -118,7 +123,9 @@ describe("Npm.install", () => {
         yield* npm.install(tmp.path, { add: [{ name: "@opencode-ai/plugin" }] })
       }).pipe(Effect.scoped, Effect.provide(npmLayer(path.join(tmp.path, "cache"))), Effect.runPromise)
 
-      await expect(fs.stat(path.join(tmp.path, "node_modules", "@opencode-ai", "plugin", "src", "tui.ts"))).resolves.toBeDefined()
+      await expect(
+        fs.stat(path.join(tmp.path, "node_modules", "@opencode-ai", "plugin", "src", "tui.ts")),
+      ).resolves.toBeDefined()
       await expect(fs.stat(path.join(tmp.path, "package-lock.json"))).rejects.toThrow()
     } finally {
       delete process.env.OPENCODE_PLUGIN_SDK_PATH

--- a/packages/opencode/src/session/llm/native-runtime.ts
+++ b/packages/opencode/src/session/llm/native-runtime.ts
@@ -105,6 +105,7 @@ export function stream(input: StreamInput): StreamResult {
       Effect.gen(function* () {
         const settlements = yield* FiberSet.make<void>()
         const results = yield* Queue.unbounded<LLMEvent, Cause.Done>()
+        const completion: LLMEvent[] = []
         const provider = input.llmClient
           .stream(
             LLMRequest.update(request, {
@@ -112,8 +113,14 @@ export function stream(input: StreamInput): StreamResult {
             }),
           )
           .pipe(
-            Stream.flatMap((event) =>
-              event.type !== "tool-call" || event.providerExecuted
+            Stream.flatMap((event) => {
+              // The processor may close the stream for compaction at step-finish.
+              // Deliver every local settlement before exposing that boundary.
+              if (event.type === "step-finish" || event.type === "finish") {
+                completion.push(event)
+                return Stream.empty
+              }
+              return event.type !== "tool-call" || event.providerExecuted
                 ? Stream.make(event)
                 : Stream.make(event).pipe(
                     Stream.concat(
@@ -126,15 +133,18 @@ export function stream(input: StreamInput): StreamResult {
                         ),
                       ),
                     ),
-                  ),
-            ),
+                  )
+            }),
             Stream.concat(
               Stream.fromEffectDrain(
                 FiberSet.awaitEmpty(settlements).pipe(Effect.andThen(Queue.end(results)), Effect.asVoid),
               ),
             ),
           )
-        return provider.pipe(Stream.concat(Stream.fromQueue(results)))
+        return provider.pipe(
+          Stream.concat(Stream.fromQueue(results)),
+          Stream.concat(Stream.suspend(() => Stream.fromIterable(completion))),
+        )
       }),
     ),
   )

--- a/packages/opencode/test/session/llm-native.test.ts
+++ b/packages/opencode/test/session/llm-native.test.ts
@@ -557,7 +557,7 @@ describe("session.llm-native.request", () => {
     }),
   )
 
-  it.effect("emits native tool calls before overlapping local settlements complete", () =>
+  it.effect("settles parallel native tools before completing the provider step", () =>
     Effect.gen(function* () {
       const observed: string[] = []
       const started: string[] = []
@@ -585,6 +585,7 @@ describe("session.llm-native.request", () => {
           Stream.fromIterable([
             LLMEvent.toolCall({ id: "call-1", name: "lookup", input: {} }),
             LLMEvent.toolCall({ id: "call-2", name: "lookup", input: {} }),
+            LLMEvent.stepFinish({ index: 0, reason: "tool-calls", usage: { inputTokens: 30_000, outputTokens: 1 } }),
             LLMEvent.finish({ reason: "tool-calls" }),
           ]),
         generate: () => Effect.die("unused"),
@@ -609,11 +610,11 @@ describe("session.llm-native.request", () => {
       yield* Effect.promise(() => bothStarted)
 
       expect(started).toEqual(["call-1", "call-2"])
-      expect(observed).toEqual(["tool-call", "tool-call", "finish"])
+      expect(observed).toEqual(["tool-call", "tool-call"])
 
       release?.()
       yield* Fiber.join(fiber)
-      expect(observed).toEqual(["tool-call", "tool-call", "finish", "tool-result", "tool-result"])
+      expect(observed).toEqual(["tool-call", "tool-call", "tool-result", "tool-result", "step-finish", "finish"])
     }),
   )
 

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -19,7 +19,7 @@ import { SessionStatus } from "../../src/session/status"
 import { SessionSummary } from "../../src/session/summary"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { provideTmpdirInstance, provideTmpdirServer } from "../fixture/fixture"
-import { testEffect } from "../lib/effect"
+import { awaitWithTimeout, testEffect } from "../lib/effect"
 import { raw, reply, TestLLMServer } from "../lib/llm-server"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { ProviderV2 } from "@opencode-ai/core/provider"
@@ -183,6 +183,18 @@ const replacements = [
 const env = LayerNode.buildLayer(LayerNode.group([root, LayerNode.make(TestLLMServer.layer, [])]), { replacements })
 
 const it = testEffect(env)
+
+const native = testEffect(
+  LayerNode.buildLayer(LayerNode.group([root, LayerNode.make(TestLLMServer.layer, [])]), {
+    replacements: [
+      LayerNode.replace(SessionSummary.node, summary),
+      LayerNode.replace(
+        RuntimeFlags.node,
+        RuntimeFlags.layer({ experimentalEventSystem: true, experimentalNativeLlm: true }),
+      ),
+    ],
+  }),
+)
 
 const providerErrorLLM = Layer.succeed(
   LLM.Service,
@@ -819,6 +831,202 @@ it.live("session.processor effect tests complete AI SDK tool calls when native f
         expect(call.state.metadata).toEqual({ source: "test" })
         expect(call.state.time.start).toBeDefined()
         expect(call.state.time.end).toBeDefined()
+      }),
+    { config: (url) => providerCfg(url) },
+  ),
+)
+
+native.live("native tools settle before high usage requests compaction", () =>
+  provideTmpdirServer(
+    ({ dir, llm }) =>
+      Effect.gen(function* () {
+        const { processors, session, provider } = yield* boot()
+        yield* llm.push(reply().tool("lookup", { query: "weather" }).usage({ input: 30_000, output: 1 }))
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "finish the slow lookup before compacting")
+        const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+        const model = {
+          ...(yield* provider.getModel(ref.providerID, ref.modelID)),
+          limit: { context: 32_000, output: 4_000 },
+        }
+        const handle = yield* processors.create({ assistantMessage: msg, sessionID: chat.id, model })
+        const value = yield* handle.process({
+          user: parent,
+          sessionID: chat.id,
+          model,
+          agent: agent(),
+          system: [],
+          messages: [{ role: "user", content: "finish the slow lookup before compacting" }],
+          tools: {
+            lookup: tool({
+              description: "Delayed lookup",
+              inputSchema: z.object({ query: z.string() }),
+              execute: async (input, options) => {
+                await new Promise<void>((resolve, reject) => {
+                  const timer = setTimeout(resolve, 500)
+                  options.abortSignal?.addEventListener(
+                    "abort",
+                    () => {
+                      clearTimeout(timer)
+                      reject(new Error("lookup interrupted"))
+                    },
+                    { once: true },
+                  )
+                })
+                return { title: "Lookup", output: `result:${input.query}`, metadata: {} }
+              },
+            }),
+          },
+        })
+        const parts = yield* MessageV2.parts(msg.id)
+        const call = parts.find((part): part is SessionV1.ToolPart => part.type === "tool")
+        expect(value).toBe("compact")
+        expect(call?.state.status).toBe("completed")
+        if (call?.state.status !== "completed") return
+        expect(call.state.output).toBe("result:weather")
+        expect(call.state.input).toEqual({ query: "weather" })
+        expect(handle.message.tokens.input).toBe(30_000)
+      }),
+    { config: (url) => providerCfg(url) },
+  ),
+)
+
+native.live("native parallel tools all deliver results before compaction", () =>
+  provideTmpdirServer(
+    ({ dir, llm }) =>
+      Effect.gen(function* () {
+        const { processors, session, provider } = yield* boot()
+        yield* llm.push(
+          raw({
+            chunks: [
+              {
+                id: "chatcmpl-parallel",
+                object: "chat.completion.chunk",
+                choices: [
+                  {
+                    index: 0,
+                    delta: {
+                      tool_calls: ["first", "second"].map((query, index) => ({
+                        index,
+                        id: `call_${query}`,
+                        type: "function",
+                        function: { name: "lookup", arguments: JSON.stringify({ query }) },
+                      })),
+                    },
+                    finish_reason: "tool_calls",
+                  },
+                ],
+                usage: { prompt_tokens: 30_000, completion_tokens: 1, total_tokens: 30_001 },
+              },
+            ],
+          }),
+        )
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "complete both lookups")
+        const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+        const model = {
+          ...(yield* provider.getModel(ref.providerID, ref.modelID)),
+          limit: { context: 32_000, output: 4_000 },
+        }
+        const handle = yield* processors.create({ assistantMessage: msg, sessionID: chat.id, model })
+        const started: string[] = []
+        const bothStarted = defer<void>()
+        const value = yield* handle
+          .process({
+            user: parent,
+            sessionID: chat.id,
+            model,
+            agent: agent(),
+            system: [],
+            messages: [{ role: "user", content: "complete both lookups" }],
+            tools: {
+              lookup: tool({
+                description: "Parallel lookup",
+                inputSchema: z.object({ query: z.string() }),
+                execute: async (input) => {
+                  started.push(input.query)
+                  if (started.length === 2) bothStarted.resolve()
+                  await bothStarted.promise
+                  return { title: "Lookup", output: `result:${input.query}`, metadata: {} }
+                },
+              }),
+            },
+          })
+          .pipe((effect) => awaitWithTimeout(effect, "parallel native tools did not complete", "5 seconds"))
+        expect(value).toBe("compact")
+        const calls = (yield* MessageV2.parts(msg.id)).filter((part) => part.type === "tool")
+        expect(
+          calls.map((part) => ({
+            id: part.callID,
+            state: part.state.status,
+            output: part.state.status === "completed" ? part.state.output : undefined,
+          })),
+        ).toEqual([
+          { id: "call_first", state: "completed", output: "result:first" },
+          { id: "call_second", state: "completed", output: "result:second" },
+        ])
+      }),
+    { config: (url) => providerCfg(url) },
+  ),
+)
+
+native.live("user interruption still aborts a native tool waiting to settle", () =>
+  provideTmpdirServer(
+    ({ dir, llm }) =>
+      Effect.gen(function* () {
+        const { processors, session, provider } = yield* boot()
+        yield* llm.push(reply().tool("lookup", { query: "weather" }).usage({ input: 30_000, output: 1 }))
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "cancel the lookup")
+        const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+        const model = {
+          ...(yield* provider.getModel(ref.providerID, ref.modelID)),
+          limit: { context: 32_000, output: 4_000 },
+        }
+        const handle = yield* processors.create({ assistantMessage: msg, sessionID: chat.id, model })
+        const started = defer<void>()
+        let aborted = false
+        const run = yield* handle
+          .process({
+            user: parent,
+            sessionID: chat.id,
+            model,
+            agent: agent(),
+            system: [],
+            messages: [{ role: "user", content: "cancel the lookup" }],
+            tools: {
+              lookup: tool({
+                description: "Pending lookup",
+                inputSchema: z.object({ query: z.string() }),
+                execute: async (_input, options) => {
+                  await new Promise<void>((_resolve, reject) => {
+                    options.abortSignal?.addEventListener(
+                      "abort",
+                      () => {
+                        aborted = true
+                        reject(new Error("lookup interrupted"))
+                      },
+                      { once: true },
+                    )
+                    started.resolve()
+                  })
+                  return { title: "Lookup", output: "unexpected completion", metadata: {} }
+                },
+              }),
+            },
+          })
+          .pipe(Effect.forkChild)
+        yield* awaitWithTimeout(
+          Effect.promise(() => started.promise),
+          "native tool did not start",
+        )
+        yield* awaitWithTimeout(Fiber.interrupt(run), "native tool ignored user interruption")
+        expect(aborted).toBe(true)
+        const exit = yield* Fiber.await(run)
+        expect(Exit.isFailure(exit) && Cause.hasInterruptsOnly(exit.cause)).toBe(true)
+        const call = (yield* MessageV2.parts(msg.id)).find((part) => part.type === "tool")
+        expect(call?.state.status).toBe("error")
+        if (call?.state.status === "error") expect(call.state.metadata?.interrupted).toBe(true)
       }),
     { config: (url) => providerCfg(url) },
   ),

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -247,6 +247,17 @@ const boot = Effect.fn("test.boot")(function* () {
   return { processors, session, provider }
 })
 
+const nativeCompactionProcessor = Effect.fn("test.nativeCompactionProcessor")(function* (msg: SessionV1.Assistant) {
+  const processors = yield* SessionProcessor.Service
+  const provider = yield* Provider.Service
+  const model = {
+    ...(yield* provider.getModel(ref.providerID, ref.modelID)),
+    limit: { context: 32_000, output: 4_000 },
+  }
+  const handle = yield* processors.create({ assistantMessage: msg, sessionID: msg.sessionID, model })
+  return { model, handle }
+})
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -840,16 +851,12 @@ native.live("native tools settle before high usage requests compaction", () =>
   provideTmpdirServer(
     ({ dir, llm }) =>
       Effect.gen(function* () {
-        const { processors, session, provider } = yield* boot()
+        const { session } = yield* boot()
         yield* llm.push(reply().tool("lookup", { query: "weather" }).usage({ input: 30_000, output: 1 }))
         const chat = yield* session.create({})
         const parent = yield* user(chat.id, "finish the slow lookup before compacting")
         const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
-        const model = {
-          ...(yield* provider.getModel(ref.providerID, ref.modelID)),
-          limit: { context: 32_000, output: 4_000 },
-        }
-        const handle = yield* processors.create({ assistantMessage: msg, sessionID: chat.id, model })
+        const { model, handle } = yield* nativeCompactionProcessor(msg)
         const value = yield* handle.process({
           user: parent,
           sessionID: chat.id,
@@ -895,7 +902,7 @@ native.live("native parallel tools all deliver results before compaction", () =>
   provideTmpdirServer(
     ({ dir, llm }) =>
       Effect.gen(function* () {
-        const { processors, session, provider } = yield* boot()
+        const { session } = yield* boot()
         yield* llm.push(
           raw({
             chunks: [
@@ -924,11 +931,7 @@ native.live("native parallel tools all deliver results before compaction", () =>
         const chat = yield* session.create({})
         const parent = yield* user(chat.id, "complete both lookups")
         const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
-        const model = {
-          ...(yield* provider.getModel(ref.providerID, ref.modelID)),
-          limit: { context: 32_000, output: 4_000 },
-        }
-        const handle = yield* processors.create({ assistantMessage: msg, sessionID: chat.id, model })
+        const { model, handle } = yield* nativeCompactionProcessor(msg)
         const started: string[] = []
         const bothStarted = defer<void>()
         const value = yield* handle
@@ -974,16 +977,12 @@ native.live("user interruption still aborts a native tool waiting to settle", ()
   provideTmpdirServer(
     ({ dir, llm }) =>
       Effect.gen(function* () {
-        const { processors, session, provider } = yield* boot()
+        const { session } = yield* boot()
         yield* llm.push(reply().tool("lookup", { query: "weather" }).usage({ input: 30_000, output: 1 }))
         const chat = yield* session.create({})
         const parent = yield* user(chat.id, "cancel the lookup")
         const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
-        const model = {
-          ...(yield* provider.getModel(ref.providerID, ref.modelID)),
-          limit: { context: 32_000, output: 4_000 },
-        }
-        const handle = yield* processors.create({ assistantMessage: msg, sessionID: chat.id, model })
+        const { model, handle } = yield* nativeCompactionProcessor(msg)
         const started = defer<void>()
         let aborted = false
         const run = yield* handle


### PR DESCRIPTION
Closes #538
Closes #540

## Why

High provider usage could request automatic compaction while a native local tool was still running, aborting it before its result reached the processor. Local-file npm tests also waited on unrelated online audit traffic before reaching their existing assertions.

## What changed

- Delay native `step-finish` and `finish` events until concurrent local tools settle and their results reach the session processor. Preserve tool IDs, parallel execution and explicit cancellation.
- Exercise slow-tool success, parallel results and interruption through the real HTTP provider/LLM/processor boundary; share only the repeated model/processor setup.
- Keep local npm fixture audits disabled in temporary project configuration. The merge retains dev's richer #541 package-lock preservation regressions and production fix.
- Include v1.0.40 notes for the integrated native, npm, event-storage, delivery and macOS installer changes, with explicitly identified CI baseline evidence.

## Evidence

Current head: `00695dab86358a34b5b756f30df07bccfbe4e309`; parents are reviewed #539 head `93959afa302a058fdb6210904dd07f6dfaa23185` and dev `8060765fccf3c3f7daf3b8b2f87f8cbe48b7a8f9`.

Independent Standards and Spec reviews found zero code blockers at `93959afa30`. The three native implementation/test files are byte-identical at the current head. The two merge conflicts retain the #539 delivery binding and dev's exact npm test file; all other imported code is unchanged from dev.

Current merged-tree validation:

- Native/session/TUI tests: 36 passed, 0 failed, 141 assertions.
- Core npm regressions: 8 passed, 0 failed, 20 assertions.
- opencode package typecheck passed; commit/push hooks passed the repository lint ratchet (4838 warnings, 0 errors) and all 29 configured typecheck tasks.
- v1.0.40 release notes rendered and validated successfully; `git diff --check` passed.
- Earlier native regression red/green evidence remains recorded in #538; these checks use temporary XDG directories and an in-memory test database.

All CI checks passed at `00695dab86`: [Typecheck](https://github.com/LeXwDeX/OpenCode-GraphAgent/actions/runs/33894718548), [complete Test CI](https://github.com/LeXwDeX/OpenCode-GraphAgent/actions/runs/33894718562), and [CodeQL](https://github.com/LeXwDeX/OpenCode-GraphAgent/actions/runs/33894715083). Core: 1225 passed / 6 skipped / 0 failed. Opencode: 4429 passed / 23 skipped / 1 todo / 0 failed. Generated client/SDK freshness passed; all three HttpAPI modes reported 230 passed with no failures, skips, missing or extra routes. Linux and Windows E2E passed. SpecGit 1.10.1 accepted this exact PR/head with exit 0; it will be rerun after this evidence update before merge. Earlier cancelled/superseded checks are not acceptance evidence. The user clarified that this Codex delivery uses subagents to carry out the review workflow. Independent Standards and Spec reviews, merge-resolution review and an independent synthesis checkpoint are complete, with zero code or merge blockers. The checkpoint binds the reviewed native files and dev imports to the current head; CI and SpecGit acceptance remain separate required gates. No external model endpoint is needed for this workflow.

## Checklist

- [x] Preserve concurrent tools, exact results and caller cancellation.
- [x] Complete independent Standards/Spec source reviews and merged-tree local validation.
- [x] Resolve current dev conflicts without reverting either fix.
- [x] Complete the subagent Standards/Spec reviews, merge review and independent synthesis checkpoint.
- [x] Pass all current-head CI checks and `specgit finish --json` with exit 0 before merging to dev.
