### PR TITLE
chore: promote memory activation release to main

### DIFF
--- a/.github/releases/v1.0.43.md
+++ b/.github/releases/v1.0.43.md
@@ -15,7 +15,11 @@
 ```
 Memory, search, server wiring: 116 pass, 0 fail
 Activation regression:          5 pass, 0 fail (included above)
-opencode typecheck:             passed
+CI opencode suite:             4574 pass, 0 fail, 23 existing skips, 1 existing todo
+CI workspace typechecks:        29/29 passed
+CI DAG coverage gate:           820 pass, existing coverage floors met
+CI HttpAPI composite:           3 x 230 pass, 0 fail, 0 skip, 0 missing
+CI E2E:                        Linux 21 pass; Windows 21 pass
 lint:                          4846 warnings, 0 errors; existing 4850 cap unchanged
 ```
 
@@ -25,7 +29,9 @@ lint:                          4846 warnings, 0 errors; existing 4850 cap unchan
 
 Local verification used Bun 1.3.14. The activation regression failed before the fix and now checks the first command response, persisted enabled state, replacement model, initialization stamp, and subsequent status. An independent review reran the focused regression and inspected the controller, identity fence, locks, and generation-based persistence. The memory suite also covers admission, identity migration, cross-process persistence, search, model wire format, and production server dependency wiring.
 
-Integration and promotion require current-head CI and SpecGit acceptance. The release workflow validates reference templates and builds Linux, macOS, and Windows archives with SHA256SUMS. Real external model-provider quality and existing user memory content are outside this verification.
+The CI counts above come from the accepted integration candidate `3b0d9da982` in [PR #582](https://github.com/LeXwDeX/OpenCode-GraphAgent/pull/582): [Typecheck and DAG gates](https://github.com/LeXwDeX/OpenCode-GraphAgent/actions/runs/34212878713), [unit, HttpAPI and E2E gates](https://github.com/LeXwDeX/OpenCode-GraphAgent/actions/runs/34212878737). Both Standards and Spec reviews found no blocking implementation findings, and SpecGit acceptance passed before dev integration. A compiled debug CLI also returned `Memory on` on the first request against a fresh isolated database and retained that status after process restart.
+
+Main promotion is separately gated by its current-head CI and SpecGit acceptance. The release workflow validates reference templates and builds Linux, macOS, and Windows archives with SHA256SUMS. Real external model-provider quality and existing user memory content are outside this verification.
 
 ---
 

--- a/.github/releases/v1.0.43.md
+++ b/.github/releases/v1.0.43.md
@@ -1,0 +1,32 @@
+## opencode {VERSION}
+
+{Prerelease/Stable} release from `{branch}` branch. Memory can now be enabled on the first request after repairing a missing project initialization stamp.
+
+---
+
+### 🐛 Bug Fixes
+
+- **Memory activation**: when a git project already has a non-empty AGENTS.md but its initialization stamp is missing, `/memory on` now repairs the stamp and completes activation in the same request. Missing configuration, disabled configuration, and an unavailable configured model follow the normal initialization and model-reselection paths. Projects without initialization evidence remain blocked ([#581](https://github.com/LeXwDeX/OpenCode-GraphAgent/issues/581)).
+
+---
+
+### 🧪 Test Summary
+
+```
+Memory, search, server wiring: 116 pass, 0 fail
+Activation regression:          5 pass, 0 fail (included above)
+opencode typecheck:             passed
+lint:                          4846 warnings, 0 errors; existing 4850 cap unchanged
+```
+
+---
+
+### 🔍 Verification
+
+Local verification used Bun 1.3.14. The activation regression failed before the fix and now checks the first command response, persisted enabled state, replacement model, initialization stamp, and subsequent status. An independent review reran the focused regression and inspected the controller, identity fence, locks, and generation-based persistence. The memory suite also covers admission, identity migration, cross-process persistence, search, model wire format, and production server dependency wiring.
+
+Integration and promotion require current-head CI and SpecGit acceptance. The release workflow validates reference templates and builds Linux, macOS, and Windows archives with SHA256SUMS. Real external model-provider quality and existing user memory content are outside this verification.
+
+---
+
+**Full changelog:** [`{previous_tag}`...`{current_tag}`](https://github.com/LeXwDeX/OpenCode-GraphAgent/compare/{previous_tag}...{current_tag})

--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -1,12 +1,11 @@
 version: 1
-delivery: memory-activation
+delivery: memory-release
 context:
   kind: worktree
-  label: delivery
-  branch: fix/581-memory-activation
+  label: promotion
+  branch: chore/583-memory-release
 issues:
-  - 581
+  - 583
 issueKinds:
-  - issue: 581
-    kind: kind::fix
-pr: 582
+  - issue: 583
+    kind: kind::chore

--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -1,11 +1,11 @@
 version: 1
 delivery: memory-release
 context:
-  kind: worktree
-  label: promotion
+  kind: branch
   branch: chore/583-memory-release
 issues:
   - 583
+  - 585
 issueKinds:
   - issue: 583
     kind: kind::chore

--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -9,3 +9,4 @@ issues:
 issueKinds:
   - issue: 581
     kind: kind::fix
+pr: 582

--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -9,3 +9,4 @@ issues:
 issueKinds:
   - issue: 583
     kind: kind::chore
+pr: 584

--- a/.specgit.yaml
+++ b/.specgit.yaml
@@ -1,11 +1,11 @@
 version: 1
-delivery: main-release-1042
+delivery: memory-activation
 context:
-  kind: branch
-  branch: chore/579-main-release-1042
+  kind: worktree
+  label: delivery
+  branch: fix/581-memory-activation
 issues:
-  - 579
+  - 581
 issueKinds:
-  - issue: 579
-    kind: kind::chore
-pr: 580
+  - issue: 581
+    kind: kind::fix

--- a/packages/opencode/src/memory/memory.ts
+++ b/packages/opencode/src/memory/memory.ts
@@ -841,7 +841,10 @@ export const layer: Layer.Layer<
 
     const setEnabledUnsafe = Effect.fn("Memory.setEnabledUnsafe")(function* (enabled: boolean) {
       const initial = yield* configuration()
-      if (!initial) {
+      // statusReason can repair a missing init stamp. Re-read before deciding
+      // activation is blocked so this same command can enable or repair the model.
+      const ready = initial ?? (enabled ? yield* statusReason().pipe(Effect.andThen(configuration)) : undefined)
+      if (!ready) {
         if (!enabled) return "Memory remains off"
         // #350: a /memory on that cannot activate must say WHY — the bare
         // "remains off" sent users to guess (real case: an initialized git
@@ -849,11 +852,11 @@ export const layer: Layer.Layer<
         // disabled Memory).
         return (yield* statusReason()) ?? "Memory remains off"
       }
-      const value = initial.loaded
-        ? initial
+      const value = ready.loaded
+        ? ready
         : yield* Effect.gen(function* () {
             yield* initUnsafe()
-            return (yield* configuration()) ?? initial
+            return (yield* configuration()) ?? ready
           })
       if (!value.loaded) return "Memory remains off" as const
       const loaded = value.loaded

--- a/packages/opencode/test/memory/memory-init-stamp-selfheal.test.ts
+++ b/packages/opencode/test/memory/memory-init-stamp-selfheal.test.ts
@@ -76,6 +76,42 @@ const layer = Layer.mergeAll(Memory.layer.pipe(Layer.provideMerge(base)), CrossS
 const it = testEffect(layer)
 
 describe("memory /init stamp self-heal", () => {
+  for (const configured of ["missing", "disabled", "unavailable-model"]) {
+    it.live(
+      `first enable completes after self-healing with ${configured} project config`,
+      () =>
+        Effect.gen(function* () {
+          const dir = yield* tmpdirScoped({ git: true })
+          yield* provideInstance(dir)(
+            Effect.gen(function* () {
+              const project = yield* Project.Service
+              const memory = yield* Memory.Service
+              const config = yield* MemoryConfig.Service
+              const { project: info } = yield* project.fromDirectory(dir)
+              fs.writeFileSync(path.join(info.worktree, "AGENTS.md"), "# project guide\n")
+              if (configured !== "missing") {
+                yield* config.writeProject(info.worktree, {
+                  schema_version: 1,
+                  enabled: configured === "unavailable-model",
+                  model: configured === "unavailable-model" ? "missing/model" : "openai/gpt-5.2",
+                  topic_limit: 10,
+                  turn_interval: 5,
+                  injection: { max_topics: 3, max_tokens: 1_200 },
+                })
+              }
+
+              expect(yield* memory.setEnabled(true)).toBe("Memory on")
+              expect((yield* project.get(info.id))?.time.initialized).toBeDefined()
+              expect((yield* config.load(info.worktree))?.config.enabled).toBe(true)
+              expect((yield* config.load(info.worktree))?.config.model).toBe("openai/gpt-5.2")
+              expect(yield* memory.status()).toBe("Memory on")
+            }),
+          ).pipe(Effect.provide(testInstanceStoreLayer))
+        }),
+      { timeout: 30_000 },
+    )
+  }
+
   it.live(
     "statusReason stamps the project when AGENTS.md already exists",
     () =>
@@ -117,6 +153,9 @@ describe("memory /init stamp self-heal", () => {
 
             const reason = yield* memory.statusReason()
             expect(reason).toContain("/init")
+            expect(yield* memory.setEnabled(true)).toContain("/init")
+            expect(yield* memory.setEnabled(false)).toBe("Memory remains off")
+            expect((yield* project.get(info.id))?.time.initialized).toBeUndefined()
             // #415 diagnostics: the blocker carries the actual row state so a
             // stale identity (worktree pointing at a deleted clone) is visible.
             expect(reason).toContain("time_initialized")


### PR DESCRIPTION
Closes #583
Closes #585

## Why
Promote the accepted Memory activation repair from dev to main for GraphAgent 1.0.43. The first /memory on now completes activation after repairing a missing initialization stamp, including unavailable-model replacement.

## What changed
- Repair the delivery context with official SpecGit bind from an ordinary branch checkout so GitHub CI can verify it; preserve the existing PR and all quality gates.
- Integrate dev commit b997acc44447e81930833c878d460cdcd053fb26, including the reviewed #581 repair and regression tests from #582.
- Update the release notes with actual accepted-candidate CI results and compiled debug CLI evidence.
- Preserve all policies and CI gates; no runtime changes beyond the accepted repair.

## Evidence
- PR #582 accepted by specgit finish exit 0 and merged to dev; #581 is closed.
- Candidate 3b0d9da982: 4574 opencode tests passed (23 existing skips, 1 todo), 29 workspace typechecks passed, DAG coverage 820 passed, HttpAPI 3 x 230 passed, Linux/Windows E2E 21 passed each.
- Bun 1.3.14 memory/search/server-wiring suite: 116 passed. Debug binary first activation and restart status passed in isolated temporary storage.
- Independent Standards and Spec review found no implementation blockers; the release-note follow-up is addressed here.
- Both prerelease and stable release-note renders passed. Candidate build succeeded: https://github.com/LeXwDeX/OpenCode-GraphAgent/actions/runs/34295529961
- Downloaded candidate archives: all four SHA256SUMS entries match. macOS actual-artifact installation acceptance: 6 passed, 0 failed. Packaged binary 1.0.43-dev.1 passed first /memory on, restarted status, off, and restarted off-state in new isolated storage.
- Main promotion requires its own current-head checks and SpecGit acceptance before merge. Stable release asset verification follows publication.

## Checklist
- [x] Accepted repair integrated into dev
- [x] Release notes include actual CI evidence
- [x] Runtime patch independently reviewed
- [x] Release-note rendering validated
